### PR TITLE
fix(desktop): use keychain password for signing ACL setup

### DIFF
--- a/docs/dev/desktop-release.md
+++ b/docs/dev/desktop-release.md
@@ -31,6 +31,20 @@ secure URL supported by electron-builder. macOS release jobs fail before the
 build if any certificate, certificate-password, or notarization secret is
 missing; unsigned artifacts must never reach a release.
 
+## Signing dependency patch
+
+`app-builder-lib@26.15.3` is patched through pnpm to pass the generated
+temporary-keychain password to `security set-key-partition-list`. The upstream
+implementation instead passes the certificate password, which can fail with
+`SecKeychainUnlock` during macOS packaging. Certificate import still uses the
+certificate password. Signing and notarization gates remain mandatory.
+
+`tests/desktop/signing-keychain.test.ts` exercises the installed dependency's
+keychain creation with a simulated security command boundary, including separate
+application and installer certificate passwords. When upgrading electron-builder,
+verify that upstream fixes this behavior before removing the patch. Validate the
+result with the non-publishing Desktop Release dry run on both macOS architectures.
+
 ## Channels
 
 - Stable: tag `desktop-vX.Y.Z` or run `Desktop Release` with `channel=stable`

--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
           "vscode-languageserver-types": "3.17.5"
         }
       }
+    },
+    "patchedDependencies": {
+      "app-builder-lib@26.15.3": "patches/app-builder-lib@26.15.3.patch"
     }
   },
   "devDependencies": {

--- a/patches/app-builder-lib@26.15.3.patch
+++ b/patches/app-builder-lib@26.15.3.patch
@@ -1,0 +1,24 @@
+diff --git a/out/codeSign/macCodeSign.js b/out/codeSign/macCodeSign.js
+index 9a69042fd48f4759a1c697bf23fa5b44f2da2366..50d9406c0986957265be819664a513d2fef71159 100644
+--- a/out/codeSign/macCodeSign.js
++++ b/out/codeSign/macCodeSign.js
+@@ -156,16 +156,16 @@ async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink, cscIK
+     if (cscIKeyPassword != null) {
+         cscPasswords.push(cscIKeyPassword);
+     }
+-    return await importCerts(keychainFile, certPaths, cscPasswords);
++    return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword);
+ }
+-async function importCerts(keychainFile, paths, keyPasswords) {
++async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {
+     var _a;
+     for (let i = 0; i < paths.length; i++) {
+         const password = (_a = keyPasswords[i]) !== null && _a !== void 0 ? _a : "";
+         await (0, builder_util_1.exec)("/usr/bin/security", ["import", paths[i], "-k", keychainFile, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productbuild", "-P", password]);
+         // https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p
+         // https://github.com/electron-userland/electron-packager/issues/701#issuecomment-322315996
+-        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]);
++        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]);
+     }
+     return {
+         keychainFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,11 @@ settings:
 
 packageExtensionsChecksum: sha256-MHRU4TXUD7qujRA9MBGatf2208j0N4EyngS9KgxMkMQ=
 
+patchedDependencies:
+  app-builder-lib@26.15.3:
+    hash: 33904f2cda5efc2f029b7b8245df2812306f0bf85e54071e3655e0dbed78dfeb
+    path: patches/app-builder-lib@26.15.3.patch
+
 importers:
 
   .:
@@ -22671,7 +22676,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
+  app-builder-lib@26.15.3(patch_hash=33904f2cda5efc2f029b7b8245df2812306f0bf85e54071e3655e0dbed78dfeb)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
@@ -24062,7 +24067,7 @@ snapshots:
 
   dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=33904f2cda5efc2f029b7b8245df2812306f0bf85e54071e3655e0dbed78dfeb)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       fs-extra: 10.1.0
       js-yaml: 4.1.1
@@ -24191,7 +24196,7 @@ snapshots:
 
   electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=33904f2cda5efc2f029b7b8245df2812306f0bf85e54071e3655e0dbed78dfeb)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
@@ -24200,7 +24205,7 @@ snapshots:
 
   electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=33904f2cda5efc2f029b7b8245df2812306f0bf85e54071e3655e0dbed78dfeb)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chalk: 4.1.2

