### PR TITLE
fix(desktop): use the keychain password for mac signing access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 
 # Copy only dependency manifests -- changes here bust the install cache
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY patches/ patches/
 COPY packages/kernel/package.json packages/kernel/
 COPY packages/gateway/package.json packages/gateway/
 COPY packages/observability/package.json packages/observability/

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -6,6 +6,7 @@ RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY patches/ patches/
 COPY packages/clerk-sync/package.json packages/clerk-sync/package.json
 COPY packages/contracts/package.json packages/contracts/package.json
 COPY packages/gateway/package.json packages/gateway/package.json

--- a/docker-compose.dev-vps.yml
+++ b/docker-compose.dev-vps.yml
@@ -76,6 +76,7 @@ services:
       - ./package.json:/app/package.json
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
+      - ./patches:/app/patches:ro
       - ./tsconfig.json:/app/tsconfig.json
       - ./vitest.config.ts:/app/vitest.config.ts
       - ./.env:/app/.env:ro

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -89,6 +89,7 @@ services:
       - ./package.json:/app/package.json
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
+      - ./patches:/app/patches:ro
       - ./tsconfig.json:/app/tsconfig.json
       - ./vitest.config.ts:/app/vitest.config.ts
       # Persistent volumes
@@ -323,6 +324,7 @@ services:
       - ./package.json:/app/package.json
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
+      - ./patches:/app/patches:ro
       - ./tsconfig.json:/app/tsconfig.json
       - ./vitest.config.ts:/app/vitest.config.ts
       - ./distro:/app/distro
@@ -371,6 +373,7 @@ services:
       - ./package.json:/app/package.json
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
+      - ./patches:/app/patches:ro
       - ./tsconfig.json:/app/tsconfig.json
       - ./vitest.config.ts:/app/vitest.config.ts
       - ./distro:/app/distro

--- a/docker-compose.staging-slot.yml
+++ b/docker-compose.staging-slot.yml
@@ -33,6 +33,7 @@ services:
       - ./package.json:/app/package.json
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
+      - ./patches:/app/patches:ro
       - ./tsconfig.json:/app/tsconfig.json
       - ./vitest.config.ts:/app/vitest.config.ts
       - slot-node-modules:/app/node_modules

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -32,6 +32,7 @@ services:
       - ./package.json:/app/package.json
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
+      - ./patches:/app/patches:ro
       - ./tsconfig.json:/app/tsconfig.json
       - ./vitest.config.ts:/app/vitest.config.ts
       - staging-node-modules:/app/node_modules

--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
           "vscode-languageserver-types": "3.17.5"
         }
       }
