### PR TITLE
fix(billing): preserve portal access across runtime plans and clients

### DIFF
--- a/apps/mobile/__tests__/billing-settings-screen.test.tsx
+++ b/apps/mobile/__tests__/billing-settings-screen.test.tsx
@@ -1,0 +1,66 @@
+const mockUseSettingsBilling = jest.fn();
+const mockOpenPortal = jest.fn();
+
+jest.mock("@/lib/queries/use-settings-billing", () => ({
+  useSettingsBilling: () => mockUseSettingsBilling(),
+}));
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import { Linking } from "react-native";
+
+import BillingSettingsScreen from "../app/settings-detail/billing";
+
+const overrideEntitlement = {
+  source: "override",
+  planSlug: "matrix_builder",
+  status: "active",
+  portalAvailable: true,
+  billingInterval: null,
+};
+
+function settingsBillingState(portalAvailable: boolean) {
+  return {
+    billing: {
+      entitlement: { ...overrideEntitlement, portalAvailable },
+    },
+    isPending: false,
+    isError: false,
+    openPortal: mockOpenPortal,
+    isOpeningPortal: false,
+  };
+}
+
+describe("native mobile billing settings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOpenPortal.mockResolvedValue("https://billing.stripe.test/session");
+    mockUseSettingsBilling.mockReturnValue(settingsBillingState(true));
+  });
+
+  it("opens billing management for an override-backed account with a linked customer", async () => {
+    const openUrl = jest.spyOn(Linking, "openURL").mockResolvedValue(true);
+    render(<BillingSettingsScreen />);
+
+    fireEvent.press(screen.getByLabelText("Change plan"));
+
+    await waitFor(() => {
+      expect(mockOpenPortal).toHaveBeenCalledTimes(1);
+      expect(openUrl).toHaveBeenCalledWith("https://billing.stripe.test/session");
+    });
+    expect(openUrl).not.toHaveBeenCalledWith("https://matrix-os.com/pricing");
+  });
+
+  it("opens pricing when billing management is unavailable", async () => {
+    const openUrl = jest.spyOn(Linking, "openURL").mockResolvedValue(true);
+    mockUseSettingsBilling.mockReturnValue(settingsBillingState(false));
+    render(<BillingSettingsScreen />);
+
+    fireEvent.press(screen.getByLabelText("Change plan"));
+
+    await waitFor(() => {
+      expect(openUrl).toHaveBeenCalledWith("https://matrix-os.com/pricing");
+    });
+    expect(mockOpenPortal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/__tests__/requests-settings.test.ts
+++ b/apps/mobile/__tests__/requests-settings.test.ts
@@ -1,0 +1,62 @@
+jest.mock("@/lib/storage", () => ({
+  HOSTED_GATEWAY_URL: "https://app.matrix-os.com",
+}));
+
+import { fetchMobileBillingStatus } from "@/lib/requests/settings";
+
+const overrideBillingStatus = {
+  entitlement: {
+    source: "override",
+    planSlug: "matrix_builder",
+    status: "active",
+    maxRuntimeSlots: 1,
+    includedRuntimeSlots: 1,
+    addonRuntimeSlots: 0,
+    allowedPlanSlugs: ["matrix_builder"],
+    allowedSelections: [],
+    portalAvailable: true,
+    billingInterval: null,
+    recurringPrice: null,
+    runtimePlacement: null,
+    gracePeriodEndsAt: null,
+    trialStartedAt: null,
+    trialEndsAt: null,
+    trialConvertedAt: null,
+    firstTrialPaymentFailedAt: null,
+    effectiveFrom: "2026-09-01T00:00:00.000Z",
+    effectiveUntil: null,
+    updatedAt: "2026-09-01T00:00:00.000Z",
+  },
+  access: {
+    runtimeProxyAllowed: true,
+    reason: "active",
+  },
+  trialOffer: {
+    eligible: false,
+    durationDays: 3,
+  },
+};
+
+describe("settings requests", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("accepts the public portal capability without a Stripe subscription identifier", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(overrideBillingStatus),
+    } as unknown as Response);
+
+    await expect(fetchMobileBillingStatus("clerk-token", "primary")).resolves.toEqual(
+      overrideBillingStatus,
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://app.matrix-os.com/billing/status?runtimeSlot=primary",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer clerk-token" },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+});

--- a/apps/mobile/app/settings-detail/billing.tsx
+++ b/apps/mobile/app/settings-detail/billing.tsx
@@ -45,7 +45,7 @@ export default function BillingSettingsScreen() {
 
   async function openChangePlan() {
     if (isOpeningPortal) return;
-    if (!entitlement?.stripeSubscriptionId || entitlement.source !== "stripe") {
+    if (entitlement?.portalAvailable !== true) {
       await Linking.openURL(PRICING_URL);
       return;
     }

--- a/apps/mobile/lib/requests/settings.ts
+++ b/apps/mobile/lib/requests/settings.ts
@@ -1,4 +1,8 @@
 import { z } from "zod/v4";
+import {
+  MatrixBillingStatusSchema,
+  type MatrixBillingStatus,
+} from "@matrix-os/contracts";
 
 import { HOSTED_GATEWAY_URL } from "@/lib/storage";
 import { buildGatewayRequestUrl, fetchAuthenticatedJson } from "./http";
@@ -11,21 +15,11 @@ const SystemInfoSchema = z.object({
   release: z.object({ version: z.string() }).passthrough().optional(),
 }).passthrough();
 
-const BillingStatusSchema = z.object({
-  entitlement: z.object({
-    planSlug: z.enum(["matrix_starter", "matrix_builder", "matrix_max", "internal"]),
-    status: z.string(),
-    source: z.string(),
-    stripeSubscriptionId: z.string().nullable(),
-    billingInterval: z.enum(["monthly", "annual"]).nullable().optional(),
-  }).passthrough().nullable(),
-}).passthrough();
-
 const OkResponseSchema = z.object({ ok: z.literal(true) }).passthrough();
 const BillingPortalSchema = z.object({ url: z.url() }).strict();
 
 export type MobileSystemInfo = z.infer<typeof SystemInfoSchema>;
-export type MobileBillingStatus = z.infer<typeof BillingStatusSchema>;
+export type MobileBillingStatus = MatrixBillingStatus;
 
 export function fetchMobileSystemInfo(
   clerkToken: string,
@@ -48,7 +42,7 @@ export function fetchMobileBillingStatus(
   return fetchAuthenticatedJson({
     url: url.toString(),
     token: clerkToken,
-    schema: BillingStatusSchema,
+    schema: MatrixBillingStatusSchema,
     errorMessage: "Billing information unavailable. Try again.",
   });
 }

--- a/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
@@ -181,7 +181,7 @@ export default function BillingSection() {
   }
 
   async function openPortal(): Promise<void> {
-    if (!api || !portalAvailable || ui.actionLoading) return;
+    if (!api || loading || error || !portalAvailable || ui.actionLoading) return;
     dispatchUi({ type: "start-action", action: "portal" });
     try {
       const raw = await api.post<unknown>("/billing/portal", {});
@@ -198,7 +198,7 @@ export default function BillingSection() {
     <>
       <SettingsSectionHeader
         title="Billing"
-        description="Manage hosted runtime billing through the native Matrix session."
+        description="View your plan and manage your subscription, invoices, and payment methods."
       />
       <Card>
         <div className="flex items-center gap-3">
@@ -239,17 +239,32 @@ export default function BillingSection() {
           </>
         ) : null}
 
-        {portalAvailable ? (
-          <div className="flex items-center justify-between border-t pt-3" style={{ borderColor: "var(--border-subtle)" }}>
-            <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-              Invoices, payment methods, coupons, and cancellation live in Stripe.
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3" style={{ borderColor: "var(--border-subtle)" }}>
+          <div className="min-w-0 flex-1 basis-64">
+            <p className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+              Billing management
             </p>
-            <Button onClick={() => void openPortal()} disabled={!portalAvailable || ui.actionLoading !== null}>
-              {ui.actionLoading === "portal" ? "Opening..." : "Open portal"}
-              <ExternalLink size={14} />
-            </Button>
+            <p className="mt-1 text-sm" style={{ color: "var(--text-secondary)" }}>
+              {loading
+                ? "Checking billing management availability."
+                : error || !api
+                  ? "Refresh your billing status to check whether billing management is available."
+                  : portalAvailable
+                    ? "Manage your subscription, invoices, and payment methods in your browser."
+                    : entitlement?.source === "override"
+                      ? "This account is managed internally. Contact the Matrix team for receipts and plan changes."
+                      : "Billing management is not available for this account yet."}
+            </p>
           </div>
-        ) : null}
+          <Button
+            variant="primary"
+            onClick={() => void openPortal()}
+            disabled={!api || loading || error || !portalAvailable || ui.actionLoading !== null}
+          >
+            {ui.actionLoading === "portal" ? "Opening..." : "Manage billing"}
+            <ExternalLink size={14} />
+          </Button>
+        </div>
 
         {!active ? (
           <div className="flex flex-col gap-3 border-t pt-3" style={{ borderColor: "var(--border-subtle)" }}>
@@ -302,7 +317,7 @@ export default function BillingSection() {
         ) : null}
 
         {ui.actionError ? (
-          <p className="text-sm" style={{ color: "var(--danger)" }}>
+          <p role="alert" className="text-sm" style={{ color: "var(--danger)" }}>
             {ui.actionError}
           </p>
         ) : null}

--- a/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
@@ -252,7 +252,7 @@ export default function BillingSection() {
                   : portalAvailable
                     ? "Manage your subscription, invoices, and payment methods in your browser."
                     : entitlement?.source === "override"
-                      ? "This account is managed internally. Contact the Matrix team for receipts and plan changes."
+                      ? "This account has no linked billing customer. Contact the Matrix team for billing help."
                       : "Billing management is not available for this account yet."}
             </p>
           </div>

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -1,4 +1,5 @@
 import { Hono, type Context } from 'hono';
+import { createBillingStatusHandler } from './billing-status-route.js';
 import { bodyLimit } from 'hono/body-limit';
 import { createHash, randomUUID } from 'node:crypto';
 import { MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
@@ -20,7 +21,6 @@ import {
   getBillingCustomerByStripeCustomerId,
   consumeCardTrial,
   getBillingEntitlement,
-  getBillingEntitlementState,
   getBillingSubscription,
   getBillingSubscriptionByStripeId,
   getActiveUserMachineByClerkId,
@@ -42,14 +42,11 @@ import {
 } from './db.js';
 import {
   DEFAULT_BILLING_PLAN_DEFINITIONS,
-  computeEffectiveEntitlement,
   deriveStripeEntitlement,
   getRuntimeAccessDecision,
   loadRuntimeCatalog,
   loadStripePriceCatalog,
   parseBillingEntitlementRecord,
-  parseBillingOverrideRecord,
-  projectPublicBillingEntitlement,
   resolveServerType,
   type BillingEntitlementStatus,
   type BillingEntitlement,
@@ -143,10 +140,6 @@ const PortalRequestSchema = z.object({
     (value) => value === undefined || resolveReturnPath(value) === value,
     { message: 'Invalid return path' },
   ),
-}).strict();
-
-const BillingStatusQuerySchema = z.object({
-  runtimeSlot: RuntimeSlotSchema.optional(),
 }).strict();
 
 const CheckoutPreparationStatusQuerySchema = z.object({
@@ -762,97 +755,16 @@ export function createBillingRoutes(options: {
     }
   });
 
-  app.get('/status', async (c) => {
-    const clerkUserId = await resolveRouteClerkUserId(c, 'status');
-    if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
-    try {
-      const currentTime = now();
-      const query = BillingStatusQuerySchema.safeParse(c.req.query());
-      if (!query.success) return c.json({ error: 'Invalid request' }, 400);
-      const runtimeSlot = query.data.runtimeSlot ?? 'primary';
-      const state = await getBillingEntitlementState(options.db, clerkUserId, currentTime.toISOString());
-      let stripeEntitlement = parseBillingEntitlementRecord(state.entitlement);
-      const selectedSubscription = await getBillingSubscription(
-        options.db,
-        clerkUserId,
-        runtimeSlot,
-        currentTime.toISOString(),
-      );
-      if (query.data.runtimeSlot) {
-        stripeEntitlement = selectedSubscription
-          ? deriveStripeEntitlement({
-            clerkUserId: selectedSubscription.clerkUserId,
-            stripeCustomerId: selectedSubscription.stripeCustomerId,
-            stripeSubscriptionId: selectedSubscription.stripeSubscriptionId,
-            status: selectedSubscription.status,
-            currentPeriodEnd: selectedSubscription.currentPeriodEnd,
-            trialStartedAt: selectedSubscription.trialStartedAt,
-            trialEndsAt: selectedSubscription.trialEndsAt,
-            trialConvertedAt: selectedSubscription.trialConvertedAt,
-            firstTrialPaymentFailedAt: selectedSubscription.firstTrialPaymentFailedAt,
-            items: [{ priceId: selectedSubscription.stripePriceId, quantity: 1 }],
-          }, {
-            priceCatalog: loadStripePriceCatalog(env),
-            runtimeCatalog: loadRuntimeCatalog(env),
-            now: currentTime,
-          })
-          : null;
-      }
-      const entitlement = computeEffectiveEntitlement({
-        stripeEntitlement,
-        override: parseBillingOverrideRecord(state.override),
-        now: currentTime,
-      });
-      const access = getRuntimeAccessDecision(entitlement, currentTime);
-      const trialsEnabledForSlot = env.MATRIX_CARD_TRIALS_ENABLED === 'true'
-        && runtimeSlot === 'primary';
-      const activeAttempt = await getActiveCheckoutAttempt(options.db, clerkUserId, runtimeSlot);
-      const offerEligible = trialsEnabledForSlot
-        ? await isCardTrialOfferEligible(options.db, clerkUserId)
-        : false;
-      const reservedTrialDays = runtimeSlot === 'primary'
-        ? activeAttempt?.trialPeriodDays ?? null
-        : null;
-      const trialOffer = {
-        eligible: reservedTrialDays !== null || (offerEligible && !activeAttempt),
-        durationDays: reservedTrialDays ?? cardTrialDays,
-      };
-      const recurringPrice = entitlement?.source === 'stripe'
-        && selectedSubscription
-        && selectedSubscription.planSlug === entitlement.planSlug
-        ? await resolvePublicRecurringPrice(
-          options.db,
-          options.stripe,
-          selectedSubscription,
-          currentTime,
-        )
-        : null;
-      const machine = await getActiveUserMachineByClerkId(
-        options.db,
-        clerkUserId,
-        runtimeSlot,
-      );
-      const placement = resolveRuntimePlacement(machine?.location);
-      return c.json({
-        entitlement: entitlement
-          ? projectPublicBillingEntitlement(entitlement, loadRuntimeCatalog(env), {
-            recurringPrice,
-            runtimePlacement: placement ? {
-              regionSlug: placement.slug,
-              label: placement.label,
-              countryLabel: placement.countryLabel,
-              networkZone: placement.networkZone,
-            } : null,
-          })
-          : null,
-        access,
-        trialOffer,
-      }, 200);
-    } catch (err: unknown) {
-      console.error('[billing] status lookup failed:', err instanceof Error ? err.message : String(err));
-      return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
-    }
-  });
+  app.get('/status', createBillingStatusHandler({
+    db: options.db,
+    stripe: options.stripe,
+    env,
+    now,
+    cardTrialDays,
+    resolveClerkUserId: (c) => resolveRouteClerkUserId(c, 'status'),
+    resolvePublicRecurringPrice,
+    resolveRuntimePlacement,
+  }));
 
   app.post('/webhooks/stripe', bodyLimit({ maxSize: STRIPE_WEBHOOK_BODY_LIMIT }), async (c) => {
     const signature = c.req.header('stripe-signature');

--- a/packages/platform/src/billing-status-route.ts
+++ b/packages/platform/src/billing-status-route.ts
@@ -1,0 +1,125 @@
+import type { Context, Handler } from 'hono';
+import { z } from 'zod/v4';
+import { MATRIX_HOSTED_BILLING_REGIONS, type MatrixBillingPublicEntitlement } from '@matrix-os/contracts';
+import {
+  getBillingCustomerByClerkUserId, getBillingEntitlementState, getBillingSubscription,
+  getActiveCheckoutAttempt, isCardTrialOfferEligible, getActiveUserMachineByClerkId,
+  type PlatformDB, type BillingSubscriptionRecord,
+} from './db.js';
+import {
+  parseBillingEntitlementRecord, deriveStripeEntitlement, loadStripePriceCatalog,
+  loadRuntimeCatalog, computeEffectiveEntitlement, parseBillingOverrideRecord,
+  getRuntimeAccessDecision, projectPublicBillingEntitlement,
+} from './billing.js';
+import type { StripeBillingClient } from './billing-routes.js';
+import { RuntimeSlotSchema } from './customer-vps-schema.js';
+
+const BillingStatusQuerySchema = z.object({ runtimeSlot: RuntimeSlotSchema.optional() }).strict();
+const BILLING_UNAVAILABLE_RESPONSE = { error: 'Billing unavailable', code: 'billing_unavailable' } as const;
+
+export function createBillingStatusHandler(options: {
+  db: PlatformDB;
+  stripe: StripeBillingClient;
+  env: NodeJS.ProcessEnv;
+  now: () => Date;
+  cardTrialDays: number;
+  resolveClerkUserId: (c: Context) => Promise<string | null>;
+  resolvePublicRecurringPrice: (db: PlatformDB, stripe: StripeBillingClient, subscription: BillingSubscriptionRecord, now: Date) => Promise<MatrixBillingPublicEntitlement['recurringPrice']>;
+  resolveRuntimePlacement: (location: string | null | undefined) => (typeof MATRIX_HOSTED_BILLING_REGIONS)[number] | null;
+}): Handler {
+  const { env, now, cardTrialDays } = options;
+  return async (c) => {
+    const clerkUserId = await options.resolveClerkUserId(c);
+    if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
+    try {
+      const currentTime = now();
+      const query = BillingStatusQuerySchema.safeParse(c.req.query());
+      if (!query.success) return c.json({ error: 'Invalid request' }, 400);
+      const runtimeSlot = query.data.runtimeSlot ?? 'primary';
+      const customer = await getBillingCustomerByClerkUserId(options.db, clerkUserId);
+      const state = await getBillingEntitlementState(options.db, clerkUserId, currentTime.toISOString());
+      let stripeEntitlement = parseBillingEntitlementRecord(state.entitlement);
+      const selectedSubscription = await getBillingSubscription(
+        options.db,
+        clerkUserId,
+        runtimeSlot,
+        currentTime.toISOString(),
+      );
+      if (query.data.runtimeSlot) {
+        stripeEntitlement = selectedSubscription
+          ? deriveStripeEntitlement({
+            clerkUserId: selectedSubscription.clerkUserId,
+            stripeCustomerId: selectedSubscription.stripeCustomerId,
+            stripeSubscriptionId: selectedSubscription.stripeSubscriptionId,
+            status: selectedSubscription.status,
+            currentPeriodEnd: selectedSubscription.currentPeriodEnd,
+            trialStartedAt: selectedSubscription.trialStartedAt,
+            trialEndsAt: selectedSubscription.trialEndsAt,
+            trialConvertedAt: selectedSubscription.trialConvertedAt,
+            firstTrialPaymentFailedAt: selectedSubscription.firstTrialPaymentFailedAt,
+            items: [{ priceId: selectedSubscription.stripePriceId, quantity: 1 }],
+          }, {
+            priceCatalog: loadStripePriceCatalog(env),
+            runtimeCatalog: loadRuntimeCatalog(env),
+            now: currentTime,
+          })
+          : null;
+      }
+      const entitlement = computeEffectiveEntitlement({
+        stripeEntitlement,
+        override: parseBillingOverrideRecord(state.override),
+        now: currentTime,
+      });
+      const access = getRuntimeAccessDecision(entitlement, currentTime);
+      const trialsEnabledForSlot = env.MATRIX_CARD_TRIALS_ENABLED === 'true'
+        && runtimeSlot === 'primary';
+      const activeAttempt = await getActiveCheckoutAttempt(options.db, clerkUserId, runtimeSlot);
+      const offerEligible = trialsEnabledForSlot
+        ? await isCardTrialOfferEligible(options.db, clerkUserId)
+        : false;
+      const reservedTrialDays = runtimeSlot === 'primary'
+        ? activeAttempt?.trialPeriodDays ?? null
+        : null;
+      const trialOffer = {
+        eligible: reservedTrialDays !== null || (offerEligible && !activeAttempt),
+        durationDays: reservedTrialDays ?? cardTrialDays,
+      };
+      const recurringPrice = entitlement?.source === 'stripe'
+        && selectedSubscription
+        && selectedSubscription.planSlug === entitlement.planSlug
+        ? await options.resolvePublicRecurringPrice(
+          options.db,
+          options.stripe,
+          selectedSubscription,
+          currentTime,
+        )
+        : null;
+      const machine = await getActiveUserMachineByClerkId(
+        options.db,
+        clerkUserId,
+        runtimeSlot,
+      );
+      const placement = options.resolveRuntimePlacement(machine?.location);
+      return c.json({
+        entitlement: entitlement
+          ? projectPublicBillingEntitlement(entitlement, loadRuntimeCatalog(env), {
+            portalAvailable: customer !== undefined,
+            recurringPrice,
+            runtimePlacement: placement ? {
+              regionSlug: placement.slug,
+              label: placement.label,
+              countryLabel: placement.countryLabel,
+              networkZone: placement.networkZone,
+            } : null,
+          })
+          : null,
+        access,
+        trialOffer,
+      }, 200);
+    } catch (err: unknown) {
+      console.error('[billing] status lookup failed:', err instanceof Error ? err.message : String(err));
+      return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
+    }
+
+  };
+}

--- a/packages/platform/src/billing.ts
+++ b/packages/platform/src/billing.ts
@@ -127,6 +127,8 @@ export interface RuntimeAccessDecision {
 }
 
 export interface PublicBillingEntitlementDetails {
+  /** Account customer linkage, independent of runtime entitlement or support overrides. */
+  portalAvailable?: boolean;
   recurringPrice?: MatrixBillingPublicEntitlement['recurringPrice'];
   runtimePlacement?: MatrixBillingPublicEntitlement['runtimePlacement'];
 }
@@ -164,7 +166,7 @@ export function projectPublicBillingEntitlement(
     addonRuntimeSlots: entitlement.addonRuntimeSlots,
     allowedPlanSlugs,
     allowedSelections,
-    portalAvailable: entitlement.source === 'stripe' && entitlement.stripeSubscriptionId !== null,
+    portalAvailable: details.portalAvailable === true,
     billingInterval: entitlement.billingInterval ?? null,
     recurringPrice: details.recurringPrice ?? null,
     runtimePlacement: details.runtimePlacement ?? null,

--- a/shell/src/components/settings/sections/BillingManagementPanel.tsx
+++ b/shell/src/components/settings/sections/BillingManagementPanel.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { ArrowUpRightIcon, ExternalLinkIcon, Loader2Icon, PlusIcon, ReceiptTextIcon, XCircleIcon } from "@/lib/hugeicons";
+import { MATRIX_BILLING_SERVER_PROFILES } from "@/lib/billing";
+import type { BillingEntitlementSummary } from "@/hooks/useMatrixBillingAccess";
+import { capturePostHogLog } from "@/lib/posthog-client";
+
+const BILLING_CHECKOUT_TIMEOUT_MS = 10_000;
+const billingDateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+const billingPlanNames: Record<string, string> = {
+  matrix_starter: "Starter",
+  matrix_builder: "Builder",
+  matrix_max: "Max",
+  internal: "Internal",
+};
+
+function formatRecurringPrice(
+  price: NonNullable<BillingEntitlementSummary["recurringPrice"]>,
+): string {
+  const formatter = new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: price.currency.toUpperCase(),
+    minimumFractionDigits: 0,
+  });
+  const fractionDigits = formatter.resolvedOptions().maximumFractionDigits ?? 2;
+  const totalMinor = price.unitAmountMinor * price.quantity;
+  const amount = formatter.format(totalMinor / (10 ** fractionDigits));
+  const period = price.intervalCount === 1
+    ? price.interval === "monthly" ? "month" : "year"
+    : `${price.intervalCount} ${price.interval === "monthly" ? "months" : "years"}`;
+  return `${amount}/${period}`;
+}
+
+export function BillingPortalButton({
+  entitlement,
+  label = "Open billing portal",
+}: {
+  entitlement: BillingEntitlementSummary | null;
+  label?: string;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const portalAvailable = entitlement?.portalAvailable === true;
+
+  async function openPortal() {
+    if (!portalAvailable || loading) return;
+    setLoading(true);
+    setError(null);
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), BILLING_CHECKOUT_TIMEOUT_MS);
+    // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler bailout on the try/finally needed to clear the abort timeout and reset `loading` on every path; the code is correct and the finalizer must run whether the request resolves, rejects, or throws.
+    try {
+      const response = await fetch("/billing/portal", {
+        method: "POST",
+        credentials: "include",
+        headers: { accept: "application/json" },
+        signal: controller.signal,
+      });
+      const body = response.ok
+        ? (await response.json().catch((err: unknown) => {
+          capturePostHogLog("warn", "billing portal_response_parse_error", {
+            source: "settings-billing",
+            error_kind: err instanceof Error ? err.name : typeof err,
+          });
+          return null;
+        })) as { url?: string } | null
+        : null;
+      if (!response.ok || !body?.url) {
+        // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler bailout on the throw inside try/catch; intentional control flow routing an unusable portal response into the catch handler. The code is correct.
+        throw new Error("portal_unavailable");
+      }
+      window.location.assign(body.url);
+    } catch (err: unknown) {
+      setError("Billing portal is unavailable. Try again in a moment.");
+      capturePostHogLog("error", "billing portal_error", {
+        source: "settings-billing",
+        error_kind: err instanceof Error ? err.message : typeof err,
+      });
+    } finally {
+      window.clearTimeout(timeoutId);
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={openPortal}
+        disabled={!portalAvailable || loading}
+        className="inline-flex h-10 items-center justify-center gap-2 rounded-xl bg-forest px-3.5 text-sm font-semibold text-ember-foreground transition-colors hover:bg-forest/90 disabled:cursor-not-allowed disabled:opacity-55"
+      >
+        {loading ? (
+          <Loader2Icon className="size-4 animate-spin" aria-hidden="true" />
+        ) : (
+          <ExternalLinkIcon className="size-4" aria-hidden="true" />
+        )}
+        {loading ? "Opening portal" : label}
+      </button>
+      {!portalAvailable && (
+        <p className="mt-2 text-xs leading-5 text-forest/55">
+          {entitlement?.source === "override"
+            ? "This account has no linked billing customer. Contact the Matrix team for billing help."
+            : "Billing management is not available for this account yet. Contact the Matrix team if you have paid."}
+        </p>
+      )}
+      {error && <p role="alert" className="mt-2 text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}
+
+export function ActiveBillingPanel({
+  entitlement,
+  accessReason,
+}: {
+  entitlement: BillingEntitlementSummary | null;
+  accessReason: string | null;
+}) {
+  const planName = entitlement ? billingPlanNames[entitlement.planSlug] ?? entitlement.planSlug : "Active";
+  const status = entitlement?.status ? formatStatus(entitlement.status) : accessReason === "legacy_clerk_plan" ? "Legacy plan" : "Active";
+  const allowedProfiles = MATRIX_BILLING_SERVER_PROFILES.filter((profile) =>
+    entitlement?.allowedPlanSlugs.includes(profile.planSlug) === true,
+  );
+  const totalComputers = entitlement?.maxRuntimeSlots ?? 1;
+  const includedComputers = entitlement?.includedRuntimeSlots ?? 1;
+  const addonComputers = entitlement?.addonRuntimeSlots ?? 0;
+  const graceLabel = entitlement?.gracePeriodEndsAt ? formatDate(entitlement.gracePeriodEndsAt) : null;
+  const isTrialing = entitlement?.status === "trialing" && Boolean(entitlement.trialEndsAt);
+  const trialEndLabel = entitlement?.trialEndsAt ? formatDate(entitlement.trialEndsAt) : null;
+  const billingInterval = entitlement?.billingInterval === "annual" ? "annual" : "monthly";
+  const recurringPriceLabel = entitlement?.recurringPrice
+    ? formatRecurringPrice(entitlement.recurringPrice)
+    : null;
+  const placement = entitlement?.runtimePlacement ?? null;
+
+  return (
+    <div className="space-y-3">
+      <section className="rounded-[22px] border border-forest/15 bg-[#fbf7ed] p-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-forest/55">
+              {isTrialing ? "Free trial active" : "Current plan"}
+            </p>
+            <h3 className="mt-2 text-2xl font-semibold tracking-tight text-deep">
+              {planName}
+            </h3>
+            <p className="mt-1 text-sm leading-6 text-forest/65">
+              {isTrialing && trialEndLabel
+                ? recurringPriceLabel
+                  ? `Your ${recurringPriceLabel} subscription starts on ${trialEndLabel}.`
+                  : `Your first ${billingInterval} charge is on ${trialEndLabel}.`
+                : `${status}. Your Matrix computers stay available while billing is active${graceLabel ? ` and through the grace period ending ${graceLabel}` : ""}.`}
+            </p>
+            {isTrialing && trialEndLabel && (
+              <p className="mt-1 text-sm font-medium text-ember">
+                Cancel before {trialEndLabel} to avoid being charged.
+              </p>
+            )}
+          </div>
+          <BillingPortalButton entitlement={entitlement} label={isTrialing ? "Manage trial" : undefined} />
+        </div>
+
+        <div className="mt-4 grid gap-3 md:grid-cols-4">
+          <BillingMetric label="Status" value={status} />
+          <BillingMetric label="Computers" value={`${totalComputers}`} detail={`${includedComputers} included${addonComputers ? `, ${addonComputers} add-on` : ""}`} />
+          <BillingMetric
+            label="Billing"
+            value={recurringPriceLabel ?? (billingInterval === "annual" ? "Annual" : "Monthly")}
+            detail="Managed subscription"
+          />
+          <BillingMetric
+            label="Location"
+            value={placement?.label ?? "Hosted region"}
+            detail={placement?.countryLabel ?? "Managed location"}
+          />
+        </div>
+      </section>
+
+      <section className="grid gap-3 lg:grid-cols-3">
+        <BillingAction
+          icon={<ArrowUpRightIcon className="size-4" aria-hidden="true" />}
+          title="Upgrade or downgrade"
+          description={`Switch between ${allowedProfiles.length ? allowedProfiles.map((profile) => profile.label).join(", ") : "Starter, Builder, and Max"} without deleting data or machines.`}
+          action={<BillingPortalButton entitlement={entitlement} label="Change plan" />}
+        />
+        <BillingAction
+          icon={<PlusIcon className="size-4" aria-hidden="true" />}
+          title="Add-ons"
+          description="Add extra machines first; storage and other hosted capacity can be attached as add-ons as they launch."
+          action={<BillingPortalButton entitlement={entitlement} label="Manage add-ons" />}
+        />
+        <BillingAction
+          icon={<ReceiptTextIcon className="size-4" aria-hidden="true" />}
+          title="Receipts and payment"
+          description="View invoices, receipts, tax details, payment methods, coupons, and billing email in the portal."
+          action={<BillingPortalButton entitlement={entitlement} label="View receipts" />}
+        />
+      </section>
+
+      <section className="rounded-[22px] border border-forest/12 bg-white p-4">
+        <div className="flex gap-3">
+          <XCircleIcon className="mt-0.5 size-4 shrink-0 text-forest/45" aria-hidden="true" />
+          <div>
+            <h4 className="text-sm font-semibold text-deep">Canceling</h4>
+            <p className="mt-1 text-sm leading-6 text-forest/65">
+              Canceling is handled in the billing portal. Your machines and owner data are not deleted automatically; access remains while billing is active and through the configured three-day grace window.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export function TrialPaymentRecoveryPanel({
+  entitlement,
+}: {
+  entitlement: BillingEntitlementSummary;
+}) {
+  return (
+    <section className="rounded-[22px] border border-ember/30 bg-card p-4 sm:p-5" role="alert">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-ember">Trial ended</p>
+          <h3 className="mt-2 text-2xl font-semibold tracking-tight text-deep">Payment required</h3>
+          <p className="mt-1 text-sm leading-6 text-forest/65">
+            Runtime access is paused until the first payment succeeds.
+          </p>
+          <p className="mt-1 text-xs leading-5 text-forest/55">
+            Update your card in Stripe. Matrix restores access automatically after the paid invoice webhook arrives.
+          </p>
+        </div>
+        <BillingPortalButton entitlement={entitlement} label="Update payment method" />
+      </div>
+    </section>
+  );
+}
+
+function BillingMetric({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-forest/10 bg-white p-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-forest/45">{label}</p>
+      <p className="mt-2 text-lg font-semibold text-deep">{value}</p>
+      {detail && <p className="mt-1 text-xs leading-5 text-forest/55">{detail}</p>}
+    </div>
+  );
+}
+
+function BillingAction({
+  icon,
+  title,
+  description,
+  action,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  action: ReactNode;
+}) {
+  return (
+    <div className="rounded-[22px] border border-forest/12 bg-white p-4">
+      <div className="flex items-center gap-2 text-deep">
+        <span className="inline-flex size-8 items-center justify-center rounded-xl bg-[#f4efe3] text-ember">
+          {icon}
+        </span>
+        <h4 className="text-sm font-semibold">{title}</h4>
+      </div>
+      <p className="mt-3 min-h-16 text-sm leading-6 text-forest/65">{description}</p>
+      <div className="mt-3">{action}</div>
+    </div>
+  );
+}
+
+function formatStatus(status: string): string {
+  return status
+    .split("_")
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return billingDateFormatter.format(date);
+}
+

--- a/shell/src/components/settings/sections/BillingManagementPanel.tsx
+++ b/shell/src/components/settings/sections/BillingManagementPanel.tsx
@@ -298,4 +298,3 @@ function formatDate(value: string): string {
   if (Number.isNaN(date.getTime())) return value;
   return billingDateFormatter.format(date);
 }
-

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -10,15 +10,10 @@ import {
 } from "react";
 import type { ReactNode } from "react";
 import {
-  ArrowUpRightIcon,
   CheckIcon,
   ChevronDownIcon,
-  ExternalLinkIcon,
   Loader2Icon,
   MapPinIcon,
-  PlusIcon,
-  ReceiptTextIcon,
-  XCircleIcon,
 } from "@/lib/hugeicons";
 import { useUser } from "@clerk/nextjs";
 import {
@@ -32,7 +27,7 @@ import type {
   BillingEntitlementSummary,
   BillingTrialOffer,
 } from "@/hooks/useMatrixBillingAccess";
-import { capturePostHogLog } from "@/lib/posthog-client";
+import { ActiveBillingPanel, BillingPortalButton, TrialPaymentRecoveryPanel } from "./BillingManagementPanel";
 import { isSelfHostedDocument } from "@/lib/self-host-mode";
 import {
   defaultDeveloperTools,
@@ -65,243 +60,11 @@ const regionGroupLabels: Record<string, string> = {
   "us-east": "United States",
   "us-west": "United States",
 };
-const BILLING_CHECKOUT_TIMEOUT_MS = 10_000;
-const billingPlanNames: Record<string, string> = {
-  matrix_starter: "Starter",
-  matrix_builder: "Builder",
-  matrix_max: "Max",
-  internal: "Internal",
-};
 const profileDescriptions: Record<string, string> = {
   server_starter: "For everyday use",
   server_builder: "For technical work and building",
   server_max: "For serious, demanding workloads",
 };
-const billingDateFormatter = new Intl.DateTimeFormat(undefined, {
-  month: "short",
-  day: "numeric",
-  year: "numeric",
-});
-
-function formatRecurringPrice(
-  price: NonNullable<BillingEntitlementSummary["recurringPrice"]>,
-): string {
-  const formatter = new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency: price.currency.toUpperCase(),
-    minimumFractionDigits: 0,
-  });
-  const fractionDigits = formatter.resolvedOptions().maximumFractionDigits ?? 2;
-  const totalMinor = price.unitAmountMinor * price.quantity;
-  const amount = formatter.format(totalMinor / (10 ** fractionDigits));
-  const period = price.intervalCount === 1
-    ? price.interval === "monthly" ? "month" : "year"
-    : `${price.intervalCount} ${price.interval === "monthly" ? "months" : "years"}`;
-  return `${amount}/${period}`;
-}
-
-function BillingPortalButton({
-  entitlement,
-  label = "Open billing portal",
-}: {
-  entitlement: BillingEntitlementSummary | null;
-  label?: string;
-}) {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const portalAvailable = entitlement?.portalAvailable === true;
-
-  async function openPortal() {
-    if (!portalAvailable) return;
-    setLoading(true);
-    setError(null);
-    const controller = new AbortController();
-    const timeoutId = window.setTimeout(() => controller.abort(), BILLING_CHECKOUT_TIMEOUT_MS);
-    // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler bailout on the try/finally needed to clear the abort timeout and reset `loading` on every path; the code is correct and the finalizer must run whether the request resolves, rejects, or throws.
-    try {
-      const response = await fetch("/billing/portal", {
-        method: "POST",
-        credentials: "include",
-        headers: { accept: "application/json" },
-        signal: controller.signal,
-      });
-      const body = response.ok
-        ? (await response.json().catch((err: unknown) => {
-          capturePostHogLog("warn", "billing portal_response_parse_error", {
-            source: "settings-billing",
-            error_kind: err instanceof Error ? err.name : typeof err,
-          });
-          return null;
-        })) as { url?: string } | null
-        : null;
-      if (!response.ok || !body?.url) {
-        // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler bailout on the throw inside try/catch; intentional control flow routing an unusable portal response into the catch handler. The code is correct.
-        throw new Error("portal_unavailable");
-      }
-      window.location.assign(body.url);
-    } catch (err: unknown) {
-      setError("Billing portal is unavailable. Try again in a moment.");
-      capturePostHogLog("error", "billing portal_error", {
-        source: "settings-billing",
-        error_kind: err instanceof Error ? err.message : typeof err,
-      });
-    } finally {
-      window.clearTimeout(timeoutId);
-      setLoading(false);
-    }
-  }
-
-  return (
-    <div>
-      <button
-        type="button"
-        onClick={openPortal}
-        disabled={!portalAvailable || loading}
-        className="inline-flex h-10 items-center justify-center gap-2 rounded-xl bg-forest px-3.5 text-sm font-semibold text-ember-foreground transition-colors hover:bg-forest/90 disabled:cursor-not-allowed disabled:opacity-55"
-      >
-        {loading ? (
-          <Loader2Icon className="size-4 animate-spin" aria-hidden="true" />
-        ) : (
-          <ExternalLinkIcon className="size-4" aria-hidden="true" />
-        )}
-        {loading ? "Opening portal" : label}
-      </button>
-      {!portalAvailable && (
-        <p className="mt-2 text-xs leading-5 text-forest/55">
-          This account is managed internally, so receipts and plan changes are handled by the Matrix team.
-        </p>
-      )}
-      {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
-    </div>
-  );
-}
-
-function ActiveBillingPanel({
-  entitlement,
-  accessReason,
-}: {
-  entitlement: BillingEntitlementSummary | null;
-  accessReason: string | null;
-}) {
-  const planName = entitlement ? billingPlanNames[entitlement.planSlug] ?? entitlement.planSlug : "Active";
-  const status = entitlement?.status ? formatStatus(entitlement.status) : accessReason === "legacy_clerk_plan" ? "Legacy plan" : "Active";
-  const allowedProfiles = MATRIX_BILLING_SERVER_PROFILES.filter((profile) =>
-    entitlement?.allowedPlanSlugs.includes(profile.planSlug) === true,
-  );
-  const totalComputers = entitlement?.maxRuntimeSlots ?? 1;
-  const includedComputers = entitlement?.includedRuntimeSlots ?? 1;
-  const addonComputers = entitlement?.addonRuntimeSlots ?? 0;
-  const graceLabel = entitlement?.gracePeriodEndsAt ? formatDate(entitlement.gracePeriodEndsAt) : null;
-  const isTrialing = entitlement?.status === "trialing" && Boolean(entitlement.trialEndsAt);
-  const trialEndLabel = entitlement?.trialEndsAt ? formatDate(entitlement.trialEndsAt) : null;
-  const billingInterval = entitlement?.billingInterval === "annual" ? "annual" : "monthly";
-  const recurringPriceLabel = entitlement?.recurringPrice
-    ? formatRecurringPrice(entitlement.recurringPrice)
-    : null;
-  const placement = entitlement?.runtimePlacement ?? null;
-
-  return (
-    <div className="space-y-3">
-      <section className="rounded-[22px] border border-forest/15 bg-[#fbf7ed] p-4">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-forest/55">
-              {isTrialing ? "Free trial active" : "Current plan"}
-            </p>
-            <h3 className="mt-2 text-2xl font-semibold tracking-tight text-deep">
-              {planName}
-            </h3>
-            <p className="mt-1 text-sm leading-6 text-forest/65">
-              {isTrialing && trialEndLabel
-                ? recurringPriceLabel
-                  ? `Your ${recurringPriceLabel} subscription starts on ${trialEndLabel}.`
-                  : `Your first ${billingInterval} charge is on ${trialEndLabel}.`
-                : `${status}. Your Matrix computers stay available while billing is active${graceLabel ? ` and through the grace period ending ${graceLabel}` : ""}.`}
-            </p>
-            {isTrialing && trialEndLabel && (
-              <p className="mt-1 text-sm font-medium text-ember">
-                Cancel before {trialEndLabel} to avoid being charged.
-              </p>
-            )}
-          </div>
-          <BillingPortalButton entitlement={entitlement} label={isTrialing ? "Manage trial" : undefined} />
-        </div>
-
-        <div className="mt-4 grid gap-3 md:grid-cols-4">
-          <BillingMetric label="Status" value={status} />
-          <BillingMetric label="Computers" value={`${totalComputers}`} detail={`${includedComputers} included${addonComputers ? `, ${addonComputers} add-on` : ""}`} />
-          <BillingMetric
-            label="Billing"
-            value={recurringPriceLabel ?? (billingInterval === "annual" ? "Annual" : "Monthly")}
-            detail="Managed subscription"
-          />
-          <BillingMetric
-            label="Location"
-            value={placement?.label ?? "Hosted region"}
-            detail={placement?.countryLabel ?? "Managed location"}
-          />
-        </div>
-      </section>
-
-      <section className="grid gap-3 lg:grid-cols-3">
-        <BillingAction
-          icon={<ArrowUpRightIcon className="size-4" aria-hidden="true" />}
-          title="Upgrade or downgrade"
-          description={`Switch between ${allowedProfiles.length ? allowedProfiles.map((profile) => profile.label).join(", ") : "Starter, Builder, and Max"} without deleting data or machines.`}
-          action={<BillingPortalButton entitlement={entitlement} label="Change plan" />}
-        />
-        <BillingAction
-          icon={<PlusIcon className="size-4" aria-hidden="true" />}
-          title="Add-ons"
-          description="Add extra machines first; storage and other hosted capacity can be attached as add-ons as they launch."
-          action={<BillingPortalButton entitlement={entitlement} label="Manage add-ons" />}
-        />
-        <BillingAction
-          icon={<ReceiptTextIcon className="size-4" aria-hidden="true" />}
-          title="Receipts and payment"
-          description="View invoices, receipts, tax details, payment methods, coupons, and billing email in the portal."
-          action={<BillingPortalButton entitlement={entitlement} label="View receipts" />}
-        />
-      </section>
-
-      <section className="rounded-[22px] border border-forest/12 bg-white p-4">
-        <div className="flex gap-3">
-          <XCircleIcon className="mt-0.5 size-4 shrink-0 text-forest/45" aria-hidden="true" />
-          <div>
-            <h4 className="text-sm font-semibold text-deep">Canceling</h4>
-            <p className="mt-1 text-sm leading-6 text-forest/65">
-              Canceling is handled in the billing portal. Your machines and owner data are not deleted automatically; access remains while billing is active and through the configured three-day grace window.
-            </p>
-          </div>
-        </div>
-      </section>
-    </div>
-  );
-}
-
-function TrialPaymentRecoveryPanel({
-  entitlement,
-}: {
-  entitlement: BillingEntitlementSummary;
-}) {
-  return (
-    <section className="rounded-[22px] border border-ember/30 bg-card p-4 sm:p-5" role="alert">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-ember">Trial ended</p>
-          <h3 className="mt-2 text-2xl font-semibold tracking-tight text-deep">Payment required</h3>
-          <p className="mt-1 text-sm leading-6 text-forest/65">
-            Runtime access is paused until the first payment succeeds.
-          </p>
-          <p className="mt-1 text-xs leading-5 text-forest/55">
-            Update your card in Stripe. Matrix restores access automatically after the paid invoice webhook arrives.
-          </p>
-        </div>
-        <BillingPortalButton entitlement={entitlement} label="Update payment method" />
-      </div>
-    </section>
-  );
-}
 
 function BillingSessionRefreshingPanel() {
   return (
@@ -321,63 +84,6 @@ function BillingSessionRefreshingPanel() {
       </div>
     </div>
   );
-}
-
-function BillingMetric({
-  label,
-  value,
-  detail,
-}: {
-  label: string;
-  value: string;
-  detail?: string;
-}) {
-  return (
-    <div className="rounded-2xl border border-forest/10 bg-white p-3">
-      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-forest/45">{label}</p>
-      <p className="mt-2 text-lg font-semibold text-deep">{value}</p>
-      {detail && <p className="mt-1 text-xs leading-5 text-forest/55">{detail}</p>}
-    </div>
-  );
-}
-
-function BillingAction({
-  icon,
-  title,
-  description,
-  action,
-}: {
-  icon: ReactNode;
-  title: string;
-  description: string;
-  action: ReactNode;
-}) {
-  return (
-    <div className="rounded-[22px] border border-forest/12 bg-white p-4">
-      <div className="flex items-center gap-2 text-deep">
-        <span className="inline-flex size-8 items-center justify-center rounded-xl bg-[#f4efe3] text-ember">
-          {icon}
-        </span>
-        <h4 className="text-sm font-semibold">{title}</h4>
-      </div>
-      <p className="mt-3 min-h-16 text-sm leading-6 text-forest/65">{description}</p>
-      <div className="mt-3">{action}</div>
-    </div>
-  );
-}
-
-function formatStatus(status: string): string {
-  return status
-    .split("_")
-    .filter(Boolean)
-    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
-    .join(" ");
-}
-
-function formatDate(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return billingDateFormatter.format(date);
 }
 
 function profilePrice(
@@ -1008,6 +714,15 @@ function BillingPanelInner({
       data-testid="billing-configurator-layout"
     >
       <div className="space-y-4" data-testid="billing-configurator-main">
+        {mode !== "add-computer" && entitlement?.portalAvailable === true && (
+          <section className="rounded-2xl border border-forest/15 bg-card p-4">
+            <h4 className="text-sm font-semibold text-deep">Receipts and payment</h4>
+            <p className="my-2 text-sm text-forest/65">
+              Your invoices and payment settings remain available while runtime access is paused.
+            </p>
+            <BillingPortalButton entitlement={entitlement} label="View receipts" />
+          </section>
+        )}
         <div>
           <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[#0E3422]/60">
             {mode === "provisioning"

--- a/tests/desktop/billing-section.test.tsx
+++ b/tests/desktop/billing-section.test.tsx
@@ -100,12 +100,100 @@ describe("desktop billing settings", () => {
 
     render(<BillingSection />);
     await waitFor(() => expect(screen.getByText("Billing active")).not.toBeNull());
-    fireEvent.click(screen.getByRole("button", { name: /Open portal/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Manage billing/i }));
 
     await waitFor(() => expect(api.post).toHaveBeenCalledWith("/billing/portal", {}));
     expect(window.operator.invoke).toHaveBeenCalledWith("shell:open-external", {
       url: "https://billing.stripe.test/session",
     });
+  });
+
+  it("explains internally managed billing instead of hiding management", async () => {
+    const api = makeApi({
+      ...activeBilling,
+      entitlement: { ...activeBilling.entitlement, source: "override", portalAvailable: false },
+    });
+    useConnection.setState({ api: api as never });
+    render(<BillingSection />);
+    await waitFor(() => expect(screen.getByText("Billing active")).not.toBeNull());
+
+    const button = screen.getByRole("button", { name: /Manage billing/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(screen.getByText(/managed internally/)).not.toBeNull();
+    fireEvent.click(button);
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  it("explains an unavailable portal without calling a paid account internal", async () => {
+    useConnection.setState({ api: makeApi({
+      ...activeBilling,
+      entitlement: { ...activeBilling.entitlement, portalAvailable: false },
+    }) as never });
+    render(<BillingSection />);
+    await waitFor(() => expect(screen.getByText("Billing active")).not.toBeNull());
+
+    expect((screen.getByRole("button", { name: /Manage billing/i }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText(/Billing management is not available for this account yet/)).not.toBeNull();
+    expect(screen.queryByText(/managed internally/)).toBeNull();
+  });
+
+  it("disables management while refreshing and explains a failed status check", async () => {
+    const api = makeApi(activeBilling);
+    useConnection.setState({ api: api as never });
+    render(<BillingSection />);
+    expect((screen.getByRole("button", { name: /Manage billing/i }) as HTMLButtonElement).disabled).toBe(true);
+    await waitFor(() => expect(screen.getByText("Billing active")).not.toBeNull());
+    let rejectRefresh!: (reason: Error) => void;
+    api.get.mockImplementationOnce(() => new Promise((_, reject) => { rejectRefresh = reject; }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    const button = screen.getByRole("button", { name: /Manage billing/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    fireEvent.click(button);
+    expect(api.post).not.toHaveBeenCalled();
+    rejectRefresh(new Error("status unavailable"));
+    await waitFor(() => expect(screen.getByText(/Refresh your billing status/)).not.toBeNull());
+    expect(button.disabled).toBe(true);
+    expect(screen.queryByText(/managed internally/)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => expect(button.disabled).toBe(false));
+  });
+
+  it("prevents duplicate portal requests while opening the browser", async () => {
+    let finishOpening!: () => void;
+    vi.mocked(window.operator.invoke).mockImplementation(() => new Promise<void>((resolve) => {
+      finishOpening = resolve;
+    }));
+    const api = makeApi(activeBilling);
+    useConnection.setState({ api: api as never });
+    render(<BillingSection />);
+    await waitFor(() => expect(screen.getByText("Billing active")).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Manage billing/i }));
+    await waitFor(() => expect(window.operator.invoke).toHaveBeenCalled());
+    const opening = screen.getByRole("button", { name: /Opening/i }) as HTMLButtonElement;
+    expect(opening.disabled).toBe(true);
+    fireEvent.click(opening);
+    expect(api.post).toHaveBeenCalledTimes(1);
+    finishOpening();
+    await waitFor(() => expect((screen.getByRole("button", { name: /Manage billing/i }) as HTMLButtonElement).disabled).toBe(false));
+  });
+
+  it.each(["request", "redirect", "browser"])("shows a safe retryable error for a %s failure", async (failure) => {
+    const api = makeApi(activeBilling);
+    if (failure === "request") api.post.mockRejectedValueOnce(new Error("private provider detail"));
+    if (failure === "redirect") api.post.mockResolvedValueOnce({ url: "javascript:alert(1)" });
+    if (failure === "browser") vi.mocked(window.operator.invoke).mockRejectedValueOnce(new Error("private filesystem path"));
+    useConnection.setState({ api: api as never });
+    render(<BillingSection />);
+    await waitFor(() => expect(screen.getByText("Billing active")).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Manage billing/i }));
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toBe("Billing portal is unavailable. Try again in a moment."));
+    expect((screen.getByRole("button", { name: /Manage billing/i }) as HTMLButtonElement).disabled).toBe(false);
+    if (failure !== "browser") expect(window.operator.invoke).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /Manage billing/i }));
+    await waitFor(() => expect(window.operator.invoke).toHaveBeenCalledWith("shell:open-external", {
+      url: "https://billing.stripe.test/session",
+    }));
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
   });
 
   it("starts checkout with the selected native billing options", async () => {
@@ -145,7 +233,7 @@ describe("desktop billing settings", () => {
     render(<BillingSection />);
     await waitFor(() => expect(screen.getByText("Billing required")).not.toBeNull());
 
-    expect(screen.getByRole("button", { name: /Open portal/i })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Manage billing/i })).not.toBeNull();
     expect(screen.getByRole("button", { name: /Continue to checkout/i })).not.toBeNull();
   });
 });

--- a/tests/desktop/billing-section.test.tsx
+++ b/tests/desktop/billing-section.test.tsx
@@ -108,7 +108,7 @@ describe("desktop billing settings", () => {
     });
   });
 
-  it("explains internally managed billing instead of hiding management", async () => {
+  it("explains missing billing linkage instead of hiding management", async () => {
     const api = makeApi({
       ...activeBilling,
       entitlement: { ...activeBilling.entitlement, source: "override", portalAvailable: false },
@@ -119,7 +119,7 @@ describe("desktop billing settings", () => {
 
     const button = screen.getByRole("button", { name: /Manage billing/i }) as HTMLButtonElement;
     expect(button.disabled).toBe(true);
-    expect(screen.getByText(/managed internally/)).not.toBeNull();
+    expect(screen.getByText(/no linked billing customer/)).not.toBeNull();
     fireEvent.click(button);
     expect(api.post).not.toHaveBeenCalled();
   });
@@ -134,7 +134,7 @@ describe("desktop billing settings", () => {
 
     expect((screen.getByRole("button", { name: /Manage billing/i }) as HTMLButtonElement).disabled).toBe(true);
     expect(screen.getByText(/Billing management is not available for this account yet/)).not.toBeNull();
-    expect(screen.queryByText(/managed internally/)).toBeNull();
+    expect(screen.queryByText(/no linked billing customer/)).toBeNull();
   });
 
   it("disables management while refreshing and explains a failed status check", async () => {
@@ -153,7 +153,7 @@ describe("desktop billing settings", () => {
     rejectRefresh(new Error("status unavailable"));
     await waitFor(() => expect(screen.getByText(/Refresh your billing status/)).not.toBeNull());
     expect(button.disabled).toBe(true);
-    expect(screen.queryByText(/managed internally/)).toBeNull();
+    expect(screen.queryByText(/no linked billing customer/)).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
     await waitFor(() => expect(button.disabled).toBe(false));
   });

--- a/tests/platform/billing-portal-access.test.ts
+++ b/tests/platform/billing-portal-access.test.ts
@@ -1,0 +1,63 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createBillingRoutes, type StripeBillingClient } from '../../packages/platform/src/billing-routes.js';
+import { upsertBillingCustomer, upsertBillingOverride, type PlatformDB } from '../../packages/platform/src/db.js';
+import { MatrixBillingStatusSchema } from '@matrix-os/contracts';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const timestamp = '2026-09-01T00:00:00.000Z';
+describe('account billing portal access', () => {
+ let db: PlatformDB;
+ const createPortalSession = vi.fn(async () => ({ url: 'https://billing.stripe.test/session' }));
+ beforeEach(async () => { ({db} = await createTestPlatformDb()); createPortalSession.mockClear(); });
+ afterEach(async () => { await destroyTestPlatformDb(db); });
+ function app(userId: string | null = 'user_owner') {
+  return new Hono().route('/billing', createBillingRoutes({
+   db, stripe: {apiTimeoutMs: 10000, createPortalSession} as unknown as StripeBillingClient,
+   resolveClerkUserId: async () => userId, env: {}, now: () => new Date(timestamp),
+  }));
+ }
+ async function override() {
+  await upsertBillingOverride(db, {
+   id: 'override_support', clerkUserId: 'user_owner', planSlug: 'matrix_builder', status: 'active',
+   maxRuntimeSlots: 1, includedRuntimeSlots: 1, addonRuntimeSlots: 0,
+   defaultServerType: 'cpx42', allowedServerTypes: ['cpx42'], reason: 'Temporary access', createdBy: 'test',
+   expiresAt: '2026-10-03T00:00:00.000Z', revokedAt: null, createdAt: timestamp,
+  });
+ }
+ async function customer(userId = 'user_owner') {
+  await upsertBillingCustomer(db, {clerkUserId: userId, stripeCustomerId: 'cus_owner', createdAt: timestamp, updatedAt: timestamp});
+ }
+ it.each(['', '?runtimeSlot=studio'])('keeps invoices accessible through a support override %s', async (query) => {
+  await customer(); await override();
+  const routes = app();
+  const response = await routes.request('/billing/status' + query);
+  expect(response.status).toBe(200);
+  const status = MatrixBillingStatusSchema.parse(await response.json());
+  expect(status.entitlement).toMatchObject({source: 'override', portalAvailable: true});
+  expect(status.access.runtimeProxyAllowed).toBe(true);
+  const portal = await routes.request('/billing/portal', {method: 'POST', body: '{}'});
+  expect(portal.status).toBe(200);
+  expect(createPortalSession).toHaveBeenCalledWith(expect.objectContaining({customerId: 'cus_owner'}));
+ });
+ it('does not advertise a portal for an override without a billing customer', async () => {
+  await override();
+  const status = await (await app().request('/billing/status')).json();
+  expect(status.entitlement.portalAvailable).toBe(false);
+  expect((await app().request('/billing/portal', {method: 'POST'})).status).toBe(404);
+  expect(createPortalSession).not.toHaveBeenCalled();
+ });
+ it('cannot use another account billing customer', async () => {
+  await customer('user_other'); await override();
+  const status = await (await app().request('/billing/status')).json();
+  expect(status.entitlement.portalAvailable).toBe(false);
+  expect((await app().request('/billing/portal', {method: 'POST'})).status).toBe(404);
+  expect(createPortalSession).not.toHaveBeenCalled();
+ });
+ it('requires authentication for billing records', async () => {
+  await customer();
+  expect((await app(null).request('/billing/status')).status).toBe(401);
+  expect((await app(null).request('/billing/portal', {method: 'POST'})).status).toBe(401);
+  expect(createPortalSession).not.toHaveBeenCalled();
+ });
+});

--- a/tests/shell/billing-portal-access.test.tsx
+++ b/tests/shell/billing-portal-access.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BillingPanel } from '../../shell/src/components/settings/sections/BillingPanel';
+import type { MatrixBillingPublicEntitlement } from '@matrix-os/contracts';
+
+vi.mock('@clerk/nextjs', () => ({useUser: () => ({user: {publicMetadata: {}}})}));
+vi.mock('../../shell/src/lib/posthog-client', () => ({capturePostHogEvent: vi.fn(), capturePostHogLog: vi.fn()}));
+const entitlement: MatrixBillingPublicEntitlement = {
+ source: 'override', planSlug: 'matrix_builder', status: 'active',
+ maxRuntimeSlots: 1, includedRuntimeSlots: 1, addonRuntimeSlots: 0,
+ allowedPlanSlugs: ['matrix_builder'], allowedSelections: [], portalAvailable: true,
+ billingInterval: null, recurringPrice: null, runtimePlacement: null,
+ gracePeriodEndsAt: null, trialStartedAt: null, trialEndsAt: null, trialConvertedAt: null, firstTrialPaymentFailedAt: null,
+ effectiveFrom: '2026-09-01T00:00:00.000Z', effectiveUntil: null, updatedAt: '2026-09-01T00:00:00.000Z',
+};
+afterEach(() => {cleanup(); vi.restoreAllMocks();});
+describe('Web Desktop and Web Canvas billing portal access', () => {
+ it('allows a customer with a support override to request invoices', async () => {
+  const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', {status: 503}));
+  render(<BillingPanel active entitlement={entitlement} mode="settings" />);
+  const receipts = screen.getByRole('button', {name: 'View receipts'}) as HTMLButtonElement;
+  expect(receipts.disabled).toBe(false);
+  expect(screen.queryByText(/managed internally/)).toBeNull();
+  fireEvent.click(receipts);
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/billing/portal', expect.objectContaining({method: 'POST', credentials: 'include', signal: expect.any(AbortSignal)})));
+  await waitFor(() => expect(screen.getByText('Billing portal is unavailable. Try again in a moment.')).toBeTruthy());
+ });
+ it('does not label a Stripe customer as internally managed when the portal is unavailable', () => {
+  render(<BillingPanel active entitlement={{...entitlement, source: 'stripe', portalAvailable: false}} mode="settings" />);
+  expect(screen.queryByText(/managed internally/)).toBeNull();
+  expect(screen.getAllByText(/Billing management is not available for this account yet/).length).toBeGreaterThan(0);
+ });
+ it.each(['past_due', 'canceled', 'unpaid'] as const)('keeps receipts accessible when runtime billing is %s', () => {
+  render(<BillingPanel active={false} entitlement={{...entitlement, source: 'stripe', status}} mode="settings" />);
+  expect((screen.getByRole('button', {name: 'View receipts'}) as HTMLButtonElement).disabled).toBe(false);
+ });
+});


### PR DESCRIPTION
## Summary

Runtime entitlement overrides incorrectly disabled the billing portal for accounts that already had a Stripe customer. Portal eligibility now comes from the signed-in account's persisted billing customer linkage, matching the existing authenticated portal endpoint. The existing response shape is preserved so deployed clients can consume the fix.

Web Desktop and Web Canvas retain invoice/payment access for overdue, canceled, and unpaid subscriptions instead of showing checkout alone. Missing billing linkage no longer labels paying accounts internally managed. Electron Desktop always shows its billing management entry point, explains unavailable states, and opens eligible portal sessions in the browser.

Native Mobile now consumes the canonical public billing-status contract and follows `portalAvailable` rather than inferring portal access from the effective entitlement source or a private Stripe subscription identifier. This preserves billing management for override-backed accounts that remain linked to a billing customer.

The billing status handler and web billing management components were extracted before adding behavior to their large composition files. The PR-wide trailing-whitespace issue reported by `git diff --check` is also fixed.

## Tests

- 9 focused Native Mobile settings/request tests pass, including override-backed portal access and the no-portal pricing fallback.
- Root `bun run typecheck` passes.
- Pattern scan passes with 0 violations and 5 existing warnings.
- `git diff --check` passes across the PR diff.
- The root `bun run test` run was attempted but stopped after unrelated local-environment failures in coding-agent review snapshots, default apps, host scripts, and app-server runtime tests. The changed billing tests remained green.
- 160 previously validated relevant tests cover platform routes/entitlements, public contracts, customer/override and owner-isolation regressions, web billing flows, and Electron billing management.
- 3 public billing documentation checks pass.
- Local interactive Electron component preview was verified with sample data. Live customer records and production portal sessions have not been verified.

## Invariants

- Source of truth: owner-bound `billing_customers` lookup for portal capability; effective entitlement continues to govern runtime access independently.
- Lock/transaction scope: one additional owner-scoped read; no database writes or schema changes introduced.
- Acceptable orphan states: a portal session can exist after browser-launch failure; retries remain available.
- Auth source of truth: existing resolved Clerk/native Matrix session. No customer IDs are accepted from clients or added to public responses.
- Deferred scope: no Stripe subscription changes, customer data repair, or deployment. Companion public documentation PR: https://github.com/FinnaAI/matrix-os-site/pull/85. Accounts with no effective entitlement still return `entitlement: null` in the existing status contract; the fix targets existing runtime entitlements and does not change that contract.
