### PR TITLE
fix(desktop): use the keychain password during macOS signing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 
 # Copy only dependency manifests -- changes here bust the install cache
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY patches/ patches/
 COPY packages/kernel/package.json packages/kernel/
 COPY packages/gateway/package.json packages/gateway/
 COPY packages/observability/package.json packages/observability/

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -6,6 +6,7 @@ RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY patches/ patches/
 COPY packages/clerk-sync/package.json packages/clerk-sync/package.json
 COPY packages/contracts/package.json packages/contracts/package.json
 COPY packages/gateway/package.json packages/gateway/package.json

--- a/docker-compose.dev-vps.yml
+++ b/docker-compose.dev-vps.yml
@@ -74,6 +74,7 @@ services:
       - ./distro:/app/distro
       - ./scripts:/app/scripts
       - ./package.json:/app/package.json
+      - ./patches:/app/patches:ro
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
       - ./tsconfig.json:/app/tsconfig.json

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -87,6 +87,7 @@ services:
       - ./scripts:/app/scripts
       # Config files from root
       - ./package.json:/app/package.json
+      - ./patches:/app/patches:ro
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
       - ./tsconfig.json:/app/tsconfig.json
@@ -182,6 +183,7 @@ services:
     volumes:
       - ./packages:/app/packages
       - ./package.json:/app/package.json
+      - ./patches:/app/patches:ro
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./tsconfig.json:/app/tsconfig.json
       - dev-node-modules:/app/node_modules
@@ -215,6 +217,7 @@ services:
     volumes:
       - ./packages:/app/packages
       - ./package.json:/app/package.json
+      - ./patches:/app/patches:ro
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./tsconfig.json:/app/tsconfig.json
       - dev-node-modules:/app/node_modules
@@ -321,6 +324,7 @@ services:
       - ./skills:/app/skills
       - ./scripts:/app/scripts
       - ./package.json:/app/package.json
+      - ./patches:/app/patches:ro
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
       - ./tsconfig.json:/app/tsconfig.json
@@ -369,6 +373,7 @@ services:
       - ./skills:/app/skills
       - ./scripts:/app/scripts
       - ./package.json:/app/package.json
+      - ./patches:/app/patches:ro
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
       - ./tsconfig.json:/app/tsconfig.json

--- a/docker-compose.staging-slot.yml
+++ b/docker-compose.staging-slot.yml
@@ -31,6 +31,7 @@ services:
       - ./distro:/app/distro
       - ./scripts:/app/scripts
       - ./package.json:/app/package.json
+      - ./patches:/app/patches:ro
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
       - ./tsconfig.json:/app/tsconfig.json

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -30,6 +30,7 @@ services:
       - ./distro:/app/distro
       - ./scripts:/app/scripts
       - ./package.json:/app/package.json
+      - ./patches:/app/patches:ro
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
       - ./tsconfig.json:/app/tsconfig.json

--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
           "vscode-languageserver-types": "3.17.5"
         }
       }
+    },
+    "patchedDependencies": {
+      "app-builder-lib@26.15.3": "patches/app-builder-lib@26.15.3.patch"
     }
   },
   "devDependencies": {

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,18 @@
+# Dependency patches
+
+## app-builder-lib 26.15.3
+
+`macCodeSign.createKeychain` creates a temporary keychain with a random password,
+but the unpatched implementation passes the certificate's password to
+`security set-key-partition-list`. On macOS ARM runners this fails with
+`SecKeychainUnlock`, even after certificate import succeeds.
+
+The patch carries the generated keychain password into ACL setup while keeping
+each certificate password scoped to `security import`. Signing and notarization
+remain enabled. `tests/desktop/macos-signing-keychain.test.ts` exercises the
+installed dependency with OS calls intercepted, covering application-only and
+application-plus-installer certificates without accessing real credentials.
+
+When upgrading electron-builder, remove this patch only after verifying the new
+dependency uses the correct password and the regression tests and signed macOS
+builds pass on both architectures.

--- a/patches/app-builder-lib@26.15.3.patch
+++ b/patches/app-builder-lib@26.15.3.patch
@@ -1,0 +1,23 @@
+--- a/out/codeSign/macCodeSign.js
++++ b/out/codeSign/macCodeSign.js
+@@ -156,16 +156,16 @@
+     if (cscIKeyPassword != null) {
+         cscPasswords.push(cscIKeyPassword);
+     }
+-    return await importCerts(keychainFile, certPaths, cscPasswords);
+-}
+-async function importCerts(keychainFile, paths, keyPasswords) {
++    return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword);
++}
++async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {
+     var _a;
+     for (let i = 0; i < paths.length; i++) {
+         const password = (_a = keyPasswords[i]) !== null && _a !== void 0 ? _a : "";
+         await (0, builder_util_1.exec)("/usr/bin/security", ["import", paths[i], "-k", keychainFile, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productbuild", "-P", password]);
+         // https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p
+         // https://github.com/electron-userland/electron-packager/issues/701#issuecomment-322315996
+-        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]);
++        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]);
+     }
+     return {
+         keychainFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,11 @@ settings:
 
 packageExtensionsChecksum: sha256-MHRU4TXUD7qujRA9MBGatf2208j0N4EyngS9KgxMkMQ=
 
+patchedDependencies:
+  app-builder-lib@26.15.3:
+    hash: 0fc9a327982b3fdd5d9f4946e17bd8bf8d3d5c9b3753f77f0b18f7c0f0bdb4db
+    path: patches/app-builder-lib@26.15.3.patch
+
 importers:
 
   .:
@@ -22701,7 +22706,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
+  app-builder-lib@26.15.3(patch_hash=0fc9a327982b3fdd5d9f4946e17bd8bf8d3d5c9b3753f77f0b18f7c0f0bdb4db)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
@@ -24092,7 +24097,7 @@ snapshots:
 
   dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=0fc9a327982b3fdd5d9f4946e17bd8bf8d3d5c9b3753f77f0b18f7c0f0bdb4db)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       fs-extra: 10.1.0
       js-yaml: 4.1.1