+    },
+    "patchedDependencies": {
+      "app-builder-lib@26.15.3": "patches/app-builder-lib@26.15.3.patch"
     }
   },
   "devDependencies": {

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,26 @@
+# Dependency patches
+
+## app-builder-lib 26.15.3: macOS signing keychain password
+
+The macOS packager creates a temporary keychain with a generated password.
+Version 26.15.3 instead supplies the certificate's import password to
+`security set-key-partition-list`, which expects the temporary keychain
+password. On macOS ARM64 this caused `SecKeychainUnlock` failures after a
+successful app build and certificate import.
+
+The patch threads the generated password through `importCerts`. Each
+certificate keeps its own password for `security import -P`; only the
+keychain access-control command uses the generated password. Signing,
+notarization, identity discovery, and cleanup behavior are unchanged.
+
+`tests/desktop/mac-signing-keychain.test.ts` exercises the installed module
+resolved through Electron Desktop's actual dependency tree, intercepting
+security commands so tests need no signing credentials or real keychains.
+It covers application and installer certificates, an empty certificate
+password, and propagation of access-control failures.
+
+The root pnpm configuration and lockfile bind this patch to 26.15.3. On an
+electron-builder upgrade, check the new `app-builder-lib` implementation;
+remove the patch only once it uses the keychain password for partition-list
+access, and keep the behavioral regression tests. CI's frozen install must
+apply the patch before packaging.

--- a/patches/app-builder-lib@26.15.3.patch
+++ b/patches/app-builder-lib@26.15.3.patch
@@ -1,0 +1,24 @@
+diff --git a/out/codeSign/macCodeSign.js b/out/codeSign/macCodeSign.js
+index 9a69042fd48f4759a1c697bf23fa5b44f2da2366..637cc19f525c6ee3479b377cac4c6c78345aa8ba 100644
+--- a/out/codeSign/macCodeSign.js
++++ b/out/codeSign/macCodeSign.js
+@@ -156,16 +156,16 @@ async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink, cscIK
+     if (cscIKeyPassword != null) {
+         cscPasswords.push(cscIKeyPassword);
+     }
+-    return await importCerts(keychainFile, certPaths, cscPasswords);
++    return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword);
+ }
+-async function importCerts(keychainFile, paths, keyPasswords) {
++async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {
+     var _a;
+     for (let i = 0; i < paths.length; i++) {
+         const password = (_a = keyPasswords[i]) !== null && _a !== void 0 ? _a : "";
+         await (0, builder_util_1.exec)("/usr/bin/security", ["import", paths[i], "-k", keychainFile, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productbuild", "-P", password]);
+         // https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p
+         // https://github.com/electron-userland/electron-packager/issues/701#issuecomment-322315996
+-        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]);
++        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]);
+     }
+     return {
+         keychainFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,11 @@ settings:
 
 packageExtensionsChecksum: sha256-MHRU4TXUD7qujRA9MBGatf2208j0N4EyngS9KgxMkMQ=
 
+patchedDependencies:
+  app-builder-lib@26.15.3:
+    hash: 4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1
+    path: patches/app-builder-lib@26.15.3.patch
+
 importers:
 
   .:
@@ -22671,7 +22676,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
+  app-builder-lib@26.15.3(patch_hash=4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
@@ -24062,7 +24067,7 @@ snapshots:
 
   dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       fs-extra: 10.1.0
       js-yaml: 4.1.1
@@ -24191,7 +24196,7 @@ snapshots:
 
   electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
@@ -24200,7 +24205,7 @@ snapshots:
 
   electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chalk: 4.1.2

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -143,6 +143,7 @@ cp -a "$ROOT_DIR/scripts/configure-hermes-matrix-defaults.mjs" "$STAGE_DIR/app/s
 cp -a "$ROOT_DIR/scripts/sync-matrix-agent-skills.sh" "$STAGE_DIR/app/scripts/sync-matrix-agent-skills.sh"
 cp -a "$ROOT_DIR/skills" "$STAGE_DIR/app/skills"
 cp -a "$ROOT_DIR/package.json" "$ROOT_DIR/pnpm-workspace.yaml" "$ROOT_DIR/pnpm-lock.yaml" "$STAGE_DIR/app/"
+cp -a "$ROOT_DIR/patches" "$STAGE_DIR/app/patches"
 printf '%s\n' "$TERMINAL_RUNTIME_GENERATION" > "$STAGE_DIR/app/TERMINAL_RUNTIME_GENERATION"
 # Activation follows the installed app payload so the supported updater's
 # app rollback atomically returns pre-activation bundles to dormant behavior.

--- a/tests/desktop/mac-signing-keychain.test.ts
+++ b/tests/desktop/mac-signing-keychain.test.ts
@@ -1,7 +1,8 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
 
 // Resolve the code actually used by the desktop packager, including pnpm patches.
 const desktopRequire = createRequire(resolve("desktop/package.json"));
@@ -92,5 +93,24 @@ describe("signing patch build inputs", () => {
   it("keeps host bundle manifests together with the patch they reference", () => {
     const source = readFileSync("scripts/build-host-bundle.sh", "utf8");
     expect(source).toContain('cp -a "$ROOT_DIR/patches" "$STAGE_DIR/app/patches"');
+  });
+});
+
+describe("signing patch Compose mounts", () => {
+  const cases = readdirSync(".")
+    .filter((file) => /^docker-compose.*\.yml$/.test(file))
+    .flatMap((file) => {
+      const config = parse(readFileSync(file, "utf8")) as { services: Record<string, { volumes?: string[] }> };
+      return Object.entries(config.services)
+        .filter(([, service]) => service.volumes?.includes("./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro"))
+        .map(([name, service]) => ({ file, name, volumes: service.volumes! }));
+    });
+
+  it("includes the development container used by Docker CI", () => {
+    expect(cases).toContainEqual(expect.objectContaining({ file: "docker-compose.dev.yml", name: "dev" }));
+  });
+
+  it.each(cases)("makes patches available with the lockfile in $file / $name", ({ volumes }) => {
+    expect(volumes).toContain("./patches:/app/patches:ro");
   });
 });

--- a/tests/desktop/mac-signing-keychain.test.ts
+++ b/tests/desktop/mac-signing-keychain.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Resolve the code actually used by the desktop packager, including pnpm patches.
+const desktopRequire = createRequire(resolve("desktop/package.json"));
+const builderRequire = createRequire(desktopRequire.resolve("electron-builder"));
+const signingRequire = createRequire(builderRequire.resolve("app-builder-lib"));
+const builderUtil = signingRequire("builder-util");
+const codesign = signingRequire("app-builder-lib/out/codeSign/codesign.js");
+const { createKeychain } = signingRequire("app-builder-lib/out/codeSign/macCodeSign.js");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+function mockSecurity(partitionError?: Error) {
+  // Skip unrelated root-certificate installation; no real keychains are touched.
+  vi.stubEnv("TRAVIS", "true");
+  const calls: string[][] = [];
+  let keychainPassword: string | undefined;
+  vi.spyOn(codesign, "importCertificate").mockImplementation(async (link: string) => link);
+  vi.spyOn(builderUtil, "exec").mockImplementation(async (file: string, args: string[]) => {
+    expect(file).toBe("/usr/bin/security");
+    calls.push(args);
+    if (args[0] === "create-keychain") keychainPassword = args[2];
+    if (args[0] === "set-key-partition-list") {
+      if (args[args.indexOf("-k") + 1] !== keychainPassword) {
+        throw new Error("SecKeychainUnlock: incorrect keychain passphrase");
+      }
+      if (partitionError) throw partitionError;
+    }
+    return "";
+  });
+  return calls;
+}
+
+describe("desktop signing keychain credentials", () => {
+  it.each([
+    { name: "application", applicationPassword: "app-certificate-password", installerPassword: undefined },
+    { name: "application and installer", applicationPassword: "app-certificate-password", installerPassword: "installer-certificate-password" },
+    { name: "unprotected certificate", applicationPassword: "", installerPassword: undefined },
+  ])("keeps $name certificate passwords separate from the keychain password", async ({ applicationPassword, installerPassword }) => {
+    const calls = mockSecurity();
+    const result = await createKeychain({
+      tmpDir: {},
+      cscLink: "/fixture/application.p12",
+      cscKeyPassword: applicationPassword,
+      ...(installerPassword === undefined ? {} : {
+        cscILink: "/fixture/installer.p12", cscIKeyPassword: installerPassword,
+      }),
+      currentDir: "/fixture/desktop",
+    });
+    const created = calls.find((args) => args[0] === "create-keychain")!;
+    const keychainPassword = created[2];
+    expect(keychainPassword).toBeTruthy();
+    expect(keychainPassword).not.toBe(applicationPassword);
+    expect(result.keychainFile).toBe(created[3]);
+    expect(calls).toContainEqual(["unlock-keychain", "-p", keychainPassword, result.keychainFile]);
+    const imports = calls.filter((args) => args[0] === "import");
+    expect(imports.map((args) => args[args.indexOf("-P") + 1])).toEqual(
+      installerPassword === undefined ? [applicationPassword] : [applicationPassword, installerPassword],
+    );
+    const partitionCalls = calls.filter((args) => args[0] === "set-key-partition-list");
+    expect(partitionCalls).toHaveLength(imports.length);
+    for (const args of partitionCalls) {
+      expect(args).toEqual(["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, result.keychainFile]);
+    }
+  });
+
+  it("still rejects failures while granting signing-key access", async () => {
+    const error = new Error("keychain access denied");
+    mockSecurity(error);
+    await expect(createKeychain({
+      tmpDir: {}, cscLink: "/fixture/application.p12", cscKeyPassword: "certificate-password", currentDir: "/fixture/desktop",
+    })).rejects.toThrow(error);
+  });
+});
+
+// A root patchedDependencies entry also affects filtered installs. Every
+// dependency-only build context must include the patch before pnpm runs.
+describe("signing patch build inputs", () => {
+  it.each(["Dockerfile", "Dockerfile.platform"])("copies dependency patches before installation in %s", (file) => {
+    const source = readFileSync(file, "utf8");
+    const copy = source.indexOf("COPY patches/ patches/");
+    expect(copy).toBeGreaterThan(-1);
+    expect(copy).toBeLessThan(source.indexOf("RUN pnpm install"));
+  });
+
+  it("keeps host bundle manifests together with the patch they reference", () => {
+    const source = readFileSync("scripts/build-host-bundle.sh", "utf8");
+    expect(source).toContain('cp -a "$ROOT_DIR/patches" "$STAGE_DIR/app/patches"');
+  });
+});


### PR DESCRIPTION
## Summary

macOS ARM64 canary packaging failed after a successful app build because `app-builder-lib 26.15.3` passed the certificate import password to `security set-key-partition-list`. That command needs the generated temporary keychain password. See [failed canary job](https://github.com/HamedMP/matrix-os/actions/runs/34012255658/job/101430002558).

Apply a version-bound pnpm patch that threads the generated keychain password into the partition-list command. Application and installer certificates retain their separate import passwords. Copy patch files into Docker dependency layers, bind-mount them read-only alongside Compose lockfiles, and include them in host bundle staging so the shipped dependency manifests remain reproducible. Patch removal guidance is documented in `patches/README.md`.

## Validation

- New tests reproduced the original keychain-unlock failure before the patch (4 failing tests).
- Frozen pnpm install applies the exact patch and its lockfile hash.
- 33 signing and desktop release workflow tests pass, covering application/installer certificates, empty certificate passwords, access-control error propagation, and patch availability in build contexts.
- 75 host bundle and incremental-manifest tests pass.
- `bash -n scripts/build-host-bundle.sh` and `git diff --check` pass.
- Tests execute the actual installed signing module with intercepted security commands; a production-certificate signing/notarization run remains to be verified by the macOS release workflow.

Docker smoke follow-up: the initial CI container could not start because its selective source mounts omitted `/app/patches`. All six Compose services that mount the lockfile now mount the patch directory read-only. Regression tests reproduced each missing mount before the fix; 49 related signing, release, local-development and entrypoint tests pass. Fresh CI is running on the corrected head.

## Invariants

- **Source of truth:** The existing signing certificate secrets remain authoritative. electron-builder still generates and owns its temporary keychain password.
- **Lock/transaction scope:** pnpm pins the patch to app-builder-lib 26.15.3 with a lockfile hash. No database changes.
- **Acceptable orphan states:** No changes to existing temporary keychain cleanup.
- **Auth source of truth:** Existing Apple credentials, certificate identity discovery, signing and notarization checks remain in place.
- **Deferred scope:** No certificate rotation, signing bypass, release channel changes, or customer VPS deployment.

