### PR TITLE
fix(terminal): unify header controls and restore splits on older hosts

### DIFF
--- a/desktop/src/renderer/src/features/terminal/TerminalSessionHeader.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalSessionHeader.tsx
@@ -1,0 +1,150 @@
+import "./terminal-session-header.css";
+import { SquareTerminal } from "@renderer/lib/hugeicons";
+import type { ComponentProps, Ref } from "react";
+import { DesktopNewSessionControl } from "./DesktopNewSessionControl";
+import { DesktopTerminalThemePicker } from "./DesktopTerminalThemePicker";
+
+/** The arrow describes the action: left hides the left sidebar, right reveals it. */
+export function TerminalSidebarToggle({
+  shown,
+  sidebarId,
+  buttonRef,
+  onToggle,
+}: {
+  shown: boolean;
+  sidebarId: string;
+  buttonRef?: Ref<HTMLButtonElement>;
+  onToggle: () => void;
+}) {
+  const label = shown ? "Hide terminal tabs" : "Show terminal tabs";
+  return (
+    <button
+      ref={buttonRef}
+      type="button"
+      aria-label={label}
+      title={label}
+      aria-controls={sidebarId}
+      aria-expanded={shown}
+      className="no-drag flex size-9 shrink-0 items-center justify-center rounded-md text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+      onClick={onToggle}
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        data-direction={shown ? "left" : "right"}
+      >
+        <rect x="3" y="4" width="18" height="16" rx="3" />
+        <path d="M8 4v16" />
+        <path d={shown ? "m16 9-3 3 3 3" : "m13 9 3 3-3 3"} />
+      </svg>
+    </button>
+  );
+}
+
+export function TerminalSessionHeader({
+  shown = true,
+  sidebarId,
+  buttonRef,
+  onToggle,
+  ...creation
+}: ComponentProps<typeof DesktopNewSessionControl> & {
+  shown?: boolean;
+  sidebarId: string;
+  buttonRef?: Ref<HTMLButtonElement>;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="flex h-12 w-[280px] shrink-0 items-center justify-between gap-2 px-4">
+      <div className="flex min-w-0 items-center gap-1.5">
+        <SquareTerminal size={16} aria-hidden="true" />
+        <h1
+          className="truncate text-base font-medium tracking-[-0.4px]"
+          style={{ color: "var(--text-primary)" }}
+        >
+          Terminal
+        </h1>
+      </div>
+      <div
+        data-terminal-sidebar-header-actions
+        className="no-drag flex shrink-0 items-center gap-2"
+      >
+        <TerminalSidebarToggle
+          shown={shown}
+          sidebarId={sidebarId}
+          buttonRef={buttonRef}
+          onToggle={onToggle}
+        />
+        <DesktopTerminalThemePicker />
+        <DesktopNewSessionControl {...creation} />
+      </div>
+    </div>
+  );
+}
+
+export function TerminalSessionDetails({
+  name,
+  subtitle,
+  status,
+  controlsRef,
+}: {
+  name?: string;
+  subtitle?: string;
+  status?: string;
+  controlsRef: Ref<HTMLDivElement>;
+}) {
+  return (
+    <div className="flex min-w-0 flex-1 items-center justify-between gap-3 px-4">
+      <div data-terminal-header-session className="min-w-0 flex-1">
+        {name && (
+          <>
+            <h1
+              title={name}
+              className="truncate text-xs font-medium leading-[19.5px]"
+              style={{ color: "var(--text-primary)" }}
+            >
+              {name}
+            </h1>
+            <p
+              title={subtitle}
+              className="truncate text-xs leading-4 tracking-[0.12px]"
+              style={{ color: "var(--text-tertiary)" }}
+            >
+              {subtitle}
+            </p>
+          </>
+        )}
+      </div>
+      <div
+        data-terminal-header-actions
+        className="no-drag relative flex shrink-0 items-center gap-2"
+      >
+        {status && (
+          <span
+            data-terminal-header-status
+            className="inline-flex h-5 items-center justify-center rounded-[26px] border px-2 py-0.5 text-xs font-medium leading-4"
+            style={{
+              borderColor: "var(--border-subtle)",
+              background: "var(--bg-selected)",
+              color:
+                status === "Active" ? "var(--success)" : "var(--text-tertiary)",
+            }}
+          >
+            {status}
+          </span>
+        )}
+        <div
+          ref={controlsRef}
+          data-terminal-controls-host
+          className="no-drag"
+        />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/terminal/TerminalSessionSidebar.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalSessionSidebar.tsx
@@ -1,12 +1,11 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { Check, Clipboard, Edit3, Folder, MoreHorizontal, PanelLeftCloseIcon, PinIcon, PinOffIcon, SquareTerminal, Trash2, X } from "@renderer/lib/hugeicons";
+import { Check, Clipboard, Edit3, Folder, MoreHorizontal, PinIcon, PinOffIcon, Trash2, X } from "@renderer/lib/hugeicons";
 import { type Ref, useState } from "react";
 
 import { DESKTOP_Z_INDEX } from "../../design/layering";
 import type { ShellSessionSummary } from "../../stores/shell-sessions";
 import { OSWindowSafeView } from "../desktop-shell/OSWindow";
-import { DesktopNewSessionControl } from "./DesktopNewSessionControl";
-import { DesktopTerminalThemePicker } from "./DesktopTerminalThemePicker";
+import { TerminalSessionHeader } from "./TerminalSessionHeader";
 import { relativeSessionActivity } from "./terminal-session-activity";
 import {
   terminalAgentLabel,
@@ -34,6 +33,7 @@ function sessionTitle(shell: ShellSessionSummary): string {
 }
 
 export function TerminalSessionSidebar({
+  showHeader = true,
   sessions,
   selectedName,
   creating,
@@ -58,6 +58,7 @@ export function TerminalSessionSidebar({
   onPin,
   onDelete,
 }: {
+  showHeader?: boolean;
   sessions: ShellSessionSummary[];
   selectedName: string | null;
   creating: boolean;
@@ -84,38 +85,13 @@ export function TerminalSessionSidebar({
 }) {
   const [actionsName, setActionsName] = useState<string | null>(null);
   return (
-    <OSWindowSafeView area="sidebar" data-terminal-session-sidebar className="flex h-full min-h-0 w-full flex-col">
+    <OSWindowSafeView area="sidebar" style={showHeader ? undefined : { paddingTop: 0 }} data-terminal-session-sidebar className="flex h-full min-h-0 w-full flex-col">
       <aside className="flex h-full min-h-0 w-full flex-col">
-        <div className="flex min-h-12 shrink-0 items-center justify-between border-b px-4 py-2" style={{ borderColor: "var(--border-subtle)" }}>
-          <div className="flex min-w-0 items-center gap-1.5">
-            <SquareTerminal size={16} aria-hidden="true" />
-            <h1 className="truncate text-base font-medium tracking-[-0.4px]" style={{ color: "var(--text-primary)" }}>Terminal</h1>
-          </div>
-          <div data-terminal-sidebar-header-actions className="no-drag flex shrink-0 items-center gap-2">
-            <button
-              type="button"
-              aria-label="Hide terminal tabs"
-              ref={collapseButtonRef}
-              aria-controls={sidebarId}
-              aria-expanded="true"
-              title="Hide terminal tabs"
-              className="flex size-9 shrink-0 items-center justify-center rounded-md text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
-              onClick={onCollapse}
-            >
-              <PanelLeftCloseIcon size={15} aria-hidden="true" />
-            </button>
-            <DesktopTerminalThemePicker />
-            <DesktopNewSessionControl
-              disabled={disabled}
-              creating={creating}
-              agentStatuses={agentStatuses}
-              checkingAgentStatuses={checkingAgentStatuses}
-              onRefreshAgentStatuses={onRefreshAgentStatuses}
-              onCreateShell={onCreate}
-              onCreateAgent={onCreateAgent}
-            />
-          </div>
-        </div>
+        {showHeader && <div className="shrink-0 border-b" style={{ borderColor: "var(--border-subtle)" }}>
+          <TerminalSessionHeader sidebarId={sidebarId} buttonRef={collapseButtonRef} onToggle={onCollapse}
+            disabled={disabled} creating={creating} agentStatuses={agentStatuses} checkingAgentStatuses={checkingAgentStatuses}
+            onRefreshAgentStatuses={onRefreshAgentStatuses} onCreateShell={onCreate} onCreateAgent={onCreateAgent} />
+        </div>}
         <ul aria-label="Terminal sessions" className="min-h-0 flex-1 overflow-y-auto pb-4">
           {[...sessions].sort((left, right) => Number(Boolean(right.pinned)) - Number(Boolean(left.pinned))).map((session) => {
             const selected = selectedName === session.name;

--- a/desktop/src/renderer/src/features/terminal/TerminalSidebarLayout.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalSidebarLayout.tsx
@@ -1,77 +1,84 @@
-import { PanelLeftOpenIcon } from "@renderer/lib/hugeicons";
-import { type ReactNode, type Ref, useId, useLayoutEffect, useRef, useState } from "react";
+import {
+  type ReactNode,
+  type Ref,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { OSWindowSafeView } from "../desktop-shell/OSWindow";
 
 interface SidebarControls {
   sidebarId: string;
   collapseButtonRef: Ref<HTMLButtonElement>;
+  shown: boolean;
   onCollapse: () => void;
+  onToggle: () => void;
 }
 
-/** Retain the session list and terminal buffers while toggling their layout. */
+/** Keep one header and the mounted terminal buffers when toggling the session list. */
 export function TerminalSidebarLayout({
+  header,
   sidebar,
   children,
 }: {
+  header: (controls: SidebarControls) => ReactNode;
   sidebar: (controls: SidebarControls) => ReactNode;
   children: ReactNode;
 }) {
   const sidebarId = useId();
   const [shown, setShown] = useState(true);
   const collapseButtonRef = useRef<HTMLButtonElement>(null);
-  const expandButtonRef = useRef<HTMLButtonElement>(null);
   const focusAfterToggle = useRef(false);
-
   const toggle = (next: boolean) => {
     focusAfterToggle.current = true;
     setShown(next);
   };
-
   useLayoutEffect(() => {
     if (!focusAfterToggle.current) return;
     focusAfterToggle.current = false;
-    (shown ? collapseButtonRef : expandButtonRef).current?.focus();
+    collapseButtonRef.current?.focus();
   }, [shown]);
-
+  const controls = {
+    sidebarId,
+    collapseButtonRef,
+    shown,
+    onCollapse: () => toggle(false),
+    onToggle: () => toggle(!shown),
+  };
   return (
     <OSWindowSafeView
-      // Floating Terminal windows put their chrome over the expanded sidebar.
-      // Once it collapses, reserve that space across the rail and session pane.
-      area={shown ? "pane" : "sidebar"}
+      area="sidebar"
       data-testid="desktop-terminal-app"
-      className="relative flex min-h-0 flex-1 overflow-hidden"
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
       style={{ background: "var(--bg-app)", color: "var(--text-primary)" }}
     >
-      <div
-        id={sidebarId}
-        data-terminal-tabs-sidebar
-        hidden={!shown}
-        className={shown ? "w-[280px] min-w-[200px] max-w-[280px] shrink-0 border-r" : "hidden"}
-        style={{ borderColor: "var(--border-subtle)" }}
+      <header
+        aria-label="Terminal toolbar"
+        className="matrix-terminal-app-header flex h-12 shrink-0 items-center justify-between border-b"
+        style={{
+          borderColor: "var(--border-subtle)",
+          background: "var(--bg-surface)",
+        }}
       >
-        {sidebar({ sidebarId, collapseButtonRef, onCollapse: () => toggle(false) })}
-      </div>
-      {!shown ? (
-        <aside
-          aria-label="Collapsed terminal tabs"
-          className="flex w-10 shrink-0 items-start justify-center border-r pt-2"
-          style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
+        {header(controls)}
+      </header>
+      <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+        <div
+          id={sidebarId}
+          data-terminal-tabs-sidebar
+          hidden={!shown}
+          className={
+            shown
+              ? "w-[280px] min-w-[200px] max-w-[280px] shrink-0 border-r"
+              : "hidden"
+          }
+          style={{ borderColor: "var(--border-subtle)" }}
         >
-          <button
-            ref={expandButtonRef}
-            type="button"
-            aria-label="Show terminal tabs"
-            aria-controls={sidebarId}
-            aria-expanded="false"
-            title="Show terminal tabs"
-            className="no-drag flex size-9 shrink-0 items-center justify-center rounded-md text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
-            onClick={() => toggle(true)}
-          >
-            <PanelLeftOpenIcon size={15} aria-hidden="true" />
-          </button>
-        </aside>
-      ) : null}
-      {children}
+          {sidebar(controls)}
+        </div>
+        {children}
+      </div>
     </OSWindowSafeView>
   );
 }

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -1,4 +1,6 @@
 import { Terminal } from "@xterm/xterm";
+import { DESKTOP_Z_INDEX } from "../../design/layering";
+import { createPortal } from "react-dom";
 import { TerminalControls } from "@matrix-os/ui";
 import {
   classifyTerminalClipboardShortcut,
@@ -102,6 +104,7 @@ interface TerminalViewProps {
   active?: boolean;
   visualScale?: number;
   onRecreate?: () => void;
+  controlsHost?: HTMLElement | null;
 }
 
 type ClipboardFeedback = {
@@ -134,6 +137,7 @@ export default function TerminalView({
   active = true,
   visualScale = 1,
   onRecreate,
+  controlsHost,
 }: TerminalViewProps) {
   const api = useConnection((state) => state.api);
   const terminalThemeId = useTerminalAppearance((state) => state.themeId);
@@ -732,7 +736,10 @@ export default function TerminalView({
       data-terminal-surface
       style={{ backgroundColor: terminalTheme.background, color: terminalTheme.foreground }}
     >
-      <TerminalControls controls={controls} theme={terminalTheme} />
+      {controlsHost === undefined ? <TerminalControls layers={DESKTOP_Z_INDEX} controls={controls} theme={terminalTheme} /> : controlsHost ? createPortal(
+        <TerminalControls layers={DESKTOP_Z_INDEX} controls={controls} placement="header" theme={{ background: "var(--bg-surface)", foreground: "var(--text-primary)" }} />,
+        controlsHost,
+      ) : null}
       <div
         ref={hostRef}
         className="h-full min-h-0 w-full min-w-0 flex-1 overflow-hidden"

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -732,7 +732,7 @@ export default function TerminalView({
       data-terminal-surface
       style={{ backgroundColor: terminalTheme.background, color: terminalTheme.foreground }}
     >
-      <TerminalControls controls={controls} />
+      <TerminalControls controls={controls} theme={terminalTheme} />
       <div
         ref={hostRef}
         className="h-full min-h-0 w-full min-w-0 flex-1 overflow-hidden"

--- a/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalsTab.tsx
@@ -15,6 +15,7 @@ import {
   syncShellSessions,
 } from "../../lib/shell-session-sync";
 import TerminalView from "./TerminalView";
+import { TerminalSessionHeader, TerminalSessionDetails } from "./TerminalSessionHeader";
 import { TerminalSessionSidebar } from "./TerminalSessionSidebar";
 import { TerminalSidebarLayout } from "./TerminalSidebarLayout";
 import { useTerminalAppearance } from "../../stores/terminal-appearance";
@@ -41,9 +42,7 @@ function shellStatusLabel(shell: ShellSessionSummary): string {
   return "Active";
 }
 
-function shellTitle(shell: ShellSessionSummary): string {
-  return shell.subtitle?.trim() || shell.lastAction?.trim() || shell.name;
-}
+
 
 function mostRecentShell(sessions: ShellSessionSummary[]): ShellSessionSummary | null {
   return sessions.reduce<ShellSessionSummary | null>((latest, session) => {
@@ -97,6 +96,7 @@ export default function TerminalsTab({
   const terminalsTabId = useTabs((s) => s.tabs.find((tab) => tab.kind === "terminals")?.id);
   const renameTab = useTabs((s) => s.renameTab);
   const loadTerminalAppearance = useTerminalAppearance((s) => s.load);
+  const [controlsHost, setControlsHost] = useState<HTMLDivElement | null>(null);
   const [selectedName, setSelectedName] = useState<string | null>(() => mostRecentShell(shells)?.name ?? null);
   const [liveSessionName, setLiveSessionName] = useState<string | null>(null);
   const [openedSessionNames, setOpenedSessionNames] = useState<string[]>([]);
@@ -340,10 +340,20 @@ export default function TerminalsTab({
   };
 
   const overviewSelected = selected === null;
+  const headerSession = shells.find((shell) => shell.name === selected);
 
   return (
-    <TerminalSidebarLayout sidebar={(controls) => (
+    <TerminalSidebarLayout header={(controls) => (<>
+      <TerminalSessionHeader shown={controls.shown} sidebarId={controls.sidebarId} buttonRef={controls.collapseButtonRef} onToggle={controls.onToggle}
+        disabled={!api} creating={creating} agentStatuses={agentStatuses} checkingAgentStatuses={checkingAgentStatuses}
+        onRefreshAgentStatuses={() => void refreshAgentStatuses()} onCreateShell={() => void createShell()}
+        onCreateAgent={(option, action) => void createAgentSession(option, action)} />
+      <TerminalSessionDetails name={headerSession?.name}
+        subtitle={headerSession ? `Started at ${sessionStart(headerSession.createdAt)} · ${runtimeSlot === "primary" ? "main computer" : runtimeSlot}` : undefined}
+        status={headerSession ? shellStatusLabel(headerSession) : undefined} controlsRef={setControlsHost} />
+    </>)} sidebar={(controls) => (
       <TerminalSessionSidebar
+        showHeader={false}
         {...controls}
         sessions={shells}
         selectedName={selectedName}
@@ -419,10 +429,7 @@ export default function TerminalsTab({
         </RetainedPane>
 
         {visibleSessionNames.map((sessionName) => {
-          const shell = shells.find((candidate) => candidate.name === sessionName) ?? { name: sessionName, status: "active" as const };
           const selected = selectedName === sessionName;
-          const statusLabel = shellStatusLabel(shell);
-          const activeStatus = statusLabel === "Active";
           return (
             <RetainedPane
               as="section"
@@ -433,29 +440,6 @@ export default function TerminalsTab({
               background="var(--bg-surface)"
               style={{ borderRadius: 8 }}
             >
-            <header
-              className="flex shrink-0 items-center justify-between gap-3 border-b px-4 py-4"
-              style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)" }}
-            >
-              <div className="min-w-0 flex-1">
-                <h1 className="truncate text-xs font-medium leading-[19.5px]" style={{ color: "var(--text-primary)" }}>{shell.name}</h1>
-                <p className="mt-1 truncate text-xs leading-4 tracking-[0.12px]" style={{ color: "var(--text-tertiary)" }}>
-                  Started at {sessionStart(shell.createdAt)} · {runtimeSlot === "primary" ? "main computer" : runtimeSlot}
-                </p>
-              </div>
-              <div data-terminal-header-actions className="no-drag relative flex shrink-0 items-center gap-2">
-                <span
-                  className="inline-flex h-5 items-center justify-center rounded-[26px] border px-2 py-0.5 text-xs font-medium leading-4"
-                  style={{
-                    borderColor: "var(--border-subtle)",
-                    background: "var(--bg-selected)",
-                    color: activeStatus ? "var(--success)" : "var(--text-tertiary)",
-                  }}
-                >
-                  {statusLabel}
-                </span>
-              </div>
-            </header>
             <div data-terminal-detail className="flex min-h-0 flex-1">
               <div
                 data-terminal-viewport
@@ -464,6 +448,7 @@ export default function TerminalsTab({
               >
                 <TerminalView
                   sessionName={sessionName}
+                  controlsHost={selected ? controlsHost : null}
                   active={active && liveSessionName === sessionName}
                   visualScale={visualScale}
                 />

--- a/desktop/src/renderer/src/features/terminal/terminal-session-header.css
+++ b/desktop/src/renderer/src/features/terminal/terminal-session-header.css
@@ -1,0 +1,15 @@
+.matrix-terminal-app-header {
+  container-type: inline-size;
+  container-name: terminal-header;
+}
+@container terminal-header (max-width: 680px) {
+  [data-terminal-header-status],
+  [data-terminal-header-session] p {
+    display: none;
+  }
+}
+@container terminal-header (max-width: 560px) {
+  [data-terminal-header-session] {
+    display: none;
+  }
+}

--- a/desktop/src/renderer/src/features/terminal/use-desktop-terminal-controls.ts
+++ b/desktop/src/renderer/src/features/terminal/use-desktop-terminal-controls.ts
@@ -1,5 +1,10 @@
+import { AppError } from "../../../../shared/app-error";
 import { useCallback, useMemo, type RefObject } from "react";
-import { useTerminalControls, type TerminalControlsTransport } from "@matrix-os/ui";
+import {
+  dispatchTerminalPaneRequest,
+  useTerminalControls,
+  type TerminalControlsTransport,
+} from "@matrix-os/ui";
 import type { ApiClient } from "../../lib/api";
 import type { ShellSocketState } from "../../lib/shell-socket";
 import type { ActiveAttachment } from "./attach-manager";
@@ -28,21 +33,47 @@ export function useDesktopTerminalControls({
   attachmentRef,
   termRef,
 }: DesktopTerminalControlsOptions) {
-  const transport = useMemo<TerminalControlsTransport | null>(() => api ? {
-    getPreferences: () => api.get("/api/terminal/preferences"),
-    savePreferences: (keyboard) => api.put("/api/terminal/preferences", { keyboard }),
-    paneAction: (name, action) => api.post(
-      `/api/terminal/sessions/${encodeURIComponent(name)}/pane-actions${chatId ? `?chatId=${encodeURIComponent(chatId)}` : ""}`,
-      action,
-    ),
-  } : null, [api, chatId]);
-  const enabled = active && socketState === "attached" && !leaseRevoked && api !== null;
-  const sendInput = useCallback((data: string) => {
-    const attachment = attachmentRef.current;
-    if (enabled && attachment?.sessionName === sessionName) attachment.write(data);
-  }, [attachmentRef, enabled, sessionName]);
+  const transport = useMemo<TerminalControlsTransport | null>(
+    () =>
+      api
+        ? {
+            getPreferences: () => api.get("/api/terminal/preferences"),
+            savePreferences: (keyboard) =>
+              api.put("/api/terminal/preferences", { keyboard }),
+            paneAction: (sessionName, action) =>
+              dispatchTerminalPaneRequest({
+                post: (path, body) => api.post(path, body),
+                isMissingRoute: (error) =>
+                  error instanceof AppError &&
+                  error.category === "notFound" &&
+                  error.detail === undefined,
+                sessionName,
+                chatId,
+                action,
+              }),
+          }
+        : null,
+    [api, chatId],
+  );
+  const enabled =
+    active && socketState === "attached" && !leaseRevoked && api !== null;
+  const sendInput = useCallback(
+    (data: string) => {
+      const attachment = attachmentRef.current;
+      if (enabled && attachment?.sessionName === sessionName)
+        attachment.write(data);
+    },
+    [attachmentRef, enabled, sessionName],
+  );
   const focus = useCallback(() => {
     if (active) termRef.current?.focus();
   }, [active, termRef]);
-  return useTerminalControls({ sessionName, enabled, isMac, transport, sendInput, focus });
+  return useTerminalControls({
+    sessionName,
+    enabled,
+    isMac,
+    transport,
+    sendInput,
+    focus,
+  });
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,15 +11,19 @@
   },
   "dependencies": {
     "@matrix-os/contracts": "workspace:*",
-    "zod": "^4.3.6",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "zod": "^4.3.6"
   },
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -53,3 +53,5 @@ export { ChatAttachments, type ChatMessageAttachment } from "./chat/ChatAttachme
 export { TerminalControls } from './terminal/TerminalControls.js';
 export { useTerminalControls } from './terminal/use-terminal-controls.js';
 export type { TerminalControlsState, TerminalControlsTransport, TerminalControlsOptions } from './terminal/use-terminal-controls.js';
+
+export { dispatchTerminalPaneRequest, TerminalPaneActionsUnavailableError } from "./terminal/terminal-pane-request.js";

--- a/packages/ui/src/terminal/TerminalControlIcon.tsx
+++ b/packages/ui/src/terminal/TerminalControlIcon.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+export type TerminalControlIconName =
+  | "split-right"
+  | "split-down"
+  | "maximize"
+  | "keyboard"
+  | "more"
+  | "close"
+  | "left"
+  | "right"
+  | "up"
+  | "down"
+  | "history-top"
+  | "history-bottom";
+
+export function TerminalControlIcon({
+  name,
+}: {
+  name: TerminalControlIconName;
+}) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {name === "split-right" && (
+        <>
+          <rect x="3" y="4" width="18" height="16" rx="2" />
+          <path d="M12 4v16M15 12h3m-1.5-1.5v3" />
+        </>
+      )}
+      {name === "split-down" && (
+        <>
+          <rect x="3" y="4" width="18" height="16" rx="2" />
+          <path d="M3 12h18m-9 3v3m-1.5-1.5h3" />
+        </>
+      )}
+      {name === "maximize" && <path d="M8 3H3v5m13-5h5v5M3 16v5h5m13-5v5h-5" />}
+      {name === "keyboard" && (
+        <>
+          <rect x="2" y="5" width="20" height="14" rx="3" />
+          <path d="M6 9h.01M10 9h.01M14 9h.01M18 9h.01M6 12h.01M10 12h.01M14 12h.01M18 12h.01M8 15h8" />
+        </>
+      )}
+      {name === "more" && (
+        <>
+          <circle cx="5" cy="12" r="1" />
+          <circle cx="12" cy="12" r="1" />
+          <circle cx="19" cy="12" r="1" />
+        </>
+      )}
+      {name === "left" && <path d="m10 6-6 6 6 6M4 12h16" />}
+      {name === "right" && <path d="m14 6 6 6-6 6M4 12h16" />}
+      {name === "up" && <path d="m6 10 6-6 6 6M12 4v16" />}
+      {name === "down" && <path d="m6 14 6 6 6-6M12 4v16" />}
+      {name === "history-top" && <path d="M5 3h14m-13 9 6-6 6 6M12 6v15" />}
+      {name === "history-bottom" && <path d="M5 21h14m-13-9 6 6 6-6M12 3v15" />}
+      {name === "close" && <path d="m6 6 12 12M6 18 18 6" />}
+    </svg>
+  );
+}

--- a/packages/ui/src/terminal/TerminalControls.tsx
+++ b/packages/ui/src/terminal/TerminalControls.tsx
@@ -36,7 +36,11 @@ const DIRECTIONS = ["left", "down", "up", "right"] as const;
 export function TerminalControls({
   controls,
   theme,
+  placement = "surface",
+  layers,
 }: {
+  placement?: "surface" | "header";
+  layers?: { popover: number; dialog: number };
   controls: TerminalControlsState;
   theme?: { background?: string; foreground?: string };
 }) {
@@ -63,6 +67,8 @@ export function TerminalControls({
   }
   // Portals need the same explicit terminal palette as the inline controls.
   const palette = {
+    "--terminal-control-popover-layer": layers?.popover,
+    "--terminal-control-dialog-layer": layers?.dialog,
     "--terminal-control-bg":
       theme?.background ?? "var(--matrix-background, #101218)",
     "--terminal-control-fg": theme?.foreground ?? "var(--matrix-fg, #e4e4e7)",
@@ -75,7 +81,7 @@ export function TerminalControls({
   return (
     <div
       data-testid="terminal-controls"
-      className="matrix-terminal-controls"
+      className={`matrix-terminal-controls${placement === "header" ? " matrix-terminal-controls-header" : ""}`}
       style={palette}
     >
       <div
@@ -83,9 +89,11 @@ export function TerminalControls({
         aria-label="Terminal pane controls"
         className="matrix-terminal-toolbar"
       >
-        <span className="matrix-terminal-hint" aria-hidden="true">
-          Pane controls <kbd>⌃ G</kbd>
-        </span>
+        {placement === "surface" && (
+          <span className="matrix-terminal-hint" aria-hidden="true">
+            Pane controls <kbd>⌃ G</kbd>
+          </span>
+        )}
         <div className="matrix-terminal-primary">
           {PRIMARY_ACTIONS.map(({ label, icon, action }) => (
             <button
@@ -114,7 +122,7 @@ export function TerminalControls({
             </button>
           </Dialog.Trigger>
           <Dialog.Portal>
-            <Dialog.Overlay className="matrix-terminal-overlay" />
+            <Dialog.Overlay className="matrix-terminal-overlay" style={palette} />
             <Dialog.Content className="matrix-terminal-dialog" style={palette}>
               <div className="matrix-terminal-dialog-header">
                 <Dialog.Title>Keyboard shortcuts</Dialog.Title>
@@ -214,7 +222,7 @@ export function TerminalControls({
       </div>
       <Dialog.Root open={closing} onOpenChange={setClosing}>
         <Dialog.Portal>
-          <Dialog.Overlay className="matrix-terminal-overlay" />
+          <Dialog.Overlay className="matrix-terminal-overlay" style={palette} />
           <Dialog.Content
             role="alertdialog"
             className="matrix-terminal-dialog matrix-terminal-confirm"

--- a/packages/ui/src/terminal/TerminalControls.tsx
+++ b/packages/ui/src/terminal/TerminalControls.tsx
@@ -1,41 +1,51 @@
-import React, { useState, type CSSProperties } from "react";
-import {
-  TERMINAL_COMMANDS,
-  TERMINAL_COMMAND_LABELS,
-  terminalBindings,
-  type TerminalKeyboardPreferences,
-  type TerminalPaneAction,
-} from "@matrix-os/contracts";
+import React, { useRef, useState, type CSSProperties } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import * as Menu from "@radix-ui/react-dropdown-menu";
+import type { TerminalPaneAction } from "@matrix-os/contracts";
 import type { TerminalControlsState } from "./use-terminal-controls.js";
-const buttonStyle: CSSProperties = {
-  font: "inherit",
-  fontSize: 12,
-  color: "inherit",
-  background: "transparent",
-  border: "1px solid currentColor",
-  borderRadius: 5,
-  padding: "3px 7px",
-  cursor: "pointer",
-};
-const ACTIONS: Array<{
+import {
+  TerminalControlIcon,
+  type TerminalControlIconName,
+} from "./TerminalControlIcon.js";
+import { TerminalKeyboardSettings } from "./TerminalKeyboardSettings.js";
+import "./terminal-controls.css";
+
+const PRIMARY_ACTIONS: Array<{
   label: string;
+  icon: TerminalControlIconName;
   action: TerminalPaneAction;
 }> = [
-  { label: "Split right", action: { type: "split", direction: "right" } },
-  { label: "Split below", action: { type: "split", direction: "down" } },
-  ...(["left", "up", "down", "right"] as const).map((direction) => ({
-    label: `Focus ${direction}`,
-    action: { type: "focus" as const, direction },
-  })),
-  { label: "Maximize / restore", action: { type: "fullscreen" } },
+  {
+    label: "Split right",
+    icon: "split-right",
+    action: { type: "split", direction: "right" },
+  },
+  {
+    label: "Split below",
+    icon: "split-down",
+    action: { type: "split", direction: "down" },
+  },
+  {
+    label: "Maximize / restore",
+    icon: "maximize",
+    action: { type: "fullscreen" },
+  },
 ];
+const DIRECTIONS = ["left", "down", "up", "right"] as const;
+
 export function TerminalControls({
   controls,
+  theme,
 }: {
   controls: TerminalControlsState;
+  theme?: { background?: string; foreground?: string };
 }) {
   const [draft, setDraft] = useState(controls.preferences);
   const [closing, setClosing] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const moreButton = useRef<HTMLButtonElement>(null);
+  const skipMenuFocus = useRef(false);
   const [previousPreferences, setPreviousPreferences] = useState(
     controls.preferences,
   );
@@ -48,191 +58,208 @@ export function TerminalControls({
   if (previousTarget !== target) {
     setPreviousTarget(target);
     setClosing(false);
+    setMenuOpen(false);
+    setShortcutsOpen(false);
   }
-  const bindings = terminalBindings(draft, controls.isMac);
+  // Portals need the same explicit terminal palette as the inline controls.
+  const palette = {
+    "--terminal-control-bg":
+      theme?.background ?? "var(--matrix-background, #101218)",
+    "--terminal-control-fg": theme?.foreground ?? "var(--matrix-fg, #e4e4e7)",
+  } as CSSProperties;
+  const disabled = !controls.paneActionsEnabled || controls.busy;
+  function runAction(action: TerminalPaneAction) {
+    skipMenuFocus.current = true;
+    void controls.runAction(action);
+  }
   return (
     <div
       data-testid="terminal-controls"
-      style={{
-        fontFamily: "inherit",
-        fontSize: 12,
-        color: "inherit",
-        padding: "4px 8px",
-        flexShrink: 0,
-        borderBottom:
-          "1px solid color-mix(in srgb, currentColor 15%, transparent)",
-      }}
+      className="matrix-terminal-controls"
+      style={palette}
     >
       <div
-        role="toolbar"
+        role="group"
         aria-label="Terminal pane controls"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 5,
-          flexWrap: "wrap",
-        }}
+        className="matrix-terminal-toolbar"
       >
-        {ACTIONS.map(({ label, action }) => (
-          <button
-            type="button"
-            style={buttonStyle}
-            key={label}
-            disabled={!controls.paneActionsEnabled || controls.busy}
-            onClick={() => void controls.runAction(action)}
-          >
-            {label}
-          </button>
-        ))}
-        <details>
-          <summary style={{ cursor: "pointer" }}>More pane actions</summary>
-          <div
-            style={{ display: "flex", gap: 5, flexWrap: "wrap", padding: 6 }}
-          >
-            {(["left", "right", "up", "down"] as const).map((direction) => (
-              <button
-                key={direction}
-                type="button"
-                style={buttonStyle}
-                disabled={!controls.paneActionsEnabled || controls.busy}
-                onClick={() =>
-                  void controls.runAction({ type: "resize", direction })
-                }
-              >
-                Resize {direction}
-              </button>
-            ))}
-            {(["top", "bottom"] as const).map((edge) => (
-              <button
-                key={edge}
-                type="button"
-                style={buttonStyle}
-                disabled={!controls.paneActionsEnabled || controls.busy}
-                onClick={() =>
-                  void controls.runAction({ type: "scroll", edge })
-                }
-              >
-                History {edge}
-              </button>
-            ))}
+        <span className="matrix-terminal-hint" aria-hidden="true">
+          Pane controls <kbd>⌃ G</kbd>
+        </span>
+        <div className="matrix-terminal-primary">
+          {PRIMARY_ACTIONS.map(({ label, icon, action }) => (
             <button
               type="button"
-              style={buttonStyle}
-              disabled={!controls.paneActionsEnabled || controls.busy}
-              onClick={() => setClosing(true)}
+              className="matrix-terminal-icon-button"
+              key={label}
+              aria-label={label}
+              title={label}
+              disabled={disabled}
+              onClick={() => void controls.runAction(action)}
             >
-              Close pane
+              <TerminalControlIcon name={icon} />
             </button>
-          </div>
-        </details>
-        <details>
-          <summary style={{ cursor: "pointer" }}>Keyboard shortcuts</summary>
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              void controls.savePreferences(draft);
-            }}
-            style={{ padding: 8, maxHeight: 280, overflow: "auto" }}
-          >
-            <label>
-              Shortcut profile{" "}
-              <select
-                aria-label="Shortcut profile"
-                disabled={controls.saving}
-                value={draft.profile}
-                onChange={(e) =>
-                  setDraft({
-                    profile: e.target
-                      .value as TerminalKeyboardPreferences["profile"],
-                    overrides: {},
-                  })
-                }
-              >
-                <option value="mac">Mac editing</option>
-                <option value="standard">Standard terminal</option>
-                <option value="passthrough">Pass through to application</option>
-              </select>
-            </label>
-            <p>
-              Ctrl+G, then H/J/K/L or arrows: focus. V/S: split right/below. F:
-              maximize. X: close. T/B: history. Shift+arrows: resize. Escape
-              cancels; prefix expires after 2 seconds.
-            </p>
-            <p>
-              Use Ctrl, Alt, Shift, Meta (Command), for example Meta+ArrowLeft.
-              Empty disables a shortcut. Browser shortcuts may require the
-              prefix alternative.
-            </p>
-            {TERMINAL_COMMANDS.map((command) => (
-              <label
-                key={command}
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  gap: 10,
-                  marginBottom: 4,
+          ))}
+        </div>
+        <span className="matrix-terminal-divider" aria-hidden="true" />
+        <Dialog.Root open={shortcutsOpen} onOpenChange={setShortcutsOpen}>
+          <Dialog.Trigger asChild>
+            <button
+              type="button"
+              className="matrix-terminal-icon-button"
+              aria-label="Keyboard shortcuts"
+              title="Keyboard shortcuts"
+            >
+              <TerminalControlIcon name="keyboard" />
+            </button>
+          </Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Overlay className="matrix-terminal-overlay" />
+            <Dialog.Content className="matrix-terminal-dialog" style={palette}>
+              <div className="matrix-terminal-dialog-header">
+                <Dialog.Title>Keyboard shortcuts</Dialog.Title>
+                <Dialog.Close asChild>
+                  <button
+                    type="button"
+                    className="matrix-terminal-icon-button"
+                    aria-label="Close keyboard shortcuts"
+                  >
+                    <TerminalControlIcon name="close" />
+                  </button>
+                </Dialog.Close>
+              </div>
+              <Dialog.Description>
+                Customize editing and pane controls for your terminal.
+              </Dialog.Description>
+              <TerminalKeyboardSettings
+                controls={controls}
+                draft={draft}
+                setDraft={setDraft}
+              />
+              {controls.error && (
+                <p role="alert" className="matrix-terminal-error">
+                  {controls.error}
+                </p>
+              )}
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
+        <Menu.Root open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
+          <Menu.Trigger asChild>
+            <button
+              ref={moreButton}
+              type="button"
+              className="matrix-terminal-icon-button"
+              aria-label="More pane actions"
+              title="More pane actions"
+            >
+              <TerminalControlIcon name="more" />
+            </button>
+          </Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Content
+              className="matrix-terminal-menu"
+              style={palette}
+              align="end"
+              sideOffset={6}
+              collisionPadding={12}
+              onCloseAutoFocus={(event) => {
+                if (skipMenuFocus.current) event.preventDefault();
+                skipMenuFocus.current = false;
+              }}
+            >
+              {(["focus", "resize"] as const).map((type) => (
+                <Menu.Group key={type}>
+                  <Menu.Label>
+                    {type === "focus" ? "Move focus" : "Resize pane"}
+                  </Menu.Label>
+                  {DIRECTIONS.map((direction) => (
+                    <Menu.Item
+                      key={direction}
+                      disabled={disabled}
+                      onSelect={() => runAction({ type, direction })}
+                    >
+                      <TerminalControlIcon name={direction} />
+                      {type === "focus" ? "Focus" : "Resize"} {direction}
+                    </Menu.Item>
+                  ))}
+                  <Menu.Separator />
+                </Menu.Group>
+              ))}
+              {(["top", "bottom"] as const).map((edge) => (
+                <Menu.Item
+                  key={edge}
+                  disabled={disabled}
+                  onSelect={() => runAction({ type: "scroll", edge })}
+                >
+                  <TerminalControlIcon name={`history-${edge}`} />
+                  History {edge}
+                </Menu.Item>
+              ))}
+              <Menu.Separator />
+              <Menu.Item
+                disabled={disabled}
+                className="matrix-terminal-destructive"
+                onSelect={() => {
+                  skipMenuFocus.current = true;
+                  setClosing(true);
                 }}
               >
-                {TERMINAL_COMMAND_LABELS[command]}
-                <input
-                  aria-label={TERMINAL_COMMAND_LABELS[command]}
-                  maxLength={64}
-                  value={bindings[command] ?? ""}
-                  disabled={controls.saving || draft.profile === "passthrough"}
-                  onChange={(e) =>
-                    setDraft({
-                      ...draft,
-                      overrides: {
-                        ...draft.overrides,
-                        [command]: e.target.value || null,
-                      },
-                    })
-                  }
-                />
-              </label>
-            ))}
-            <button
-              type="submit"
-              style={buttonStyle}
-              disabled={!controls.enabled || controls.saving}
-            >
-              Save shortcuts
-            </button>{" "}
-            <button
-              type="button"
-              style={buttonStyle}
-              disabled={controls.saving}
-              onClick={() => setDraft({ profile: "mac", overrides: {} })}
-            >
-              Reset defaults
-            </button>
-          </form>
-        </details>
+                <TerminalControlIcon name="close" />
+                Close pane
+              </Menu.Item>
+            </Menu.Content>
+          </Menu.Portal>
+        </Menu.Root>
       </div>
-      {closing && (
-        <div role="alertdialog" aria-label="Close terminal pane">
-          Closing ends the process in this pane.{" "}
-          <button
-            type="button"
-            onClick={() => {
-              setClosing(false);
-              void controls.runAction({ type: "close" });
+      <Dialog.Root open={closing} onOpenChange={setClosing}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="matrix-terminal-overlay" />
+          <Dialog.Content
+            role="alertdialog"
+            className="matrix-terminal-dialog matrix-terminal-confirm"
+            style={palette}
+            onCloseAutoFocus={(event) => {
+              event.preventDefault();
+              moreButton.current?.focus();
             }}
           >
-            Close this pane
-          </button>{" "}
-          <button type="button" onClick={() => setClosing(false)}>
-            Cancel
-          </button>
-        </div>
-      )}
+            <Dialog.Title>Close terminal pane</Dialog.Title>
+            <Dialog.Description>
+              Closing ends the process in this pane. Other panes stay open.
+            </Dialog.Description>
+            <div className="matrix-terminal-dialog-actions">
+              <Dialog.Close asChild>
+                <button type="button" className="matrix-terminal-button">
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="button"
+                className="matrix-terminal-button matrix-terminal-destructive"
+                disabled={disabled}
+                onClick={() => {
+                  setClosing(false);
+                  void controls.runAction({ type: "close" });
+                }}
+              >
+                Close this pane
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
       {controls.prefixActive && (
-        <div role="status">
+        <div role="status" className="matrix-terminal-prefix">
           Pane command: H/J/K/L focus · V/S split · F maximize · X close · Esc
           cancel
         </div>
       )}
-      {controls.error && <div role="alert">{controls.error}</div>}
+      {controls.error && !shortcutsOpen && (
+        <div role="alert" className="matrix-terminal-error">
+          {controls.error}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/terminal/TerminalKeyboardSettings.tsx
+++ b/packages/ui/src/terminal/TerminalKeyboardSettings.tsx
@@ -1,0 +1,93 @@
+import React, { type Dispatch, type SetStateAction } from "react";
+import {
+  TERMINAL_COMMANDS,
+  TERMINAL_COMMAND_LABELS,
+  terminalBindings,
+  type TerminalKeyboardPreferences,
+} from "@matrix-os/contracts";
+import type { TerminalControlsState } from "./use-terminal-controls.js";
+
+export function TerminalKeyboardSettings({
+  controls,
+  draft,
+  setDraft,
+}: {
+  controls: TerminalControlsState;
+  draft: TerminalKeyboardPreferences;
+  setDraft: Dispatch<SetStateAction<TerminalKeyboardPreferences>>;
+}) {
+  const bindings = terminalBindings(draft, controls.isMac);
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void controls.savePreferences(draft);
+      }}
+      className="matrix-terminal-shortcuts"
+    >
+      <label>
+        Shortcut profile{" "}
+        <select
+          aria-label="Shortcut profile"
+          disabled={controls.saving}
+          value={draft.profile}
+          onChange={(e) =>
+            setDraft({
+              profile: e.target.value as TerminalKeyboardPreferences["profile"],
+              overrides: {},
+            })
+          }
+        >
+          <option value="mac">Mac editing</option>
+          <option value="standard">Standard terminal</option>
+          <option value="passthrough">Pass through to application</option>
+        </select>
+      </label>
+      <p>
+        Ctrl+G, then H/J/K/L or arrows: focus. V/S: split right/below. F:
+        maximize. X: close. T/B: history. Shift+arrows: resize. Escape cancels;
+        prefix expires after 2 seconds.
+      </p>
+      <p>
+        Use Ctrl, Alt, Shift, Meta (Command), for example Meta+ArrowLeft. Empty
+        disables a shortcut. Browser shortcuts may require the prefix
+        alternative.
+      </p>
+      {TERMINAL_COMMANDS.map((command) => (
+        <label key={command} className="matrix-terminal-binding">
+          {TERMINAL_COMMAND_LABELS[command]}
+          <input
+            aria-label={TERMINAL_COMMAND_LABELS[command]}
+            maxLength={64}
+            value={bindings[command] ?? ""}
+            disabled={controls.saving || draft.profile === "passthrough"}
+            onChange={(e) =>
+              setDraft({
+                ...draft,
+                overrides: {
+                  ...draft.overrides,
+                  [command]: e.target.value || null,
+                },
+              })
+            }
+          />
+        </label>
+      ))}
+      <button
+        type="submit"
+        className="matrix-terminal-button"
+        disabled={!controls.enabled || controls.saving}
+      >
+        Save shortcuts
+      </button>{" "}
+      <button
+        type="button"
+        className="matrix-terminal-button"
+        disabled={controls.saving}
+        onClick={() => setDraft({ profile: "mac", overrides: {} })}
+      >
+        Reset defaults
+      </button>
+    </form>
+  );
+}

--- a/packages/ui/src/terminal/terminal-controls.css
+++ b/packages/ui/src/terminal/terminal-controls.css
@@ -81,9 +81,9 @@
   border: 1px solid
     color-mix(in srgb, var(--terminal-control-fg) 16%, transparent);
   box-shadow: 0 12px 40px rgb(0 0 0 / 0.25);
-  z-index: 100001;
 }
 .matrix-terminal-menu {
+  z-index: var(--terminal-control-popover-layer, auto);
   width: 220px;
   max-width: calc(100vw - 24px);
   max-height: var(--radix-dropdown-menu-content-available-height);
@@ -122,9 +122,10 @@
   position: fixed;
   inset: 0;
   background: rgb(0 0 0 / 0.38);
-  z-index: 100000;
+  z-index: var(--terminal-control-dialog-layer, auto);
 }
 .matrix-terminal-dialog {
+  z-index: var(--terminal-control-dialog-layer, auto);
   position: fixed;
   top: 50%;
   left: 50%;
@@ -236,4 +237,29 @@
     display: flex;
     align-items: center;
   }
+}
+
+/* A host header owns the row; portal content keeps the same accessible controls. */
+.matrix-terminal-controls-header {
+  position: relative;
+  border: 0;
+  background: transparent;
+}
+.matrix-terminal-controls-header .matrix-terminal-toolbar {
+  padding: 0;
+}
+.matrix-terminal-controls-header
+  :is(.matrix-terminal-prefix, .matrix-terminal-error) {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: var(--terminal-control-popover-layer, auto);
+  width: 280px;
+  max-width: calc(100vw - 32px);
+  padding: 10px 12px;
+  border: 1px solid
+    color-mix(in srgb, var(--terminal-control-fg) 15%, transparent);
+  border-radius: 8px;
+  background: var(--terminal-control-bg);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.15);
 }

--- a/packages/ui/src/terminal/terminal-controls.css
+++ b/packages/ui/src/terminal/terminal-controls.css
@@ -1,0 +1,239 @@
+.matrix-terminal-controls {
+  flex-shrink: 0;
+  min-width: 0;
+  color: var(--terminal-control-fg);
+  background: var(--terminal-control-bg);
+  border-bottom: 1px solid color-mix(in srgb, currentColor 9%, transparent);
+}
+.matrix-terminal-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  height: 36px;
+  padding: 0 4px;
+}
+.matrix-terminal-hint {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font:
+    11px/1.4 system-ui,
+    sans-serif;
+  color: color-mix(in srgb, currentColor 45%, transparent);
+}
+.matrix-terminal-hint kbd {
+  margin-left: 6px;
+  font: inherit;
+  opacity: 0.7;
+}
+.matrix-terminal-primary {
+  display: flex;
+  gap: 2px;
+  margin-left: auto;
+}
+.matrix-terminal-divider {
+  width: 1px;
+  height: 14px;
+  margin: 0 5px;
+  background: currentColor;
+  opacity: 0.12;
+}
+.matrix-terminal-icon-button {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  opacity: 0.65;
+  cursor: pointer;
+}
+.matrix-terminal-icon-button:hover:not(:disabled),
+.matrix-terminal-icon-button[data-state="open"] {
+  background: color-mix(in srgb, currentColor 9%, transparent);
+  opacity: 1;
+}
+.matrix-terminal-icon-button:focus-visible,
+.matrix-terminal-button:focus-visible,
+.matrix-terminal-shortcuts :is(input, select):focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+.matrix-terminal-icon-button:disabled,
+.matrix-terminal-button:disabled {
+  opacity: 0.25;
+  cursor: default;
+}
+.matrix-terminal-menu,
+.matrix-terminal-dialog {
+  box-sizing: border-box;
+  color: var(--terminal-control-fg);
+  background: var(--terminal-control-bg);
+  font:
+    13px/1.5 system-ui,
+    sans-serif;
+  border: 1px solid
+    color-mix(in srgb, var(--terminal-control-fg) 16%, transparent);
+  box-shadow: 0 12px 40px rgb(0 0 0 / 0.25);
+  z-index: 100001;
+}
+.matrix-terminal-menu {
+  width: 220px;
+  max-width: calc(100vw - 24px);
+  max-height: var(--radix-dropdown-menu-content-available-height);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border-radius: 10px;
+  padding: 5px;
+}
+.matrix-terminal-menu [role="menuitem"] {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 10px;
+  border-radius: 5px;
+  outline: none;
+  cursor: default;
+}
+.matrix-terminal-menu [role="menuitem"][data-highlighted] {
+  background: color-mix(in srgb, currentColor 10%, transparent);
+}
+.matrix-terminal-menu [data-disabled] {
+  opacity: 0.3;
+}
+.matrix-terminal-menu [role="group"] > div:first-child {
+  padding: 5px 10px 3px;
+  font-size: 10px;
+  font-weight: 600;
+  color: color-mix(in srgb, currentColor 50%, transparent);
+}
+.matrix-terminal-menu [role="separator"] {
+  height: 1px;
+  margin: 4px 5px;
+  background: color-mix(in srgb, currentColor 10%, transparent);
+}
+.matrix-terminal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgb(0 0 0 / 0.38);
+  z-index: 100000;
+}
+.matrix-terminal-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(560px, calc(100vw - 32px));
+  max-height: min(760px, calc(100dvh - 32px));
+  overflow: auto;
+  overscroll-behavior: contain;
+  border-radius: 14px;
+  padding: 24px;
+}
+.matrix-terminal-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.matrix-terminal-dialog h2 {
+  margin: 0;
+  color: inherit;
+  font-size: 16px;
+  font-weight: 600;
+}
+.matrix-terminal-dialog p {
+  margin: 8px 0 20px;
+  color: color-mix(in srgb, currentColor 65%, transparent);
+}
+.matrix-terminal-shortcuts > label:first-child {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+}
+.matrix-terminal-shortcuts :is(input, select) {
+  box-sizing: border-box;
+  min-width: 0;
+  border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+  border-radius: 6px;
+  background: var(--terminal-control-bg);
+  color: inherit;
+  padding: 6px 8px;
+  font: inherit;
+}
+.matrix-terminal-binding {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 5px 0;
+}
+.matrix-terminal-binding input {
+  width: 48%;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}
+.matrix-terminal-shortcuts :disabled {
+  opacity: 0.4;
+}
+.matrix-terminal-button {
+  font: inherit;
+  color: inherit;
+  background: color-mix(in srgb, currentColor 6%, transparent);
+  border: 1px solid color-mix(in srgb, currentColor 15%, transparent);
+  border-radius: 7px;
+  padding: 7px 12px;
+  cursor: pointer;
+}
+.matrix-terminal-button:hover:not(:disabled) {
+  background: color-mix(in srgb, currentColor 12%, transparent);
+}
+.matrix-terminal-shortcuts > button {
+  margin-top: 16px;
+}
+.matrix-terminal-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 24px;
+}
+.matrix-terminal-confirm {
+  width: min(400px, calc(100vw - 32px));
+}
+.matrix-terminal-destructive {
+  color: color-mix(in srgb, #e5484d 85%, var(--terminal-control-fg));
+}
+.matrix-terminal-prefix,
+.matrix-terminal-error {
+  font:
+    12px/1.5 system-ui,
+    sans-serif;
+  padding: 6px 8px;
+  overflow-wrap: anywhere;
+}
+.matrix-terminal-error {
+  color: color-mix(in srgb, #e5484d 85%, var(--terminal-control-fg));
+}
+@media (pointer: coarse) {
+  .matrix-terminal-toolbar {
+    height: 48px;
+  }
+  .matrix-terminal-icon-button {
+    width: 44px;
+    height: 44px;
+  }
+  .matrix-terminal-menu [role="menuitem"] {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+  }
+}

--- a/packages/ui/src/terminal/terminal-pane-request.ts
+++ b/packages/ui/src/terminal/terminal-pane-request.ts
@@ -1,0 +1,39 @@
+import type { TerminalPaneAction } from "@matrix-os/contracts";
+
+export class TerminalPaneActionsUnavailableError extends Error {
+  constructor() {
+    super(
+      "Update this computer to use these pane controls. Standalone terminal splits are available on older versions.",
+    );
+    this.name = "TerminalPaneActionsUnavailableError";
+  }
+}
+
+/** Older host bundles support standalone splits at /panes. Never bypass a
+ * recognized session/auth error or drop Chat's authorization context to retry. */
+export async function dispatchTerminalPaneRequest({
+  post,
+  isMissingRoute,
+  sessionName,
+  chatId,
+  action,
+}: {
+  post(path: string, body: unknown): Promise<unknown>;
+  isMissingRoute(error: unknown): boolean;
+  sessionName: string;
+  chatId?: string;
+  action: TerminalPaneAction;
+}): Promise<unknown> {
+  const session = `/api/terminal/sessions/${encodeURIComponent(sessionName)}`;
+  try {
+    return await post(
+      `${session}/pane-actions${chatId ? `?chatId=${encodeURIComponent(chatId)}` : ""}`,
+      action,
+    );
+  } catch (error: unknown) {
+    if (!isMissingRoute(error)) throw error;
+    if (action.type === "split" && !chatId)
+      return post(`${session}/panes`, { direction: action.direction });
+    throw new TerminalPaneActionsUnavailableError();
+  }
+}

--- a/packages/ui/src/terminal/use-terminal-controls.ts
+++ b/packages/ui/src/terminal/use-terminal-controls.ts
@@ -122,7 +122,6 @@ export function useTerminalControls(
           sessionName,
           TerminalPaneActionSchema.parse(action),
         );
-        if (current === generation.current) focus();
       } catch (err) {
         console.warn("[terminal-controls] pane action failed", err);
         if (current === generation.current)
@@ -130,6 +129,7 @@ export function useTerminalControls(
             ? "Update this computer to use this pane control."
             : "The pane action could not be completed. Try again.");
       } finally {
+        if (current === generation.current) focus();
         pendingAction.current = false;
         setBusy(false);
       }

--- a/packages/ui/src/terminal/use-terminal-controls.ts
+++ b/packages/ui/src/terminal/use-terminal-controls.ts
@@ -1,3 +1,4 @@
+import { TerminalPaneActionsUnavailableError } from "./terminal-pane-request.js";
 import {
   useCallback,
   useEffect,
@@ -125,7 +126,9 @@ export function useTerminalControls(
       } catch (err) {
         console.warn("[terminal-controls] pane action failed", err);
         if (current === generation.current)
-          setError("The pane action could not be completed.");
+          setError(err instanceof TerminalPaneActionsUnavailableError
+            ? "Update this computer to use this pane control."
+            : "The pane action could not be completed. Try again.");
       } finally {
         pendingAction.current = false;
         setBusy(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1004,15 +1004,15 @@ importers:
       '@matrix-os/contracts':
         specifier: workspace:*
         version: link:../contracts
-      react:
-        specifier: ^19.0.0
-        version: 19.2.3
-      react-dom:
-        specifier: ^19.0.0
-        version: 19.2.3(react@19.2.3)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-markdown:
         specifier: ^10.1.0
-        version: 10.1.0(@types/react@19.2.14)(react@19.2.3)
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.6)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1020,6 +1020,12 @@ importers:
         specifier: ^4.3.6
         version: 4.4.3
     devDependencies:
+      react:
+        specifier: ^19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -137,7 +137,8 @@ export function TerminalPane({
   const terminalCursorStyle = useTerminalSettings((s) => s.cursorStyle);
   const terminalSmoothScroll = useTerminalSettings((s) => s.smoothScroll);
   const cursorBlink = useTerminalSettings((s) => s.cursorBlink);
-  const terminalSurfaceBackground = buildXtermTheme(theme, terminalThemeId).background;
+  const terminalSurfaceTheme = buildXtermTheme(theme, terminalThemeId);
+  const terminalSurfaceBackground = terminalSurfaceTheme.background;
   // Visual-viewport state drives keyboard-aware re-fitting on mobile: when the
   // iOS soft keyboard opens the layout viewport doesn't shrink, so the terminal
   // host must re-fit to the visible band or the prompt hides behind the keyboard.
@@ -1866,7 +1867,7 @@ export function TerminalPane({
 
   return (
     <div className="ph-no-capture flex h-full w-full min-h-0 min-w-0 flex-col" style={{ backgroundColor: terminalSurfaceBackground }}>
-      <TerminalControls controls={controls} />
+      <TerminalControls controls={controls} theme={terminalSurfaceTheme} />
     {/* react-doctor-disable-next-line react-doctor/no-static-element-interactions, react-doctor/click-events-have-key-events -- presentational click-to-focus wrapper: clicking anywhere in the pane forwards focus to the embedded xterm terminal, which is itself the keyboard-interactive element (its textarea is in natural tab order). This div is not a control, so a role/tabIndex would be misleading; keyboard users interact with the terminal directly. */}
     <div
       ref={containerRef}

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -9,6 +9,7 @@ import { useVisualViewport } from "@/hooks/useVisualViewport";
 import { ImageAddon } from "@xterm/addon-image";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { Terminal } from "@xterm/xterm";
+import { SHELL_Z_INDEX } from "@/lib/shell-layering";
 import { TerminalControls } from "@matrix-os/ui";
 import { createTerminalKeyHandler } from "./terminal-key-handler";
 import { useWebTerminalControls } from "./useWebTerminalControls";
@@ -1867,7 +1868,7 @@ export function TerminalPane({
 
   return (
     <div className="ph-no-capture flex h-full w-full min-h-0 min-w-0 flex-col" style={{ backgroundColor: terminalSurfaceBackground }}>
-      <TerminalControls controls={controls} theme={terminalSurfaceTheme} />
+      <TerminalControls layers={{ popover: SHELL_Z_INDEX.popover, dialog: SHELL_Z_INDEX.appDialog }} controls={controls} theme={terminalSurfaceTheme} />
     {/* react-doctor-disable-next-line react-doctor/no-static-element-interactions, react-doctor/click-events-have-key-events -- presentational click-to-focus wrapper: clicking anywhere in the pane forwards focus to the embedded xterm terminal, which is itself the keyboard-interactive element (its textarea is in natural tab order). This div is not a control, so a role/tabIndex would be misleading; keyboard users interact with the terminal directly. */}
     <div
       ref={containerRef}

--- a/shell/src/components/terminal/terminal-controls-transport.ts
+++ b/shell/src/components/terminal/terminal-controls-transport.ts
@@ -1,28 +1,65 @@
-import type { TerminalControlsTransport } from "@matrix-os/ui";
+import {
+  dispatchTerminalPaneRequest,
+  type TerminalControlsTransport,
+} from "@matrix-os/ui";
+
+class TerminalRequestError extends Error {
+  constructor(readonly missingRoute = false) {
+    super("Terminal request failed");
+  }
+}
 
 /** Uses the same owner-authenticated, VM-scoped gateway as terminal sessions. */
-export function createWebTerminalControlsTransport(gatewayUrl: string): TerminalControlsTransport {
-  const request = async (path: string, method = "GET", body?: unknown): Promise<unknown> => {
+export function createWebTerminalControlsTransport(
+  gatewayUrl: string,
+): TerminalControlsTransport {
+  const request = async (
+    path: string,
+    method = "GET",
+    body?: unknown,
+  ): Promise<unknown> => {
     try {
-      const response = await fetch(`${gatewayUrl}/api/terminal${path}`, {
+      const response = await fetch(`${gatewayUrl}${path}`, {
         method,
         credentials: "same-origin",
         signal: AbortSignal.timeout(10_000),
-        ...(body === undefined ? {} : {
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        }),
+        ...(body === undefined
+          ? {}
+          : {
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            }),
       });
-      if (!response.ok) throw new Error("Terminal request failed");
+      if (!response.ok) {
+        // Only a plain router 404 permits a compatibility retry. Structured
+        // errors (including session_not_found) must retain their semantics.
+        const text = response.status === 404 ? await response.text() : "";
+        throw new TerminalRequestError(
+          response.status === 404 && text.trim() === "404 Not Found",
+        );
+      }
       return await response.json();
     } catch (error: unknown) {
-      console.warn("Terminal control request failed", error instanceof Error ? error.name : "UnknownError");
-      throw new Error("Terminal request failed");
+      console.warn(
+        "Terminal control request failed",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+      throw error instanceof TerminalRequestError
+        ? error
+        : new TerminalRequestError();
     }
   };
   return {
-    getPreferences: () => request("/preferences"),
-    savePreferences: (keyboard) => request("/preferences", "PUT", { keyboard }),
-    paneAction: (sessionName, action) => request(`/sessions/${encodeURIComponent(sessionName)}/pane-actions`, "POST", action),
+    getPreferences: () => request("/api/terminal/preferences"),
+    savePreferences: (keyboard) =>
+      request("/api/terminal/preferences", "PUT", { keyboard }),
+    paneAction: (sessionName, action) =>
+      dispatchTerminalPaneRequest({
+        post: (path, body) => request(path, "POST", body),
+        isMissingRoute: (error) =>
+          error instanceof TerminalRequestError && error.missingRoute,
+        sessionName,
+        action,
+      }),
   };
 }

--- a/shell/src/lib/shell-layering.ts
+++ b/shell/src/lib/shell-layering.ts
@@ -15,6 +15,8 @@ export const SHELL_Z_INDEX = {
   appWindowMax: 500,
   fullscreenWindow: 600,
   fullscreenExit: 601,
+  // App-owned dialogs sit above terminal/fullscreen windows, below OS settings and gates.
+  appDialog: 620,
   desktopDrawerBackdrop: 640,
   desktopDrawer: 645,
   desktopHeader: 650,

--- a/tests/desktop/terminal-controls-view.test.tsx
+++ b/tests/desktop/terminal-controls-view.test.tsx
@@ -79,6 +79,22 @@ describe("TerminalView keyboard control wiring", () => {
     useConnection.setState({ api: null });
   });
 
+  it("renders controls in the supplied header without remounting the terminal", async () => {
+    const header = document.createElement("div");
+    document.body.append(header);
+    const view = render(<TerminalView sessionName="session-one" controlsHost={header} />);
+    act(() => events.onState("attached"));
+    expect(header.querySelector('[data-testid="terminal-controls"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="terminal-controls"]')).toBeNull();
+    expect(header.textContent).not.toContain("Pane controls");
+    view.rerender(<TerminalView sessionName="session-one" controlsHost={header} active={false} />);
+    expect(terminals).toHaveLength(1);
+    expect((header.querySelector('button[aria-label="Split right"]') as HTMLButtonElement).disabled).toBe(true);
+    view.unmount();
+    expect(header.childElementCount).toBe(0);
+    header.remove();
+  });
+
   it("uses the latest attached controller without remounting xterm and preserves select-all", async () => {
     const { rerender } = render(<TerminalView sessionName="session-one" />);
     act(() => events.onState("attached"));

--- a/tests/desktop/terminal-controls.test.tsx
+++ b/tests/desktop/terminal-controls.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { AppError } from "../../desktop/src/shared/app-error";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient } from "@desktop/renderer/src/lib/api";
@@ -6,13 +7,23 @@ import { useDesktopTerminalControls } from "@desktop/renderer/src/features/termi
 
 function setup() {
   const api = {
-    get: vi.fn().mockResolvedValue({ preferences: { keyboard: { profile: "mac", overrides: {} } } }),
-    put: vi.fn().mockResolvedValue({ preferences: { keyboard: { profile: "passthrough", overrides: {} } } }),
+    get: vi
+      .fn()
+      .mockResolvedValue({
+        preferences: { keyboard: { profile: "mac", overrides: {} } },
+      }),
+    put: vi
+      .fn()
+      .mockResolvedValue({
+        preferences: { keyboard: { profile: "passthrough", overrides: {} } },
+      }),
     post: vi.fn().mockResolvedValue({ ok: true }),
   };
   const write = vi.fn();
   const focus = vi.fn();
-  const attachment = { current: { sessionName: "session-one", write, resize: vi.fn() } };
+  const attachment = {
+    current: { sessionName: "session-one", write, resize: vi.fn() },
+  };
   const terminal = { current: { focus } };
   const initialProps = {
     api: api as unknown as ApiClient,
@@ -37,32 +48,60 @@ describe("Electron Desktop shared terminal controls", () => {
     ["ArrowRight", { altKey: true }, "\x1bf"],
     ["Backspace", { altKey: true }, "\x1b\x7f"],
     ["Backspace", { metaKey: true }, "\x15"],
-  ])("sends %s %j once through the active attachment", async (key, modifiers, expected) => {
-    const { api, write, initialProps } = setup();
-    const { result } = renderHook(() => useDesktopTerminalControls(initialProps));
-    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/api/terminal/preferences"));
-    const event = new KeyboardEvent("keydown", { key, ...modifiers, cancelable: true });
-    act(() => expect(result.current.handleKeyEvent(event)).toBe(false));
-    expect(event.defaultPrevented).toBe(true);
-    expect(write).toHaveBeenCalledExactlyOnceWith(expected);
-  });
+  ])(
+    "sends %s %j once through the active attachment",
+    async (key, modifiers, expected) => {
+      const { api, write, initialProps } = setup();
+      const { result } = renderHook(() =>
+        useDesktopTerminalControls(initialProps),
+      );
+      await waitFor(() =>
+        expect(api.get).toHaveBeenCalledWith("/api/terminal/preferences"),
+      );
+      const event = new KeyboardEvent("keydown", {
+        key,
+        ...modifiers,
+        cancelable: true,
+      });
+      act(() => expect(result.current.handleKeyEvent(event)).toBe(false));
+      expect(event.defaultPrevented).toBe(true);
+      expect(write).toHaveBeenCalledExactlyOnceWith(expected);
+    },
+  );
 
   it("targets pane actions at the current session and keeps stable transport across redraws", async () => {
     const { api, initialProps } = setup();
-    const { result, rerender } = renderHook((props) => useDesktopTerminalControls(props), { initialProps });
-    await act(async () => { await result.current.runAction({ type: "split", direction: "right" }); });
-    expect(api.post).toHaveBeenCalledWith("/api/terminal/sessions/session-one/pane-actions", { type: "split", direction: "right" });
+    const { result, rerender } = renderHook(
+      (props) => useDesktopTerminalControls(props),
+      { initialProps },
+    );
+    await act(async () => {
+      await result.current.runAction({ type: "split", direction: "right" });
+    });
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/terminal/sessions/session-one/pane-actions",
+      { type: "split", direction: "right" },
+    );
     rerender({ ...initialProps });
     expect(api.get).toHaveBeenCalledTimes(1);
     rerender({ ...initialProps, sessionName: "session-two" });
-    await act(async () => { await result.current.runAction({ type: "fullscreen" }); });
-    expect(api.post).toHaveBeenLastCalledWith("/api/terminal/sessions/session-two/pane-actions", { type: "fullscreen" });
+    await act(async () => {
+      await result.current.runAction({ type: "fullscreen" });
+    });
+    expect(api.post).toHaveBeenLastCalledWith(
+      "/api/terminal/sessions/session-two/pane-actions",
+      { type: "fullscreen" },
+    );
   });
 
   it("includes Chat authorization context for an embedded Chat terminal", async () => {
     const { api, initialProps } = setup();
-    const { result } = renderHook(() => useDesktopTerminalControls({ ...initialProps, chatId: "chat-one" }));
-    await act(async () => { await result.current.runAction({ type: "split", direction: "down" }); });
+    const { result } = renderHook(() =>
+      useDesktopTerminalControls({ ...initialProps, chatId: "chat-one" }),
+    );
+    await act(async () => {
+      await result.current.runAction({ type: "split", direction: "down" });
+    });
     expect(api.post).toHaveBeenCalledWith(
       "/api/terminal/sessions/session-one/pane-actions?chatId=chat-one",
       { type: "split", direction: "down" },
@@ -71,10 +110,17 @@ describe("Electron Desktop shared terminal controls", () => {
 
   it("does not write editing sequences into an attachment from the previous session", async () => {
     const { api, write, initialProps } = setup();
-    const { result, rerender } = renderHook((props) => useDesktopTerminalControls(props), { initialProps });
+    const { result, rerender } = renderHook(
+      (props) => useDesktopTerminalControls(props),
+      { initialProps },
+    );
     await waitFor(() => expect(api.get).toHaveBeenCalled());
     rerender({ ...initialProps, sessionName: "session-two" });
-    act(() => result.current.handleKeyEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", metaKey: true })));
+    act(() =>
+      result.current.handleKeyEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", metaKey: true }),
+      ),
+    );
     expect(write).not.toHaveBeenCalled();
   });
 
@@ -84,31 +130,83 @@ describe("Electron Desktop shared terminal controls", () => {
     { socketState: "connecting" as const },
     { leaseRevoked: true },
     { api: null },
-  ])("disables controls when the input lease is unavailable: %j", async (override) => {
-    const { api, write, initialProps } = setup();
-    const { result } = renderHook(() => useDesktopTerminalControls({ ...initialProps, ...override }));
-    expect(result.current.enabled).toBe(false);
-    await act(async () => { await result.current.runAction({ type: "close" }); });
-    act(() => result.current.handleKeyEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", metaKey: true })));
-    expect(api.post).not.toHaveBeenCalled();
-    expect(write).not.toHaveBeenCalled();
-  });
+  ])(
+    "disables controls when the input lease is unavailable: %j",
+    async (override) => {
+      const { api, write, initialProps } = setup();
+      const { result } = renderHook(() =>
+        useDesktopTerminalControls({ ...initialProps, ...override }),
+      );
+      expect(result.current.enabled).toBe(false);
+      await act(async () => {
+        await result.current.runAction({ type: "close" });
+      });
+      act(() =>
+        result.current.handleKeyEvent(
+          new KeyboardEvent("keydown", { key: "ArrowLeft", metaKey: true }),
+        ),
+      );
+      expect(api.post).not.toHaveBeenCalled();
+      expect(write).not.toHaveBeenCalled();
+    },
+  );
 
   it("saves keyboard settings through the authenticated preferences API", async () => {
     const { api, initialProps } = setup();
-    const { result } = renderHook(() => useDesktopTerminalControls(initialProps));
+    const { result } = renderHook(() =>
+      useDesktopTerminalControls(initialProps),
+    );
     await waitFor(() => expect(api.get).toHaveBeenCalled());
-    await act(async () => { await result.current.savePreferences({ profile: "passthrough", overrides: {} }); });
-    expect(api.put).toHaveBeenCalledWith("/api/terminal/preferences", { keyboard: { profile: "passthrough", overrides: {} } });
+    await act(async () => {
+      await result.current.savePreferences({
+        profile: "passthrough",
+        overrides: {},
+      });
+    });
+    expect(api.put).toHaveBeenCalledWith("/api/terminal/preferences", {
+      keyboard: { profile: "passthrough", overrides: {} },
+    });
   });
 
   it("reports a safe error without disposing the terminal after a failed pane action", async () => {
     const { api, initialProps, attachment } = setup();
-    api.post.mockRejectedValue(new Error("private gateway /home/operator failure"));
-    const { result } = renderHook(() => useDesktopTerminalControls(initialProps));
-    await act(async () => { await result.current.runAction({ type: "close" }); });
+    api.post.mockRejectedValue(
+      new Error("private gateway /home/operator failure"),
+    );
+    const { result } = renderHook(() =>
+      useDesktopTerminalControls(initialProps),
+    );
+    await act(async () => {
+      await result.current.runAction({ type: "close" });
+    });
     expect(result.current.error).toBeTruthy();
     expect(result.current.error).not.toMatch(/operator|gateway|\/home/);
     expect(attachment.current.sessionName).toBe("session-one");
   });
+});
+
+it("retries a missing standalone split route on older hosts", async () => {
+  const { api, initialProps } = setup();
+  api.post.mockRejectedValueOnce(new AppError("notFound"));
+  const { result } = renderHook(() => useDesktopTerminalControls(initialProps));
+  await act(async () => {
+    await result.current.runAction({ type: "split", direction: "right" });
+  });
+  expect(api.post).toHaveBeenLastCalledWith(
+    "/api/terminal/sessions/session-one/panes",
+    { direction: "right" },
+  );
+  expect(result.current.error).toBeNull();
+});
+it("does not retry a recognized session-not-found response", async () => {
+  const { api, initialProps } = setup();
+  api.post.mockRejectedValueOnce(
+    new AppError("notFound", { detail: "session_not_found" }),
+  );
+  const { result } = renderHook(() => useDesktopTerminalControls(initialProps));
+  await act(async () => {
+    await result.current.runAction({ type: "split", direction: "right" });
+  });
+  expect(api.post).toHaveBeenCalledTimes(1);
+  expect(result.current.error).toContain("could not be completed");
 });

--- a/tests/desktop/terminals-tab.test.tsx
+++ b/tests/desktop/terminals-tab.test.tsx
@@ -31,7 +31,7 @@ function deferred<T>() {
 }
 
 vi.mock("../../desktop/src/renderer/src/features/terminal/TerminalView", () => ({
-  default: ({
+  default: function MockTerminalView({
     sessionName,
     active,
     visualScale,
@@ -39,7 +39,7 @@ vi.mock("../../desktop/src/renderer/src/features/terminal/TerminalView", () => (
     sessionName: string;
     active?: boolean;
     visualScale?: number;
-  }) => {
+  }) {
     const themeMode = useAppearance((state) => state.mode);
     const terminalThemeId = useTerminalAppearance((state) => state.themeId);
     React.useEffect(() => {
@@ -231,6 +231,20 @@ describe("TerminalsTab", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open matrix-main" }));
 
     expect(screen.queryByRole("navigation", { name: "Terminal breadcrumb" })).toBeNull();
+  });
+
+  it("keeps the Terminal title, session details, and controls in one header with a persistent sidebar toggle", () => {
+    useShellSessions.setState({ sessions: [{ name: "matrix-main", status: "active" }] });
+    renderTab();
+    const header = screen.getByRole("banner");
+    expect(header.contains(screen.getByRole("heading", { name: "Terminal", exact: true }))).toBe(true);
+    expect(header.querySelector("[data-terminal-controls-host]")).not.toBeNull();
+    const toggle = screen.getByRole("button", { name: "Hide terminal tabs" });
+    expect(toggle.querySelector('svg')?.getAttribute('data-direction')).toBe('left');
+    fireEvent.click(toggle);
+    const show = screen.getByRole("button", { name: "Show terminal tabs" });
+    expect(header.contains(show)).toBe(true);
+    expect(show.querySelector('svg')?.getAttribute('data-direction')).toBe('right');
   });
 
   it("places the shell theme picker beside the new-session controls in the sidebar", () => {
@@ -627,13 +641,14 @@ describe("TerminalsTab", () => {
     );
     const content = container.querySelector<HTMLElement>('[data-testid="desktop-terminal-app"]');
     expect(content).not.toBeNull();
-    expect(content!.style.paddingTop).toBe("");
+    expect(content!.style.paddingTop).toBe("48px");
     fireEvent.click(screen.getByRole("button", { name: "Hide terminal tabs" }));
-    const rail = screen.getByRole("complementary", { name: "Collapsed terminal tabs" });
-    expect(content!.contains(rail)).toBe(true);
+    const header = screen.getByRole("banner");
+    expect(header.contains(screen.getByRole("button", { name: "Show terminal tabs" }))).toBe(true);
+    expect(screen.queryByRole("complementary", { name: "Collapsed terminal tabs" })).toBeNull();
     expect(content!.style.paddingTop).toBe("48px");
     fireEvent.click(screen.getByRole("button", { name: "Show terminal tabs" }));
-    expect(content!.style.paddingTop).toBe("");
+    expect(content!.style.paddingTop).toBe("48px");
   });
 
   it("keeps delete and connect actions in one non-overlapping overflow menu", async () => {

--- a/tests/e2e/desktop/handoff-regression-matrix.ts
+++ b/tests/e2e/desktop/handoff-regression-matrix.ts
@@ -406,7 +406,7 @@ export const HANDOFF_REGRESSION_MATRIX: readonly HandoffRegressionScenario[] = [
     evidence: [
       testEvidence(
         "tests/e2e/desktop/terminal-sessions.e2e.test.ts",
-        "renders the Figma-aligned list and preserves the mounted terminal buffer across list-detail navigation",
+        "keeps controls in the title row and preserves the terminal buffer across sidebar and session changes",
       ),
       testEvidence(
         "tests/e2e/desktop/operator.e2e.test.ts",

--- a/tests/e2e/desktop/terminal-clipboard.e2e.test.ts
+++ b/tests/e2e/desktop/terminal-clipboard.e2e.test.ts
@@ -36,9 +36,8 @@ suite("packaged Electron terminal clipboard", () => {
   const pasteShortcut = process.platform === "darwin" ? "Meta+V" : "Control+Shift+V";
 
   const terminalSurface = () => page
-    .getByRole("heading", { name: activeSessionName, exact: true })
-    .locator("xpath=ancestor::section[1]")
-    .locator("[data-terminal-surface]");
+    .getByTestId("desktop-terminal-app")
+    .locator('[data-retained-pane][data-active="true"] [data-terminal-surface]');
 
   async function clipboardText(): Promise<string> {
     return app.evaluate(({ clipboard }) => clipboard.readText());
@@ -273,9 +272,8 @@ suite("packaged Electron production-mode terminal selection", () => {
   let userDataDir: string;
 
   const terminalSurface = () => page
-    .getByRole("heading", { name: "matrix-task-1", exact: true })
-    .locator("xpath=ancestor::section[1]")
-    .locator("[data-terminal-surface]");
+    .getByTestId("desktop-terminal-app")
+    .locator('[data-retained-pane][data-active="true"] [data-terminal-surface]');
 
   async function terminalGrid() {
     await expect.poll(

--- a/tests/e2e/desktop/terminal-sessions.e2e.test.ts
+++ b/tests/e2e/desktop/terminal-sessions.e2e.test.ts
@@ -36,7 +36,7 @@ interface TerminalViewportGeometry {
 async function readTerminalViewportGeometry(viewport: Locator): Promise<TerminalViewportGeometry> {
   await viewport.locator(".xterm").waitFor();
   return viewport.evaluate((host) => {
-    const frame = host.closest("section");
+    const frame = host.closest('[data-testid="desktop-terminal-app"]');
     const header = frame?.querySelector("header");
     const root = host.querySelector<HTMLElement>(".xterm");
     const xtermViewport = host.querySelector<HTMLElement>(".xterm-viewport");
@@ -143,9 +143,10 @@ suite("Desktop terminal session handoff", () => {
   it("opens the compact shell-theme picker through Electron hit testing", async () => {
     await page.getByRole("button", { name: "Terminal", exact: true }).first().dblclick({ timeout: 5_000 });
     const terminalWindow = page.getByRole("dialog", { name: "Terminal window" });
-    const fullWidthChrome = terminalWindow.locator('[data-os-window-chrome-placement="full-width"]');
-    await fullWidthChrome.waitFor({ timeout: 5_000 });
-    expect(await fullWidthChrome.textContent()).toContain("Terminal");
+    const header = terminalWindow.locator(".matrix-terminal-app-header");
+    await header.waitFor({ timeout: 5_000 });
+    expect(await header.getByRole("heading", { name: "Terminal", exact: true }).count()).toBe(1);
+    expect(await header.getByRole("button", { name: "Hide terminal tabs" }).count()).toBe(1);
 
     await terminalWindow.getByRole("button", { name: "Choose session type" }).click();
     for (const agent of ["Claude Code", "Codex", "OpenCode", "Pi"]) {
@@ -171,36 +172,44 @@ suite("Desktop terminal session handoff", () => {
 
     await page.getByRole("menu", { name: "Shell theme" }).waitFor({ timeout: 5_000 });
     await page.getByRole("menuitemradio", { name: /P10k Rainbow/ }).waitFor({ timeout: 5_000 });
+    await page.keyboard.press("Escape");
   });
 
-  it("renders the Figma-aligned list and preserves the mounted terminal buffer across list-detail navigation", async () => {
-    await page.getByRole("button", { name: "Terminal", exact: true }).first().dblclick();
-    await page.getByRole("heading", { name: "Terminal" }).waitFor({ timeout: 10_000 });
-    await page.getByText("Active", { exact: true }).waitFor();
-    await page.getByText("Waiting", { exact: true }).waitFor();
-    await page.getByText("Closed", { exact: true }).waitFor();
+  it("keeps controls in the title row and preserves the terminal buffer across sidebar and session changes", async () => {
+    await page.getByRole("heading", { name: "Terminal", exact: true }).waitFor({ timeout: 10_000 });
+    for (const name of ["matrix-task-1", "matrix-review", "matrix-closed"]) {
+      await page.getByRole("button", { name: `Open ${name}` }).waitFor();
+    }
     await page.screenshot({ path: join(SCREENSHOT_DIR, "mat-300-terminal-session-list.png") });
 
     await page.getByRole("button", { name: "Open matrix-task-1" }).click();
     await page.getByRole("heading", { name: "matrix-task-1" }).waitFor();
     expect(await page.getByRole("navigation", { name: "Terminal breadcrumb" }).count()).toBe(0);
     await page.getByText(/Started at .*main computer/).waitFor();
-    const viewport = page.locator("section[aria-hidden='false'] [data-terminal-surface]");
+    const viewport = page.getByTestId("desktop-terminal-app").locator('[data-retained-pane][data-active="true"] [data-terminal-surface]');
     await viewport.evaluate((element) => { element.setAttribute("data-mat-300-identity", "preserved"); });
     const initialGeometry = await expectTerminalViewportToFill(viewport);
     await page.screenshot({ path: join(SCREENSHOT_DIR, "mat-300-terminal-session-detail.png") });
 
-    await page.getByRole("button", { name: "Collapse sidebar" }).click();
+    const header = page.locator(".matrix-terminal-app-header");
+    const split = header.getByRole("button", { name: "Split right", exact: true });
+    const [titleBounds, splitBounds] = await Promise.all([
+      header.getByRole("heading", { name: "Terminal", exact: true }).boundingBox(),
+      split.boundingBox(),
+    ]);
+    expect(titleBounds).not.toBeNull();
+    expect(splitBounds).not.toBeNull();
+    expect(Math.abs(titleBounds!.y + titleBounds!.height / 2 - splitBounds!.y - splitBounds!.height / 2)).toBeLessThanOrEqual(1);
+    const hideSidebar = header.getByRole("button", { name: "Hide terminal tabs" });
+    expect(await hideSidebar.locator("svg").getAttribute("data-direction")).toBe("left");
+    await hideSidebar.click();
+    expect(await header.getByRole("button", { name: "Show terminal tabs" }).locator("svg").getAttribute("data-direction")).toBe("right");
     await expect.poll(async () => (await readTerminalViewportGeometry(viewport)).hostWidth)
       .toBeGreaterThan(initialGeometry.hostWidth + 20);
     const collapsedGeometry = await expectTerminalViewportToFill(viewport);
 
-    await app.evaluate(({ BrowserWindow }) => {
-      const window = BrowserWindow.getAllWindows()[0];
-      if (!window) throw new Error("desktop window is unavailable");
-      const [width, height] = window.getSize();
-      window.setSize(Math.max(900, width - 140), Math.max(650, height - 100));
-    });
+    await page.getByRole("dialog", { name: "Terminal window" })
+      .getByRole("button", { name: "Maximize", exact: true }).click();
     await expect.poll(async () => {
       const resized = await readTerminalViewportGeometry(viewport);
       return Math.abs(resized.hostWidth - collapsedGeometry.hostWidth)
@@ -208,20 +217,16 @@ suite("Desktop terminal session handoff", () => {
     }).toBeGreaterThan(20);
     await expectTerminalViewportToFill(viewport);
 
-    await page.getByRole("navigation", { name: "Breadcrumb" })
-      .getByRole("button", { name: "Terminal" })
-      .click();
-    await page.getByRole("heading", { name: "Terminal" }).waitFor();
+    await header.getByRole("button", { name: "Show terminal tabs" }).click();
+    await page.getByRole("button", { name: "Open matrix-review" }).click();
+    await page.getByRole("heading", { name: "matrix-review", exact: true }).waitFor();
     await page.getByRole("button", { name: "Open matrix-task-1" }).click();
     await expect.poll(() => viewport.getAttribute("data-mat-300-identity")).toBe("preserved");
     await expectTerminalViewportToFill(viewport);
 
-    await page.getByRole("navigation", { name: "Breadcrumb" })
-      .getByRole("button", { name: "Terminal" })
-      .click();
-    await page.getByRole("button", { name: "New shell" }).click();
-    const newSessionViewport = page.locator(
-      'section[aria-hidden="false"] [data-terminal-surface]',
+    await header.getByRole("button", { name: "New shell session", exact: true }).click();
+    const newSessionViewport = page.getByTestId("desktop-terminal-app").locator(
+      '[data-retained-pane][data-active="true"] [data-terminal-surface]',
     );
     await newSessionViewport.waitFor();
     await expectTerminalViewportToFill(newSessionViewport);

--- a/tests/shell/terminal-pane-controls.test.ts
+++ b/tests/shell/terminal-pane-controls.test.ts
@@ -2,40 +2,90 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createWebTerminalControlsTransport } from "../../shell/src/components/terminal/terminal-controls-transport.js";
 import { createTerminalKeyHandler } from "../../shell/src/components/terminal/terminal-key-handler.js";
-import { dispatchTerminalPaneAction, listenTerminalPaneActions } from "../../shell/src/components/terminal/terminal-pane-actions.js";
+import {
+  dispatchTerminalPaneAction,
+  listenTerminalPaneActions,
+} from "../../shell/src/components/terminal/terminal-pane-actions.js";
 
 afterEach(() => vi.unstubAllGlobals());
 
 describe("Web terminal controls transport", () => {
   it("targets the explicit gateway and includes owner cookies with bounded requests", async () => {
-    const fetcher = vi.fn(async () => ({ ok: true, json: async () => ({ keyboard: { profile: "mac" } }) }));
+    const fetcher = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ keyboard: { profile: "mac" } }),
+    }));
     vi.stubGlobal("fetch", fetcher);
-    const transport = createWebTerminalControlsTransport("https://app.matrix-os.com/vm/test");
+    const transport = createWebTerminalControlsTransport(
+      "https://app.matrix-os.com/vm/test",
+    );
     await transport.getPreferences();
     await transport.savePreferences({ profile: "mac", overrides: {} });
-    await transport.paneAction("my shell", { type: "split", direction: "right" });
+    await transport.paneAction("my shell", {
+      type: "split",
+      direction: "right",
+    });
     expect(fetcher.mock.calls).toEqual([
-      ["https://app.matrix-os.com/vm/test/api/terminal/preferences", expect.objectContaining({ credentials: "same-origin", signal: expect.any(AbortSignal) })],
-      ["https://app.matrix-os.com/vm/test/api/terminal/preferences", expect.objectContaining({ method: "PUT", body: JSON.stringify({ keyboard: { profile: "mac", overrides: {} } }), signal: expect.any(AbortSignal) })],
-      ["https://app.matrix-os.com/vm/test/api/terminal/sessions/my%20shell/pane-actions", expect.objectContaining({ method: "POST", body: JSON.stringify({ type: "split", direction: "right" }), signal: expect.any(AbortSignal) })],
+      [
+        "https://app.matrix-os.com/vm/test/api/terminal/preferences",
+        expect.objectContaining({
+          credentials: "same-origin",
+          signal: expect.any(AbortSignal),
+        }),
+      ],
+      [
+        "https://app.matrix-os.com/vm/test/api/terminal/preferences",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ keyboard: { profile: "mac", overrides: {} } }),
+          signal: expect.any(AbortSignal),
+        }),
+      ],
+      [
+        "https://app.matrix-os.com/vm/test/api/terminal/sessions/my%20shell/pane-actions",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ type: "split", direction: "right" }),
+          signal: expect.any(AbortSignal),
+        }),
+      ],
     ]);
   });
   it("never exposes server failures or network details", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("secret provider path")));
-    await expect(createWebTerminalControlsTransport("").paneAction("main", { type: "close" })).rejects.toThrow("Terminal request failed");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("secret provider path")),
+    );
+    await expect(
+      createWebTerminalControlsTransport("").paneAction("main", {
+        type: "close",
+      }),
+    ).rejects.toThrow("Terminal request failed");
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
-    await expect(createWebTerminalControlsTransport("").getPreferences()).rejects.toThrow("Terminal request failed");
+    await expect(
+      createWebTerminalControlsTransport("").getPreferences(),
+    ).rejects.toThrow("Terminal request failed");
   });
 });
 
 describe("Web xterm keyboard integration", () => {
-  const event = (key: string, options = {}) => new KeyboardEvent("keydown", { key, cancelable: true, ...options });
+  const event = (key: string, options = {}) =>
+    new KeyboardEvent("keydown", { key, cancelable: true, ...options });
   function setup() {
     const controls = vi.fn(() => false);
     const copy = vi.fn();
     const paste = vi.fn();
     const selectAll = vi.fn();
-    const handler = createTerminalKeyHandler({ isMac: true, getSelection: () => "selected", getCommandBlock: () => "block", copy, paste, selectAll, toggleSearch: vi.fn(), handleControls: controls });
+    const handler = createTerminalKeyHandler({
+      isMac: true,
+      getSelection: () => "selected",
+      getCommandBlock: () => "block",
+      copy,
+      paste,
+      selectAll,
+      toggleSearch: vi.fn(),
+      handleControls: controls,
+    });
     return { handler, controls, copy, paste };
   }
   it("gives clipboard precedence and suppresses browser copy", () => {
@@ -74,13 +124,54 @@ describe("Zellij actions from legacy web pane layouts", () => {
     const other = vi.fn();
     const stop = listenTerminalPaneActions("selected", selected);
     const stopOther = listenTerminalPaneActions("other", other);
-    dispatchTerminalPaneAction("selected", { type: "split", direction: "down" });
+    dispatchTerminalPaneAction("selected", {
+      type: "split",
+      direction: "down",
+    });
     dispatchTerminalPaneAction("selected", { type: "close" });
-    expect(selected.mock.calls).toEqual([[{ type: "split", direction: "down" }], [{ type: "close" }]]);
+    expect(selected.mock.calls).toEqual([
+      [{ type: "split", direction: "down" }],
+      [{ type: "close" }],
+    ]);
     expect(other).not.toHaveBeenCalled();
     stop();
     stopOther();
     dispatchTerminalPaneAction("selected", { type: "close" });
     expect(selected).toHaveBeenCalledTimes(2);
   });
+});
+
+it("retries only a plain missing route through the older standalone split endpoint", async () => {
+  const fetcher = vi
+    .fn()
+    .mockResolvedValueOnce(new Response("404 Not Found", { status: 404 }))
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ pane: "terminal_2" })),
+    );
+  vi.stubGlobal("fetch", fetcher);
+  await createWebTerminalControlsTransport("/vm/owner").paneAction("main", {
+    type: "split",
+    direction: "down",
+  });
+  expect(fetcher).toHaveBeenLastCalledWith(
+    "/vm/owner/api/terminal/sessions/main/panes",
+    expect.objectContaining({ body: JSON.stringify({ direction: "down" }) }),
+  );
+});
+it("does not retry structured session errors or failed requests", async () => {
+  const fetcher = vi
+    .fn()
+    .mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: "session_not_found" } }), {
+        status: 404,
+      }),
+    );
+  vi.stubGlobal("fetch", fetcher);
+  await expect(
+    createWebTerminalControlsTransport("").paneAction("main", {
+      type: "split",
+      direction: "down",
+    }),
+  ).rejects.toThrow("Terminal request failed");
+  expect(fetcher).toHaveBeenCalledTimes(1);
 });

--- a/tests/ui/terminal-controls.test.tsx
+++ b/tests/ui/terminal-controls.test.tsx
@@ -19,16 +19,12 @@ const setup = () => ({
   sendInput: vi.fn(),
   focus: vi.fn(),
   transport: {
-    getPreferences: vi
-      .fn()
-      .mockResolvedValue({
-        preferences: { keyboard: { profile: "mac", overrides: {} } },
-      }),
-    savePreferences: vi
-      .fn()
-      .mockResolvedValue({
-        preferences: { keyboard: { profile: "standard", overrides: {} } },
-      }),
+    getPreferences: vi.fn().mockResolvedValue({
+      preferences: { keyboard: { profile: "mac", overrides: {} } },
+    }),
+    savePreferences: vi.fn().mockResolvedValue({
+      preferences: { keyboard: { profile: "standard", overrides: {} } },
+    }),
     paneAction: vi.fn().mockResolvedValue({ ok: true }),
   },
 });
@@ -154,8 +150,11 @@ it("cancels a pending close confirmation when the terminal target changes", asyn
     return <TerminalControls controls={controls} />;
   }
   const view = render(<Harness name="alpha" />);
+  fireEvent.keyDown(view.getByRole("button", { name: "More pane actions" }), {
+    key: "ArrowDown",
+  });
   fireEvent.click(
-    view.getByRole("button", { name: "Close pane", exact: true, hidden: true }),
+    view.getByRole("menuitem", { name: "Close pane", exact: true }),
   );
   expect(view.getByRole("alertdialog")).toBeTruthy();
   view.rerender(<Harness name="beta" />);
@@ -169,6 +168,7 @@ it("edits and saves custom keyboard settings through the shared toolbar", async 
   }
   const view = render(<Harness />);
   await waitFor(() => expect(opts.transport.getPreferences).toHaveBeenCalled());
+  fireEvent.click(view.getByRole("button", { name: "Keyboard shortcuts" }));
   fireEvent.change(view.getByLabelText("Shortcut profile"), {
     target: { value: "standard" },
   });
@@ -219,6 +219,7 @@ it("disables edits while keyboard settings are saving", async () => {
   }
   const view = render(<Harness />);
   await waitFor(() => expect(opts.transport.getPreferences).toHaveBeenCalled());
+  fireEvent.click(view.getByRole("button", { name: "Keyboard shortcuts" }));
   fireEvent.click(view.getByText("Save shortcuts"));
   expect(
     (view.getByLabelText("Shortcut profile") as HTMLSelectElement).disabled,
@@ -262,4 +263,53 @@ it("keeps a pane action serialized while its transport refreshes", async () => {
     await pending;
   });
   expect(result.current.busy).toBe(false);
+});
+
+it("keeps secondary actions and shortcut inputs out of the terminal layout", () => {
+  const opts = setup();
+  function Harness() {
+    return <TerminalControls controls={useTerminalControls(opts)} />;
+  }
+  const view = render(<Harness />);
+  expect(view.queryByText("Focus left")).toBeNull();
+  expect(view.queryByLabelText("Shortcut profile")).toBeNull();
+  expect(view.getByRole("button", { name: "Split right" }).textContent).toBe(
+    "",
+  );
+  expect(view.getByRole("button", { name: "Split below" }).textContent).toBe(
+    "",
+  );
+  expect(view.getByRole("button", { name: "Maximize / restore" })).toBeTruthy();
+});
+it("runs secondary actions from a keyboard-accessible menu and dismisses it", async () => {
+  const opts = setup();
+  function Harness() {
+    return <TerminalControls controls={useTerminalControls(opts)} />;
+  }
+  const view = render(<Harness />);
+  fireEvent.keyDown(view.getByRole("button", { name: "More pane actions" }), {
+    key: "ArrowDown",
+  });
+  fireEvent.click(view.getByRole("menuitem", { name: "Resize left" }));
+  await waitFor(() =>
+    expect(opts.transport.paneAction).toHaveBeenCalledWith("alpha", {
+      type: "resize",
+      direction: "left",
+    }),
+  );
+  expect(view.queryByRole("menu")).toBeNull();
+});
+it("opens shortcuts in an overlay and restores focus when dismissed", async () => {
+  const opts = setup();
+  function Harness() {
+    return <TerminalControls controls={useTerminalControls(opts)} />;
+  }
+  const view = render(<Harness />);
+  const trigger = view.getByRole("button", { name: "Keyboard shortcuts" });
+  fireEvent.click(trigger);
+  const dialog = view.getByRole("dialog", { name: "Keyboard shortcuts" });
+  expect(view.getByTestId("terminal-controls").contains(dialog)).toBe(false);
+  fireEvent.keyDown(dialog, { key: "Escape" });
+  await waitFor(() => expect(view.queryByRole("dialog")).toBeNull());
+  expect(document.activeElement).toBe(trigger);
 });

--- a/tests/ui/terminal-controls.test.tsx
+++ b/tests/ui/terminal-controls.test.tsx
@@ -313,3 +313,22 @@ it("opens shortcuts in an overlay and restores focus when dismissed", async () =
   await waitFor(() => expect(view.queryByRole("dialog")).toBeNull());
   expect(document.activeElement).toBe(trigger);
 });
+it("returns keyboard focus after a failed current pane action", async () => {
+  const opts = setup();
+  opts.transport.paneAction.mockRejectedValueOnce(new Error("request rejected"));
+  const { result } = renderHook(() => useTerminalControls(opts));
+  await act(async () => result.current.runAction({ type: "focus", direction: "left" }));
+  expect(opts.focus).toHaveBeenCalledOnce();
+  expect(result.current.error).toContain("could not be completed");
+});
+it("does not steal focus when a failed action belongs to the previous terminal", async () => {
+  const opts = setup();
+  let reject!: (error: Error) => void;
+  opts.transport.paneAction.mockImplementationOnce(() => new Promise((_, fail) => { reject = fail; }));
+  const { result, rerender } = renderHook((props) => useTerminalControls(props), { initialProps: opts });
+  let pending!: Promise<void>;
+  act(() => { pending = result.current.runAction({ type: "focus", direction: "left" }); });
+  rerender({ ...opts, sessionName: "beta" });
+  await act(async () => { reject(new Error("request rejected")); await pending; });
+  expect(opts.focus).not.toHaveBeenCalled();
+});

--- a/tests/ui/terminal-pane-request.test.ts
+++ b/tests/ui/terminal-pane-request.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  dispatchTerminalPaneRequest,
+  TerminalPaneActionsUnavailableError,
+} from "../../packages/ui/src/terminal/terminal-pane-request.js";
+
+describe("pane endpoint compatibility", () => {
+  const missing = new Error("missing route");
+  const setup = () => ({
+    post: vi
+      .fn()
+      .mockRejectedValueOnce(missing)
+      .mockResolvedValue({ ok: true }),
+    isMissingRoute: (error: unknown) => error === missing,
+  });
+  it.each(["right", "down"] as const)(
+    "splits %s on a host that predates pane actions",
+    async (direction) => {
+      const transport = setup();
+      await dispatchTerminalPaneRequest({
+        ...transport,
+        sessionName: "my terminal",
+        action: { type: "split", direction },
+      });
+      expect(transport.post.mock.calls).toEqual([
+        [
+          "/api/terminal/sessions/my%20terminal/pane-actions",
+          { type: "split", direction },
+        ],
+        ["/api/terminal/sessions/my%20terminal/panes", { direction }],
+      ]);
+    },
+  );
+  it("never drops Chat authorization to retry through the standalone route", async () => {
+    const transport = setup();
+    await expect(
+      dispatchTerminalPaneRequest({
+        ...transport,
+        sessionName: "chat_shell",
+        chatId: "chat_one",
+        action: { type: "split", direction: "right" },
+      }),
+    ).rejects.toBeInstanceOf(TerminalPaneActionsUnavailableError);
+    expect(transport.post).toHaveBeenCalledTimes(1);
+    expect(transport.post).toHaveBeenCalledWith(
+      "/api/terminal/sessions/chat_shell/pane-actions?chatId=chat_one",
+      { type: "split", direction: "right" },
+    );
+  });
+  it("does not retry failures that could already have executed, or authorization failures", async () => {
+    const failed = new Error("timeout or denied");
+    const post = vi.fn().mockRejectedValue(failed);
+    await expect(
+      dispatchTerminalPaneRequest({
+        post,
+        isMissingRoute: () => false,
+        sessionName: "main",
+        action: { type: "split", direction: "right" },
+      }),
+    ).rejects.toBe(failed);
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+  it("reports an update requirement for new actions on old hosts", async () => {
+    const transport = setup();
+    await expect(
+      dispatchTerminalPaneRequest({
+        ...transport,
+        sessionName: "main",
+        action: { type: "focus", direction: "left" },
+      }),
+    ).rejects.toBeInstanceOf(TerminalPaneActionsUnavailableError);
+    expect(transport.post).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Terminal pane controls occupied several rows above the prompt, and newer desktop clients could not split terminals on older host bundles.

Use compact split/maximize icons, an accessible action menu, and a shortcut settings dialog. In Electron Desktop, place the controls in the same 48px header as the Terminal title and session details. Keep the sidebar toggle available when collapsed, point its arrow toward the action, and preserve mounted terminal buffers and keyboard focus. Narrow headers progressively hide secondary metadata. Shared controls follow the terminal palette and each renderer’s central overlay layers across Electron Desktop, Web Desktop, Web Canvas, and Web Mobile.

For standalone splits only, retry a missing pane-action endpoint through the older `/panes` endpoint. Never retry recognized session errors, authentication errors, timeouts, or server failures, and never drop Chat authorization context. Other unsupported actions explain that the computer needs an update. Restore terminal focus after both successful and failed actions without stealing focus after a session change.

## Validation

- 198 focused tests passed across shared controls, request compatibility, desktop/web adapters, renderer integration, and the E2E verification matrix.
- UI, Electron renderer, and web TypeScript checks passed. Targeted lint has no errors; existing warnings remain in the large Web Terminal component.
- Rebased onto main `f3de76ede`; final Electron production build and frozen-lockfile install passed.
- All 10 packaged Electron clipboard/session E2E tests passed. The session suite checks shared-row geometry, both sidebar arrows, viewport resizing, and retained buffers; clipboard tests target only the active retained pane.
- Repository typecheck and pattern scan passed (zero pattern violations). The full local unit run passed 13,726 tests. A stale E2E matrix reference was corrected and its focused suite passed. Remaining failures are in three files unchanged from main: Linux host prerequisites on macOS (GNU stat and Ubuntu add-apt-repository), platform-dependent DMG artwork bytes, and shell-process timeouts. Linux CI remains the full-suite gate.
- Browser preview verified sidebar open/collapsed, arrow direction, retained focus, and a 570px header without horizontal overflow. Earlier shared-control checks covered 390px layouts, light/dark palettes, menu dismissal, and overlays that preserve viewport height.
- Real Zellij smoke test: split right and split below created three live panes in an isolated session; test session/client cleaned up.

## Invariants

- **Source of truth:** shared Terminal controls and request dispatcher; existing keyboard preferences and Zellij runtime remain authoritative. Electron portals only the active terminal’s controls into a persistent header.
- **Lock/transaction scope:** existing serialized pane-action and preference-save lifecycles remain; no database writes added.
- **Acceptable orphan states:** none added; overlays close on session changes and unmount, terminal instances survive sidebar toggles, and smoke-test sessions are removed.
- **Auth source of truth:** existing authenticated, runtime-scoped transports. Compatibility retries are standalone-only; Chat always retains its authorization context.
- **Deferred scope:** no host deployment or desktop release in this PR. Older hosts still need an update for actions beyond standalone splitting. Native Mobile does not consume these shared web/Electron controls.