@@ -24221,7 +24226,7 @@ snapshots:
 
   electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=0fc9a327982b3fdd5d9f4946e17bd8bf8d3d5c9b3753f77f0b18f7c0f0bdb4db)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
@@ -24230,7 +24235,7 @@ snapshots:
 
   electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=0fc9a327982b3fdd5d9f4946e17bd8bf8d3d5c9b3753f77f0b18f7c0f0bdb4db)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chalk: 4.1.2

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -143,6 +143,7 @@ cp -a "$ROOT_DIR/scripts/configure-hermes-matrix-defaults.mjs" "$STAGE_DIR/app/s
 cp -a "$ROOT_DIR/scripts/sync-matrix-agent-skills.sh" "$STAGE_DIR/app/scripts/sync-matrix-agent-skills.sh"
 cp -a "$ROOT_DIR/skills" "$STAGE_DIR/app/skills"
 cp -a "$ROOT_DIR/package.json" "$ROOT_DIR/pnpm-workspace.yaml" "$ROOT_DIR/pnpm-lock.yaml" "$STAGE_DIR/app/"
+cp -a "$ROOT_DIR/patches" "$STAGE_DIR/app/patches"
 printf '%s\n' "$TERMINAL_RUNTIME_GENERATION" > "$STAGE_DIR/app/TERMINAL_RUNTIME_GENERATION"
 # Activation follows the installed app payload so the supported updater's
 # app rollback atomically returns pre-activation bundles to dormant behavior.