--- a/tests/desktop/signing-keychain.test.ts
+++ b/tests/desktop/signing-keychain.test.ts
@@ -1,0 +1,46 @@
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { runInNewContext } from "node:vm";
+import { describe, expect, it } from "vitest";
+
+describe("installed electron-builder signing keychain", () => {
+  it.each([false, true])("uses the keychain password for ACLs (installer: %s)", async (installer) => {
+    const desktopRequire = createRequire(resolve("desktop/package.json"));
+    const builderRequire = createRequire(desktopRequire.resolve("electron-builder"));
+    const sourcePath = builderRequire.resolve("app-builder-lib/out/codeSign/macCodeSign.js");
+    const dependencyRequire = createRequire(sourcePath);
+    const commands: string[][] = [];
+    let keychainPassword = "";
+    const exports = {} as { createKeychain: (options: Record<string, unknown>) => Promise<unknown> };
+    runInNewContext(readFileSync(sourcePath, "utf8"), {
+      exports,
+      process: { env: { TRAVIS: "true" } },
+      require: (name: string) => {
+        if (name === "builder-util") return {
+          exec: async (_command: string, args: string[]) => {
+            commands.push(args);
+            if (args[0] === "create-keychain") keychainPassword = args[2];
+            if (args[0] === "set-key-partition-list" && args[args.indexOf("-k") + 1] !== keychainPassword) {
+              throw new Error("SecKeychainUnlock: incorrect keychain password");
+            }
+            return "";
+          },
+        };
+        if (name === "./codesign") return { importCertificate: async (link: string) => link };
+        return dependencyRequire(name);
+      },
+    });
+    await exports.createKeychain({
+      tmpDir: {}, currentDir: "/fixture/desktop", cscLink: "application.p12",
+      cscKeyPassword: "certificate-password",
+      ...(installer ? { cscILink: "installer.p12", cscIKeyPassword: "installer-password" } : {}),
+    });
+    expect(keychainPassword).not.toBe("certificate-password");
+    const imports = commands.filter(([command]) => command === "import");
+    expect(imports.map((args) => args[args.indexOf("-P") + 1])).toEqual(
+      installer ? ["certificate-password", "installer-password"] : ["certificate-password"],
+    );
+    expect(commands.filter(([command]) => command === "set-key-partition-list")).toHaveLength(installer ? 2 : 1);
+  });
+});


### PR DESCRIPTION
## Summary

macOS arm64 Canary packaging fails with `SecKeychainUnlock` during `security set-key-partition-list` ([failed run](https://github.com/HamedMP/matrix-os/actions/runs/34012255658)). `app-builder-lib@26.15.3` creates a temporary keychain with a random password but passes the certificate password when configuring its ACLs. Apply a version-scoped pnpm patch that forwards the generated keychain password; certificate import continues using the certificate password.

Tracks [OM-215](https://linear.app/matrix-os/issue/OM-215/fix-macos-arm64-canary-signing-keychain-unlock-failures).

## Tests

- Before patch: both installed-dependency regression cases fail with the same keychain-password mismatch.
- After patch: 35 signing, packaging, and release workflow tests pass.
- Root typecheck passes; pattern scanner reports zero violations.
- `pnpm install --frozen-lockfile` passes with the patch.
- Full repository suite stopped after 531 passing tests: billing-routes and golden-snapshot-repository database initialization hooks timed out at 60 seconds in unchanged files. Both affected cases pass in an isolated rerun (2.5 seconds total). This is not a full-suite pass.
- Signed macOS dry-run validation: https://github.com/HamedMP/matrix-os/actions/runs/34035504981 — arm64 packaging, signature/notarization verification, DMG mount and application launch all pass; Linux passes; x64 is still running.
- Greptile: 5/5 on `e741b9bf113a6811560e98b5e19f2b0b61b46bd8`; ready-for-ci added and full CI running.

The regression executes the installed dependency in a VM with only certificate import and security commands simulated. It covers distinct application and installer passwords. It does not substitute for real signing/notarization validation.

## Invariants

- Source of truth: the generated keychain password authorizes keychain ACL changes; each certificate password decrypts only its certificate.
- Lock/transaction scope: unchanged upstream keychain lifecycle; no database writes.
- Acceptable orphan states: unchanged upstream cleanup; this patch adds no files at runtime.
- Auth source of truth: existing signing secrets and notarization credentials; no credential changes.
- Deferred scope: upstream package upgrade, certificate rotation, release publication, and channel promotion. Remove the patch only after validating an upstream fix.

## Post-Deploy Monitoring & Validation

Run Desktop Release with `mode=dry-run` on this branch. Both macOS architectures must pass packaging, signature and notarization verification, and DMG launch checks. The dry run must leave release/channel pointers unchanged.