--- a/tests/desktop/dependency-patch-packaging.test.ts
+++ b/tests/desktop/dependency-patch-packaging.test.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
 
 describe("dependency patch packaging", () => {
   it.each(["Dockerfile", "Dockerfile.platform"])("copies patches before installing dependencies in %s", (file) => {
@@ -13,4 +14,15 @@ describe("dependency patch packaging", () => {
     const source = readFileSync("scripts/build-host-bundle.sh", "utf8");
     expect(source).toContain('cp -a "$ROOT_DIR/patches" "$STAGE_DIR/app/patches"');
   });
+
+  it.each(readdirSync(".").filter((file) => /^docker-compose.*\.yml$/.test(file)))("mounts patches with package metadata in %s", (file) => {
+    const compose = parse(readFileSync(file, "utf8"));
+    for (const service of Object.values(compose.services ?? {}) as { volumes?: string[] }[]) {
+      const volumes = service.volumes ?? [];
+      if (volumes.includes("./package.json:/app/package.json")) {
+        expect(volumes).toContain("./patches:/app/patches:ro");
+      }
+    }
+  });
+
 });

--- a/tests/desktop/dependency-patch-packaging.test.ts
+++ b/tests/desktop/dependency-patch-packaging.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("dependency patch packaging", () => {
+  it.each(["Dockerfile", "Dockerfile.platform"])("copies patches before installing dependencies in %s", (file) => {
+    const source = readFileSync(file, "utf8");
+    const copy = source.indexOf("COPY patches/ patches/");
+    expect(copy).toBeGreaterThanOrEqual(0);
+    expect(copy).toBeLessThan(source.indexOf("RUN pnpm install"));
+  });
+
+  it("ships patch files alongside host bundle package metadata", () => {
+    const source = readFileSync("scripts/build-host-bundle.sh", "utf8");
+    expect(source).toContain('cp -a "$ROOT_DIR/patches" "$STAGE_DIR/app/patches"');
+  });
+});

--- a/tests/desktop/macos-signing-keychain.test.ts
+++ b/tests/desktop/macos-signing-keychain.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { runInNewContext } from "node:vm";
+import { describe, expect, it } from "vitest";
+
+const desktopRequire = createRequire(resolve("desktop/package.json"));
+const builderRequire = createRequire(desktopRequire.resolve("electron-builder"));
+const signingPath = builderRequire.resolve("app-builder-lib/out/codeSign/macCodeSign.js");
+const signingRequire = createRequire(signingPath);
+
+describe("installed macOS signing dependency", () => {
+  it.each([false, true])("uses the keychain password for ACL setup (installer certificate: %s)", async (installer) => {
+    const commands: string[][] = [];
+    const signing: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+    // Exercise the installed dependency while replacing only OS/certificate I/O.
+    // No real keychain, certificate, or credential is accessed by this test.
+    runInNewContext(readFileSync(signingPath, "utf8"), {
+      exports: signing,
+      __dirname: dirname(signingPath),
+      process: { env: { TRAVIS: "true" }, platform: "darwin" },
+      require: (name: string) => {
+        if (name === "builder-util") return {
+          exec: async (executable: string, args: string[]) => {
+            expect(executable).toBe("/usr/bin/security");
+            commands.push(Array.from(args));
+            return "";
+          },
+        };
+        if (name === "./codesign") return {
+          importCertificate: async (link: string) => `/fixture/${link}.p12`,
+        };
+        return signingRequire(name);
+      },
+    });
+    await signing.createKeychain({
+      tmpDir: {},
+      currentDir: "/fixture/app",
+      cscLink: "application",
+      cscKeyPassword: "application-certificate-password",
+      ...(installer ? { cscILink: "installer", cscIKeyPassword: "installer-certificate-password" } : {}),
+    });
+
+    const create = commands.find((args) => args[0] === "create-keychain")!;
+    const keychainPassword = create[2];
+    const keychainPath = create[3];
+    expect(keychainPassword).toBeTruthy();
+    expect(keychainPassword).not.toBe("application-certificate-password");
+    expect(commands).toContainEqual(["unlock-keychain", "-p", keychainPassword, keychainPath]);
+    const imports = commands.filter((args) => args[0] === "import");
+    expect(imports.map((args) => args[args.indexOf("-P") + 1])).toEqual(
+      installer ? ["application-certificate-password", "installer-certificate-password"] : ["application-certificate-password"],
+    );
+    const partitions = commands.filter((args) => args[0] === "set-key-partition-list");
+    expect(partitions).toHaveLength(imports.length);
+    for (const args of partitions) {
+      expect(args[args.indexOf("-k") + 1]).toBe(keychainPassword);
+      expect(args.at(-1)).toBe(keychainPath);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The Electron dev build on main failed twice on macOS ARM with `SecKeychainUnlock` during keychain ACL setup ([failed run](https://github.com/HamedMP/matrix-os/actions/runs/34060861036)). The pinned `app-builder-lib` creates its temporary keychain with a random password but passes the certificate password to `security set-key-partition-list`.

Patch the pinned dependency to carry the generated keychain password into ACL setup. Certificate import continues to use each certificate's own password, and signing and notarization remain enabled. Copy the patch into Docker dependency stages and host bundles, and mount it alongside package metadata in local/dev Compose services so their package metadata remains self-contained. No dependency versions change.

## Tests

- Red/green regression against the installed dependency, intercepting OS calls: application-only and application-plus-installer certificates.
- Red/green packaging checks for both Docker dependency stages and host bundle patch inclusion.
- Frozen-lockfile install passed.
- 102 initial focused signing, release workflow, and host-bundle tests passed; 21 focused Compose, dev-entrypoint, and signing tests passed after adding the missing dev-container mount.
- Signed desktop builds passed on Linux x64, macOS arm64, and macOS x64, including macOS notarization and DMG launch smoke tests ([artifact run](https://github.com/HamedMP/matrix-os/actions/runs/34064680433)).
- All four Linux unit shards and E2E passed on the first revision. Docker smoke exposed missing patch mounts in Compose; these are now covered by regression tests.
- Repository typecheck passed; pattern checks reported zero violations.
- Full local macOS suite: 13,581 passed, 11 failed, 2 skipped. Failures are in unchanged Linux host-script tests (GNU stat / add-apt-repository), committed DMG artwork byte comparison, and interactive Bash timeout tests. Linux CI and signed macOS packaging remain the release gates.

## Invariants

- Source of truth: the random password used to create the temporary keychain also unlocks it and configures its ACL. Certificate passwords only unlock their corresponding certificate imports.
- Lock/transaction scope: no database or concurrency behavior changes; existing temporary-keychain lifecycle is preserved.
- Acceptable orphan states: none added; existing builder cleanup remains responsible for temporary keychains.
- Auth source of truth: existing CI signing certificates and credentials; no signing, notarization, or credential checks are bypassed.
- Deferred scope: remove the patch when an upstream upgrade passes the regression tests and signed macOS builds on both architectures, as documented in `patches/README.md`.
