### PR TITLE
fix(chat): handle connector consent and resolve pending requests

### DIFF
--- a/docs/dev/connector-consent.md
+++ b/docs/dev/connector-consent.md
@@ -1,0 +1,48 @@
+# Connector consent in Chat
+
+Chat distinguishes active model work from waiting for an approval or response.
+Pending requests appear above the work history. They must remain actionable in
+both canonical Chat and the coding-agent conversation view.
+
+## Protocol and consent
+
+The Codex app-server adapter handles `mcpServer/elicitation/request` explicitly.
+Supported forms include message-only consent, bounded primitive fields (text,
+number, integer, boolean, enumerations and enumeration arrays), and URL-mode
+authorization. Both `openai/form` spellings are accepted. Form answers are
+converted back to their native types and validated before sending a response.
+
+Consent is per request. Nothing is pre-approved and no persistent connector
+grant is created. URL authorization opens only after a user clicks its HTTPS
+link; opening the link does not itself submit consent. The user must confirm
+after completing the external flow, or decline/cancel.
+
+Product limits remain enforced: at most seven form fields plus consent, ten
+options per field, four selected values, and 400 characters/700 UTF-8 bytes per
+answer. Nested/custom schemas outside these supported shapes fail closed with
+a protocol error; they do not leave an unanswered server request. Provider
+metadata, defaults and persistent-grant suggestions are not automatically
+applied. Response values are not copied into chat history or diagnostic logs.
+
+## Ownership and lifecycle
+
+`POST /api/chats/:chatId/runs/:runId/inputs/:requestId` uses the existing gateway
+authentication and owner principal. It validates route identifiers and a
+40-KiB bounded body. The orchestrator checks the exact active owner/chat/run
+and persisted pending request before invoking the provider. The coding-thread
+store validates correlation, question identities and options; the live runner
+is authoritative for outstanding native requests and typed form constraints.
+
+Pending requests are capped and expire after five minutes (swept every thirty
+seconds). Expiry, turn termination and runner shutdown cancel rather than
+approve. Resolution events clear the UI request. Unknown server requests
+receive an explicit unsupported-method response instead of waiting forever.
+
+## Verification
+
+Focused tests cover the runner's real JSON-RPC/control-socket path, typed form
+conversion, explicit consent, expiry, replay, owner isolation, body limits,
+canonical input persistence/submission, and both conversation renderers.
+Run the chat/coding-agent tests plus repository typecheck and pattern checks
+before publication. Runtime and desktop/client delivery must both include the
+change; updating a transport alone does not add missing request handling.

--- a/packages/contracts/src/agent-thread-contracts.ts
+++ b/packages/contracts/src/agent-thread-contracts.ts
@@ -108,6 +108,8 @@ export const UserInputQuestionSchema = z.object({
   options: UserInputOptionListSchema.optional(),
   allowOther: z.boolean().default(false),
   secret: z.boolean().default(false),
+  required: z.boolean().optional(),
+  multiple: z.boolean().optional(),
 }).strict();
 
 const UserInputQuestionListSchema = z.array(UserInputQuestionSchema).min(1).max(8)
@@ -129,6 +131,11 @@ export const UserInputRequestSchema = z.object({
   placeholder: SafeDisplayStringSchema.optional(),
   required: z.boolean().default(true),
   questions: UserInputQuestionListSchema.optional(),
+  connectorActionId: referenceId(128).optional(),
+  connectorUrl: z.url().max(2048).refine((value) => {
+    const url = new URL(value);
+    return url.protocol === "https:" && !url.username && !url.password;
+  }).optional(),
   autoResolutionMs: z.number().int().min(60_000).max(240_000).optional(),
   expiresAt: IsoTimestampSchema.optional(),
   correlationId: CorrelationIdSchema,
@@ -139,6 +146,8 @@ const BaseThreadEventSchema = z.object({
   threadId: ThreadIdSchema,
   occurredAt: IsoTimestampSchema,
 });
+
+export type UserInputRequest = z.infer<typeof UserInputRequestSchema>;
 
 export const AgentTurnLifecycleEventSchema = z.discriminatedUnion("type", [
   BaseThreadEventSchema.extend({

--- a/packages/contracts/src/canonical-chat-api.ts
+++ b/packages/contracts/src/canonical-chat-api.ts
@@ -29,6 +29,18 @@ export const CanonicalChatApiCursorSchema = z.string()
 
 export const CanonicalChatEventCursorSchema = z.number().int().min(0).max(Number.MAX_SAFE_INTEGER);
 
+export const CanonicalSubmitChatInputRequestSchema = z.object({
+  clientRequestId: CanonicalChatRequestIdSchema,
+  answers: z.record(canonicalReferenceId(128), z.array(z.string().min(1).max(400)
+    .refine((value) => new TextEncoder().encode(value).length <= 700)).min(1).max(4))
+    .refine((answers) => Object.keys(answers).length >= 1 && Object.keys(answers).length <= 8),
+}).strict();
+export const CanonicalChatInputSubmissionResponseSchema = z.object({
+  requestId: canonicalReferenceId(128), submission: z.literal("accepted"),
+}).strict();
+export type CanonicalSubmitChatInputRequest = z.infer<typeof CanonicalSubmitChatInputRequestSchema>;
+export type CanonicalChatInputSubmissionResponse = z.infer<typeof CanonicalChatInputSubmissionResponseSchema>;
+
 export const CanonicalChatOutboxEventTypeSchema = z.enum([
   "chat.created",
   "chat.updated",

--- a/packages/contracts/src/canonical-chat.ts
+++ b/packages/contracts/src/canonical-chat.ts
@@ -519,6 +519,7 @@ export const CanonicalChatRunActivitySchema = z.discriminatedUnion("type", [
     type: z.literal("approval.requested"),
     approvalId: canonicalReferenceId(128),
     title: canonicalSafeLabel(160, 640),
+    description: canonicalSafeLabel(1_000, 4_000).optional(),
     risk: z.enum(["low", "medium", "high"]),
     allowedDecisions: z.array(CanonicalChatApprovalDecisionSchema).min(1).max(4),
   }).strict(),

--- a/packages/contracts/src/canonical-chat.ts
+++ b/packages/contracts/src/canonical-chat.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { UserInputRequestSchema } from "#agent-thread-contracts";
 import { IsoTimestampSchema, ProviderModelReferenceSchema } from "#contract-primitives";
 import { MAX_AGENT_ATTACHMENT_BYTES } from "#agent-thread-contracts";
 import {
@@ -530,6 +531,7 @@ export const CanonicalChatRunActivitySchema = z.discriminatedUnion("type", [
     type: z.literal("input.requested"),
     requestId: canonicalReferenceId(128),
     title: canonicalSafeLabel(160, 640),
+    input: UserInputRequestSchema.optional(),
   }).strict(),
   CanonicalChatRunActivityBaseSchema.extend({
     type: z.literal("input.resolved"),

--- a/packages/gateway/src/chat/coding-provider-adapter.ts
+++ b/packages/gateway/src/chat/coding-provider-adapter.ts
@@ -187,6 +187,7 @@ function normalizeEvent(
       type: "approval.requested",
       approvalId: event.approval.approvalId,
       title: event.approval.title,
+      description: event.approval.safeDescription,
       risk: event.approval.risk,
       allowedDecisions: event.approval.allowedDecisions,
     })];

--- a/packages/gateway/src/chat/coding-provider-adapter.ts
+++ b/packages/gateway/src/chat/coding-provider-adapter.ts
@@ -29,7 +29,7 @@ const MAX_ACTIVE_STEER_RUNS = 64;
 
 type CodingThreads = Pick<
   CodingAgentThreadStore & CodingAgentTurnStore,
-  "createThread" | "acceptTurn" | "steerTurn" | "getThread" | "abortThread" | "submitApproval" | "registerEventSink"
+  "createThread" | "acceptTurn" | "steerTurn" | "getThread" | "abortThread" | "submitApproval" | "submitInput" | "registerEventSink"
 >;
 
 type CodingState = { conversationId: string; providerThreadId?: string };
@@ -201,7 +201,11 @@ function normalizeEvent(
   if (event.type === "user_input.requested") {
     return [CanonicalProviderRunEventSchema.parse({
       type: "input.requested", requestId: event.request.requestId, title: event.request.title,
+      input: event.request,
     })];
+  }
+  if (event.type === "user_input.answered") {
+    return [CanonicalProviderRunEventSchema.parse({ type: "input.resolved", requestId: event.requestId })];
   }
   if (event.type === "thread.error") {
     return [CanonicalProviderRunEventSchema.parse({
@@ -553,6 +557,21 @@ export function createCanonicalCodingChatProviderAdapter(options: {
         input.approvalId,
         { decision: input.decision, clientRequestId: input.clientRequestId, correlationId },
       );
+    },
+    async submitInput(input) {
+      if (!input.state) throw new Error("Input state unavailable");
+      const state = CodingAgentProviderResumeStateSchema.parse(input.state);
+      const current = await options.threads.getThread(principal(input.owner.ownerId), state.conversationId);
+      let pending: Extract<AgentThreadEvent, { type: "user_input.requested" }> | undefined;
+      for (const event of current.events.items) {
+        if (event.type === "user_input.requested" && event.request.requestId === input.requestId) pending = event;
+        if (event.type === "user_input.answered" && event.requestId === input.requestId) pending = undefined;
+      }
+      if (!pending) throw new Error("Input request unavailable");
+      await options.threads.submitInput(principal(input.owner.ownerId), state.conversationId, input.requestId, {
+        answer: "Structured response submitted.", structuredAnswers: input.answers,
+        clientRequestId: input.clientRequestId, correlationId: pending.request.correlationId,
+      });
     },
   };
 }

--- a/packages/gateway/src/chat/input-submission.ts
+++ b/packages/gateway/src/chat/input-submission.ts
@@ -1,0 +1,30 @@
+import {
+  CanonicalSubmitChatInputRequestSchema,
+  type CanonicalSubmitChatInputRequest,
+  type CanonicalChatInputSubmissionResponse,
+} from "@matrix-os/contracts";
+import type { ChatOwner } from "./records.js";
+import type { ChatRepository } from "./repository.js";
+import type { CanonicalChatProviderAdapter } from "./provider-adapter.js";
+
+export async function submitCanonicalInput(options: {
+  repository: Pick<ChatRepository, "getPendingInput" | "getAdapterState">;
+  active?: { chatId: string; owner: ChatOwner; adapter: CanonicalChatProviderAdapter; instanceId: string };
+  unavailable(): Error;
+}, owner: ChatOwner, chatId: string, runId: string, requestId: string,
+inputValue: CanonicalSubmitChatInputRequest): Promise<CanonicalChatInputSubmissionResponse> {
+  const input = CanonicalSubmitChatInputRequestSchema.parse(inputValue);
+  const active = options.active;
+  if (!active || active.chatId !== chatId || active.owner.type !== owner.type
+    || active.owner.ownerId !== owner.ownerId || !active.adapter.submitInput) throw options.unavailable();
+  const pending = await options.repository.getPendingInput(owner, { chatId, runId, requestId });
+  if (!pending?.input) throw options.unavailable();
+  const state = await options.repository.getAdapterState(owner, {
+    runId, driverKind: active.adapter.driverKind, instanceId: active.instanceId,
+  });
+  await active.adapter.submitInput({ owner, chatId, runId, requestId, answers: input.answers,
+    clientRequestId: input.clientRequestId,
+    ...(state ? { state: active.adapter.parseState(state.state) } : {}),
+  });
+  return { requestId, submission: "accepted" };
+}

--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -1,4 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
+import { submitCanonicalInput } from "./input-submission.js";
+import type { CanonicalSubmitChatInputRequest } from "@matrix-os/contracts";
 import {
   CanonicalChatMessageSchema,
   CanonicalChatRunActivitySchema,
@@ -277,6 +279,7 @@ export class CanonicalChatOrchestrator {
       | "finishRun"
       | "getAdapterState"
       | "getPendingApproval"
+      | "getPendingInput"
       | "getLatestAdapterStateForChat"
       | "getTurnRunContext"
       | "admitRetry"
@@ -1289,6 +1292,12 @@ export class CanonicalChatOrchestrator {
       );
     }
     return { approvalId, decision: input.decision, submission: "accepted" };
+  }
+
+  async submitInput(owner: ChatOwner, chatId: string, runId: string, requestId: string, input: CanonicalSubmitChatInputRequest) {
+    return submitCanonicalInput({ repository: this.options.repository, active: this.active.get(runId),
+      unavailable: () => new CanonicalChatOrchestrationError(safeError("capability_mismatch", "This input request is no longer available."), 409),
+    }, owner, chatId, runId, requestId, input);
   }
 
   async reconcileActiveRuns(owner: ChatOwner): Promise<number> {

--- a/packages/gateway/src/chat/provider-adapter.ts
+++ b/packages/gateway/src/chat/provider-adapter.ts
@@ -65,6 +65,7 @@ export const CanonicalProviderRunEventSchema = z.discriminatedUnion("type", [
     type: z.literal("approval.requested"),
     approvalId: SafeProviderRefSchema,
     title: z.string().trim().min(1).max(160),
+    description: z.string().trim().min(1).max(1_000).optional(),
     risk: z.enum(["low", "medium", "high"]),
     allowedDecisions: z.array(CanonicalChatApprovalDecisionSchema).min(1).max(4),
   }).strict(),

--- a/packages/gateway/src/chat/provider-adapter.ts
+++ b/packages/gateway/src/chat/provider-adapter.ts
@@ -1,5 +1,7 @@
 import {
   CanonicalChatAgentActivityPayloadSchema,
+  UserInputRequestSchema,
+  type UserInputAnswerRequest,
   CanonicalChatApprovalDecisionSchema,
   CanonicalChatMessagePartSchema,
   CanonicalChatModelSelectionSchema,
@@ -75,7 +77,9 @@ export const CanonicalProviderRunEventSchema = z.discriminatedUnion("type", [
     type: z.literal("input.requested"),
     requestId: SafeProviderRefSchema,
     title: z.string().trim().min(1).max(160),
+    input: UserInputRequestSchema.optional(),
   }).strict(),
+  z.object({ type: z.literal("input.resolved"), requestId: SafeProviderRefSchema }).strict(),
   z.object({ type: z.literal("state.updated"), state: z.unknown() }).strict(),
   z.object({
     type: z.literal("run.completed"),
@@ -131,6 +135,11 @@ export interface CanonicalChatProviderAdapter<State = unknown> {
     decision: CanonicalChatApprovalDecision;
     clientRequestId: string;
     state?: State;
+  }): Promise<void>;
+  submitInput?(input: {
+    owner: CanonicalOwnerScope; chatId: string; runId: string; requestId: string;
+    answers: NonNullable<UserInputAnswerRequest["structuredAnswers"]>;
+    clientRequestId: string; state?: State;
   }): Promise<void>;
 }
 

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -1275,6 +1275,10 @@ export class ChatRepository {
     return this.runLifecycle.getPendingApproval(ownerInput, input);
   }
 
+  async getPendingInput(owner: ChatOwner, input: { chatId: string; runId: string; requestId: string }) {
+    return this.runLifecycle.getPendingInput(owner, input);
+  }
+
   async getLatestAdapterStateForChat(ownerInput: ChatOwner, input: {
     chatId: string;
     driverKind: string;

--- a/packages/gateway/src/chat/routes.ts
+++ b/packages/gateway/src/chat/routes.ts
@@ -1,4 +1,8 @@
 import {
+  CanonicalSubmitChatInputRequestSchema,
+  CanonicalChatInputSubmissionResponseSchema,
+  type CanonicalSubmitChatInputRequest,
+  type CanonicalChatInputSubmissionResponse,
   CanonicalAcknowledgeChatCompletionRequestSchema,
   CanonicalCancelChatRunRequestSchema,
   CanonicalCancelQueuedChatTurnRequestSchema,
@@ -201,6 +205,8 @@ export interface CanonicalChatRouteService {
     approvalId: string,
     input: CanonicalSubmitChatApprovalRequest,
   ): Promise<CanonicalChatApprovalSubmissionResponse>;
+  submitInput(owner: ChatOwner, chatId: string, runId: string, requestId: string,
+    input: CanonicalSubmitChatInputRequest): Promise<CanonicalChatInputSubmissionResponse>;
   retryTurn(
     principal: RequestPrincipal,
     owner: ChatOwner,
@@ -655,6 +661,17 @@ export function createCanonicalChatRoutes(options: {
     } catch (error: unknown) {
       return handleError(context, error);
     }
+  });
+
+  routes.post("/api/chats/:chatId/runs/:runId/inputs/:requestId", bodyLimit({ maxSize: 40 * 1024 }), async (context) => {
+    try {
+      const chatId = CanonicalChatIdSchema.parse(context.req.param("chatId"));
+      const runId = CanonicalChatRunIdSchema.parse(context.req.param("runId"));
+      const requestId = z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/).parse(context.req.param("requestId"));
+      const input = CanonicalSubmitChatInputRequestSchema.parse(await context.req.json());
+      const result = await options.service.submitInput(ownerFromPrincipal(options.getPrincipal(context)), chatId, runId, requestId, input);
+      return context.json(CanonicalChatInputSubmissionResponseSchema.parse(result));
+    } catch (error: unknown) { return handleError(context, error); }
   });
 
   routes.post("/api/chats/:chatId/turns/:turnId/runs", cancelBodyLimit, async (context) => {

--- a/packages/gateway/src/chat/run-lifecycle-repository.ts
+++ b/packages/gateway/src/chat/run-lifecycle-repository.ts
@@ -200,6 +200,25 @@ export class ChatRunLifecycleRepository {
     return pending;
   }
 
+  async getPendingInput(ownerInput: ChatOwner, input: { chatId: string; runId: string; requestId: string }): Promise<Extract<CanonicalChatRunActivity, { type: "input.requested" }> | null> {
+    const owner = validateOwner(ownerInput);
+    const chatId = CanonicalChatIdSchema.parse(input.chatId);
+    [input.runId, input.requestId].forEach(requireSafeRef);
+    const row = await this.kysely.selectFrom("chat_run_events")
+      .innerJoin("chat_runs", "chat_runs.id", "chat_run_events.run_id")
+      .innerJoin("chats", "chats.id", "chat_runs.chat_id")
+      .select("chat_run_events.event")
+      .where("chats.owner_type", "=", owner.type).where("chats.owner_id", "=", owner.ownerId)
+      .where("chat_runs.chat_id", "=", chatId).where("chat_runs.id", "=", input.runId)
+      .where("chat_runs.status", "in", [...ACTIVE_RUNS])
+      .where(sql<string>`chat_run_events.event->>'requestId'`, "=", input.requestId)
+      .where(sql<string>`chat_run_events.event->>'type'`, "in", ["input.requested", "input.resolved"])
+      .orderBy("chat_run_events.run_seq", "desc").limit(1).executeTakeFirst();
+    if (!row) return null;
+    const event = CanonicalChatRunActivitySchema.parse(row.event);
+    return event.type === "input.requested" ? event : null;
+  }
+
   async markRunRunning(ownerInput: ChatOwner, input: {
     chatId: string;
     runId: string;

--- a/packages/gateway/src/chat/service.ts
+++ b/packages/gateway/src/chat/service.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
+  CanonicalSubmitChatInputRequestSchema,
+  type CanonicalSubmitChatInputRequest,
   CanonicalChatApiCursorSchema,
   CanonicalChatDetailResponseSchema,
   CanonicalChatIdSchema,
@@ -132,7 +134,7 @@ export function createCanonicalChatService(
   repository: ChatServiceRepository,
   options: {
     orchestrator?: Pick<CanonicalChatOrchestrator,
-      "admitTurn" | "enqueueQueuedTurn" | "steerRun" | "steerQueuedTurn" | "cancelRun" | "submitApproval" | "retryTurn"
+      "admitTurn" | "enqueueQueuedTurn" | "steerRun" | "steerQueuedTurn" | "cancelRun" | "submitApproval" | "submitInput" | "retryTurn"
     >;
     executionRoots?: Pick<ChatExecutionRootResolver, "resolve">;
   } = {},
@@ -430,6 +432,10 @@ export function createCanonicalChatService(
         CanonicalSubmitChatApprovalRequestSchema.parse(input),
       );
     },
+    async submitInput(owner: ChatOwner, chatId: string, runId: string, requestId: string, input: CanonicalSubmitChatInputRequest) {
+      if (!options.orchestrator) throw new Error("Canonical Chat orchestration unavailable");
+      return options.orchestrator.submitInput(owner, CanonicalChatIdSchema.parse(chatId), CanonicalChatRunIdSchema.parse(runId), requestId, CanonicalSubmitChatInputRequestSchema.parse(input));
+    },
 
     async retryTurn(
       principal: RequestPrincipal,
@@ -475,6 +481,7 @@ export function createUnavailableCanonicalChatService(): CanonicalChatRouteServi
     steerRun: unavailable,
     cancelRun: unavailable,
     submitApproval: unavailable,
+    submitInput: unavailable,
     retryTurn: unavailable,
   };
 }

--- a/packages/gateway/src/coding-agents/codex-app-server-contract.json
+++ b/packages/gateway/src/coding-agents/codex-app-server-contract.json
@@ -65,7 +65,8 @@
     "item/commandExecution/requestApproval",
     "item/fileChange/requestApproval",
     "item/tool/requestUserInput",
-    "item/permissions/requestApproval"
+    "item/permissions/requestApproval",
+    "mcpServer/elicitation/request"
   ],
   "requiredServerNotifications": [
     "item/started",
@@ -76,6 +77,7 @@
     "turn/completed"
   ],
   "requiredServerProtocolSchemaDigests": {
+    "mcpServer/elicitation/request": "7db52750b4b1e97486c99734d8a785fa3b112b29908458e3b166c6d6aa9bfecf",
     "item/commandExecution/requestApproval": {
       "schemaSha256ByTarget": {
         "darwin-arm64": "ef803ac64161397389bc35428803c3ec8dcc94757c93d758a9fdf0ae6b5a944f",

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -9,6 +9,8 @@ import { StringDecoder } from "node:string_decoder";
 import { z } from "zod/v4";
 import { assertCodexProviderVersion } from "./codex-provider-version-check.mjs";
 import { createCodexSessionApprovalGrants } from "./codex-session-approvals.mjs";
+import { createConnectorRequests } from "./codex-connector-requests.mjs";
+import { expireNativeRequests } from "./codex-request-expiry.mjs";
 
 process.on("uncaughtException", () => {
   process.stderr.write("Codex app-server runner stopped unexpectedly.\n");
@@ -716,6 +718,7 @@ async function handleInput(raw) {
   });
   pendingInputs.set(identity.requestId, {
     nativeRequestId: parsed.data.id,
+    correlationId: identity.correlationId,
     questions: questions.map((question, index) => ({
       questionId: question.questionId,
       nativeQuestionId: parsed.data.params.questions[index].id,
@@ -805,6 +808,7 @@ async function handleProviderMessage(raw) {
   }
   if (await handleApproval(raw)) return;
   if (await handleInput(raw)) return;
+  if (await connectorRequests.handle(raw)) return;
   if (await handleItemLifecycle(raw)) return;
   const outputDelta = ToolOutputDeltaSchema.safeParse(raw);
   if (outputDelta.success) {
@@ -963,18 +967,22 @@ async function applyControl(control) {
     pendingApprovals.delete(control.approvalId);
   } else {
     const pending = pendingInputs.get(control.requestId);
-    if (!pending) return { ok: false };
-    const expected = new Set(pending.questions.map((question) => question.questionId));
-    const provided = Object.keys(control.structuredAnswers);
-    if (provided.length !== expected.size || provided.some((questionId) => !expected.has(questionId))) {
-      return { ok: false };
+    const handled = connectorRequests.answer(control.requestId, control.structuredAnswers);
+    if (handled === false) return { ok: false };
+    if (handled === undefined) {
+      if (!pending) return { ok: false };
+      const expected = new Set(pending.questions.map((question) => question.questionId));
+      const provided = Object.keys(control.structuredAnswers);
+      if (provided.length !== expected.size || provided.some((questionId) => !expected.has(questionId))) {
+        return { ok: false };
+      }
+      const answers = Object.fromEntries(pending.questions.map((question) => [
+        question.nativeQuestionId,
+        { answers: control.structuredAnswers[question.questionId] },
+      ]));
+      sendProvider({ id: pending.nativeRequestId, result: { answers } });
+      pendingInputs.delete(control.requestId);
     }
-    const answers = Object.fromEntries(pending.questions.map((question) => [
-      question.nativeQuestionId,
-      { answers: control.structuredAnswers[question.questionId] },
-    ]));
-    sendProvider({ id: pending.nativeRequestId, result: { answers } });
-    pendingInputs.delete(control.requestId);
   }
   if (completedControls.size >= MAX_COMPLETED_REQUESTS) {
     const oldest = completedControls.keys().next().value;
@@ -1025,18 +1033,22 @@ await new Promise((resolve, reject) => {
 });
 await chmod(controlPath, 0o600);
 
+const connectorRequests = createConnectorRequests({
+  send: sendProvider, persist, safeText: safeExternalText,
+  scope: () => ({ threadId: nativeThreadId, turnId: activeNativeTurnId }),
+});
+async function expireRequests(all = false, reply = true) {
+  await Promise.all([
+    connectorRequests.expire(all, reply),
+    expireNativeRequests({ approvals: pendingApprovals, inputs: pendingInputs, send: sendProvider, persist, now: Date.now(), all, reply }),
+  ]);
+}
 const cleanupTimer = setInterval(() => {
+  void expireRequests().catch(() => {
+    console.warn("[coding-agents] request expiry failed");
+    stop();
+  });
   const now = Date.now();
-  for (const [approvalId, pending] of pendingApprovals) {
-    if (pending.expiresAt > now) continue;
-    pendingApprovals.delete(approvalId);
-    try { sendProvider({ id: pending.nativeRequestId, result: { decision: "cancel" } }); } catch (_error) { stopping = true; }
-  }
-  for (const [requestId, pending] of pendingInputs) {
-    if (pending.expiresAt > now) continue;
-    pendingInputs.delete(requestId);
-    try { sendProvider({ id: pending.nativeRequestId, result: { answers: {} } }); } catch (_error) { stopping = true; }
-  }
   for (const [requestId, completed] of completedControls) {
     if (completed.expiresAt <= now) completedControls.delete(requestId);
   }
@@ -1135,12 +1147,16 @@ function stop() {
   input.close();
   wakeTurn?.();
   wakeTurn = undefined;
-  child.kill("SIGTERM");
+  void expireRequests(true).catch(() => {
+    console.warn("[coding-agents] shutdown request cleanup failed");
+  }).finally(() => child.kill("SIGTERM"));
   stopTimer = setTimeout(() => child.kill("SIGKILL"), PROVIDER_STOP_TIMEOUT_MS);
   stopTimer.unref();
 }
 
 async function finishTurn(outcome) {
+  // The native turn is terminal: clear stale controls, but never write into its closing pipe.
+  await expireRequests(true, false);
   const hasUnsettledItems = assistantItemsWithDelta.size > 0 ||
     assistantDeltaBuffers.size > 0 ||
     startedToolItems.size > 0 ||

--- a/packages/gateway/src/coding-agents/codex-connector-requests.mjs
+++ b/packages/gateway/src/coding-agents/codex-connector-requests.mjs
@@ -1,0 +1,69 @@
+import { z } from "zod/v4";
+import { compileElicitation } from "./codex-elicitation.mjs";
+import { cancel } from "./codex-request-expiry.mjs";
+
+const Envelope = z.object({ id: z.union([z.string().min(1).max(128), z.number().int().safe()]), method: z.string().min(1).max(160) });
+
+/** Bounded pending consent. Unknown server requests always receive a JSON-RPC error. */
+export function createConnectorRequests({ send, persist, safeText, scope, now = Date.now }) {
+  const pending = new Map(); // Cap 20; five-minute expiry and explicit turn/shutdown drain.
+  return {
+    async handle(raw) {
+      const envelope = Envelope.safeParse(raw);
+      if (!envelope.success) return false;
+      const { id, method } = envelope.data;
+      if (method !== "mcpServer/elicitation/request") {
+        send({ id, error: { code: -32601, message: "This request is not supported." } });
+        return true;
+      }
+      let form;
+      const current = scope();
+      try { form = compileElicitation(raw, safeText, current.turnId); }
+      catch (error) {
+        if (!(error instanceof Error)) throw error;
+        console.warn("[coding-agents] unsupported connector request");
+        send({ id, error: { code: -32602, message: "This connector form is not supported." } });
+        return true;
+      }
+      if (pending.has(form.requestId)) return true;
+      if (!current.turnId || form.threadId !== current.threadId || (form.turnId && form.turnId !== current.turnId)
+        || pending.size >= 20) {
+        send({ id, result: { action: "cancel", content: null, _meta: null } });
+        return true;
+      }
+      pending.set(form.requestId, { id, form, expiresAt: now() + 300_000 });
+      try {
+        await persist({ type: "matrix.codex.user_input.requested", requestId: form.requestId,
+          correlationId: form.correlationId, title: "Connector request", safeDescription: "Review this connector request before continuing.",
+          questions: form.questions, required: false, connectorActionId: form.actionId,
+          ...(form.connectorUrl ? { connectorUrl: form.connectorUrl } : {}),
+        });
+      } catch (error) {
+        pending.delete(form.requestId);
+        send({ id, result: { action: "cancel", content: null, _meta: null } });
+        throw error;
+      }
+      return true;
+    },
+    answer(requestId, answers) {
+      const entry = pending.get(requestId);
+      if (!entry) return undefined;
+      if (entry.expiresAt <= now()) return false;
+      const result = entry.form.respond(answers);
+      if (!result) return false;
+      send({ id: entry.id, result });
+      pending.delete(requestId);
+      return true;
+    },
+    async expire(all = false, reply = true) {
+      const events = [];
+      for (const [requestId, entry] of pending) {
+        if (!all && entry.expiresAt > now()) continue;
+        pending.delete(requestId);
+        if (reply) cancel(send, { id: entry.id, result: { action: "cancel", content: null, _meta: null } });
+        events.push({ type: "matrix.codex.user_input.resolved", requestId, correlationId: entry.form.correlationId });
+      }
+      for (const event of events) await persist(event);
+    },
+  };
+}

--- a/packages/gateway/src/coding-agents/codex-elicitation.mjs
+++ b/packages/gateway/src/coding-agents/codex-elicitation.mjs
@@ -1,0 +1,135 @@
+import { createHash } from "node:crypto";
+import { z } from "zod/v4";
+
+const Request = z.object({
+  id: z.union([z.string().min(1).max(128), z.number().int().safe()]),
+  method: z.literal("mcpServer/elicitation/request"),
+  params: z.object({
+    threadId: z.string().min(1).max(512),
+    turnId: z.string().max(512).nullish(),
+    serverName: z.string().min(1).max(128),
+    mode: z.enum(["form", "openai/form", "openaiForm", "url"]),
+    message: z.string().max(2400),
+    requestedSchema: z.unknown().optional(),
+    url: z.string().max(2048).optional(),
+    elicitationId: z.string().min(1).max(512).optional(),
+  }),
+});
+
+const Text = z.string().max(2400);
+const Choices = z.array(z.string().max(700)).min(1).max(10);
+const TitledChoices = z.array(z.object({ const: z.string().max(700), title: Text }).strict()).min(1).max(10);
+const Field = z.object({
+  type: z.enum(["string", "number", "integer", "boolean", "array"]),
+  title: Text.nullish(), description: Text.nullish(), default: z.unknown().optional(),
+  enum: Choices.optional(), enumNames: z.array(Text).max(10).nullish(), oneOf: TitledChoices.optional(),
+  items: z.object({ type: z.literal("string").optional(), enum: Choices.optional(), anyOf: TitledChoices.optional() }).strict().optional(),
+  minimum: z.number().finite().nullish(), maximum: z.number().finite().nullish(),
+  minLength: z.number().int().nonnegative().nullish(), maxLength: z.number().int().nonnegative().nullish(),
+  minItems: z.number().int().nonnegative().nullish(), maxItems: z.number().int().nonnegative().nullish(),
+  format: z.enum(["email", "uri", "date", "date-time"]).nullish(),
+}).strict().refine((field) => {
+  const permitted = {
+    string: ["enum", "enumNames", "oneOf", "minLength", "maxLength", "format"],
+    number: ["minimum", "maximum"], integer: ["minimum", "maximum"],
+    boolean: [], array: ["items", "minItems", "maxItems"],
+  };
+  return Object.keys(field).every((key) => ["type", "title", "description", "default", ...permitted[field.type]].includes(key));
+});
+const Form = z.object({
+  type: z.literal("object"), properties: z.record(z.string().min(1).max(128), Field)
+    .refine((fields) => Object.keys(fields).length <= 7),
+  required: z.array(z.string().min(1).max(128)).max(7).nullish(),
+  $schema: Text.nullish(), additionalProperties: z.literal(false).optional(),
+}).strict();
+
+function compileField(name, field, index, digest, required, safeText) {
+  const questionId = `question_codex_${createHash("sha256").update(`${digest}:${index}`).digest("hex").slice(0, 24)}`;
+  const enumValues = field.type === "array" ? field.items?.enum : field.enum;
+  const titled = field.type === "array" ? field.items?.anyOf : field.oneOf;
+  if (field.type === "array" && !enumValues && !titled) throw new Error("Unsupported array form");
+  const values = field.type === "boolean" ? [true, false] : titled?.map((entry) => entry.const) ?? enumValues;
+  const labels = values?.map((value, i) => field.type === "boolean" ? (value ? "True" : "False")
+    : `${i + 1}. ${safeText(titled?.[i]?.title ?? field.enumNames?.[i] ?? String(value), `Option ${i + 1}`, 100, 400)}`);
+  const options = labels?.map((label) => ({ label, description: "Choose this value." }));
+  const question = {
+    questionId, header: safeText(field.title ?? name, `Field ${index + 1}`, 120, 512),
+    question: safeText(field.description ?? field.title ?? name, `Field ${index + 1}`, 600, 2400),
+    ...(options ? { options } : {}), allowOther: false, secret: true,
+    required, multiple: field.type === "array",
+  };
+  return { name, question, parse(answers) {
+    if (!answers || answers.length === 0 || (answers.length === 1 && answers[0] === "")) {
+      if (required) throw new Error("Required field");
+      return undefined;
+    }
+    if (field.type !== "array" && answers.length !== 1) throw new Error("Expected one value");
+    if (new Set(answers).size !== answers.length) throw new Error("Duplicate values");
+    let value;
+    if (values) {
+      const selected = answers.map((answer) => {
+        const i = labels.indexOf(answer);
+        if (i < 0) throw new Error("Unknown choice");
+        return values[i];
+      });
+      value = field.type === "array" ? selected : selected[0];
+    } else if (field.type === "number" || field.type === "integer") {
+      if (!/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(answers[0])) throw new Error("Invalid number");
+      value = Number(answers[0]);
+      if (!Number.isFinite(value) || (field.type === "integer" && !Number.isSafeInteger(value))) throw new Error("Invalid number");
+    } else value = answers[0];
+    if (typeof value === "number" && ((field.minimum != null && value < field.minimum) || (field.maximum != null && value > field.maximum))) throw new Error("Number out of range");
+    if (typeof value === "string") {
+      const length = [...value].length;
+      if ((field.minLength != null && length < field.minLength) || (field.maxLength != null && length > field.maxLength)) throw new Error("Text length out of range");
+      const formats = { email: z.email(), uri: z.url(), date: z.iso.date(), "date-time": z.iso.datetime({ offset: true }) };
+      if (field.format && !formats[field.format].safeParse(value).success) throw new Error("Invalid format");
+    }
+    if (Array.isArray(value) && ((field.minItems != null && value.length < field.minItems) || (field.maxItems != null && value.length > field.maxItems))) throw new Error("Selection count out of range");
+    return value;
+  } };
+}
+
+/** Plain-Node boundary: no provider schema, field names or metadata become control IDs. */
+export function compileElicitation(raw, safeText, activeTurnId) {
+  const { id, params } = Request.parse(raw);
+  const digest = createHash("sha256").update(JSON.stringify(["connector", params.threadId, params.turnId ?? activeTurnId, params.serverName, id])).digest("hex").slice(0, 32);
+  const actionId = `question_codex_${digest.slice(0, 24)}`;
+  let connectorUrl;
+  if (params.mode === "url") {
+    const url = new URL(params.url);
+    if (!params.elicitationId || url.protocol !== "https:" || url.username || url.password
+      || !url.hostname.includes(".") || /(?:^|\.)(?:localhost|local|internal)$/.test(url.hostname)
+      || /^[\d.]+$/.test(url.hostname) || url.hostname.includes(":")) throw new Error("Unsafe connector URL");
+    connectorUrl = url.href;
+  }
+  const schema = Form.parse(params.mode === "url" ? { type: "object", properties: {} } : params.requestedSchema ?? { type: "object", properties: {} });
+  if (schema.required?.some((key) => !Object.hasOwn(schema.properties, key))) throw new Error("Unknown required field");
+  const fields = Object.entries(schema.properties).map(([name, field], index) => compileField(name, field, index, digest, schema.required?.includes(name) ?? false, safeText));
+  return {
+    threadId: params.threadId,
+    turnId: params.turnId,
+    requestId: `req_codex_${digest}`,
+    correlationId: `corr_codex_${digest}`,
+    actionId,
+    ...(connectorUrl ? { connectorUrl } : {}),
+    questions: [...fields.map((field) => field.question), { questionId: actionId, header: "Connector permission", question: safeText(params.message, "Allow this connector request?", 600, 2400),
+      options: ["Allow once", "Decline", "Cancel"].map((label) => ({ label, description: label })), allowOther: false, secret: false }],
+    respond(answers) {
+      if (Object.keys(answers).some((key) => key !== actionId && !fields.some((field) => field.question.questionId === key)) || answers[actionId]?.length !== 1) return null;
+      const choice = answers[actionId][0];
+      const action = choice === "Allow once" ? "accept" : choice === "Decline" ? "decline" : choice === "Cancel" ? "cancel" : undefined;
+      if (!action) return null;
+      if (action !== "accept") return { action, content: null, _meta: null };
+      try {
+        const content = Object.fromEntries(fields.map((field) => [field.name, field.parse(answers[field.question.questionId])]).filter(([, value]) => value !== undefined));
+        return { action, content: connectorUrl ? null : content, _meta: null };
+      } catch (error) {
+        if (!(error instanceof Error)) throw error;
+        // The parser above performs only bounded, synchronous validation.
+        console.warn("[coding-agents] invalid connector form answer");
+        return null;
+      }
+    },
+  };
+}

--- a/packages/gateway/src/coding-agents/codex-elicitation.mjs
+++ b/packages/gateway/src/coding-agents/codex-elicitation.mjs
@@ -44,11 +44,18 @@ const Form = z.object({
 }).strict();
 
 function compileField(name, field, index, digest, required, safeText) {
+  if ((field.minLength ?? 0) > Math.min(field.maxLength ?? 400, 400) || field.maxLength === 0
+    || (field.minItems ?? 0) > Math.min(field.maxItems ?? 4, 4) || field.maxItems === 0
+    || (field.minimum != null && field.maximum != null && field.minimum > field.maximum)
+    || (field.type === "integer" && Math.ceil(field.minimum ?? -Number.MAX_SAFE_INTEGER) > Math.floor(field.maximum ?? Number.MAX_SAFE_INTEGER))) {
+    throw new Error("Unrepresentable form constraints");
+  }
   const questionId = `question_codex_${createHash("sha256").update(`${digest}:${index}`).digest("hex").slice(0, 24)}`;
   const enumValues = field.type === "array" ? field.items?.enum : field.enum;
   const titled = field.type === "array" ? field.items?.anyOf : field.oneOf;
   if (field.type === "array" && !enumValues && !titled) throw new Error("Unsupported array form");
   const values = field.type === "boolean" ? [true, false] : titled?.map((entry) => entry.const) ?? enumValues;
+  if (field.type === "array" && (field.minItems ?? 0) > new Set(values).size) throw new Error("Unrepresentable selection count");
   const labels = values?.map((value, i) => field.type === "boolean" ? (value ? "True" : "False")
     : `${i + 1}. ${safeText(titled?.[i]?.title ?? field.enumNames?.[i] ?? String(value), `Option ${i + 1}`, 100, 400)}`);
   const options = labels?.map((label) => ({ label, description: "Choose this value." }));

--- a/packages/gateway/src/coding-agents/codex-events.ts
+++ b/packages/gateway/src/coding-agents/codex-events.ts
@@ -99,6 +99,9 @@ const CodexExecEventSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("error") }).passthrough(),
 ]);
 const MatrixCodexRecordSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("matrix.codex.approval.resolved"), approvalId: ApprovalIdSchema,
+    decision: z.literal("cancel"),
+  }).strict(),
   z.object({
     type: z.literal("matrix.codex.approval.requested"),
     approvalId: ApprovalIdSchema,
@@ -117,7 +120,15 @@ const MatrixCodexRecordSchema = z.discriminatedUnion("type", [
     title: SafeDisplayStringSchema,
     safeDescription: SafeDisplayStringSchema,
     questions: z.array(UserInputQuestionSchema).min(1).max(8),
+    required: z.boolean().optional(),
+    connectorActionId: z.string().min(1).max(128).optional(),
+    connectorUrl: z.url().max(2048).optional(),
     autoResolutionMs: z.number().int().min(60_000).max(240_000).optional(),
+  }).strict(),
+  z.object({
+    type: z.literal("matrix.codex.user_input.resolved"),
+    requestId: RequestIdSchema,
+    correlationId: CorrelationIdSchema,
   }).strict(),
   z.object({
     type: z.literal("matrix.codex.assistant.delta"),
@@ -214,6 +225,12 @@ function appServerRecordEvents(
   context: CodexEventContext,
   record: z.infer<typeof MatrixCodexRecordSchema>,
 ): AgentThreadEvent[] {
+  if (record.type === "matrix.codex.user_input.resolved") {
+    return [event(context, { type: "user_input.answered", requestId: record.requestId, correlationId: record.correlationId })];
+  }
+  if (record.type === "matrix.codex.approval.resolved") {
+    return [event(context, { type: "approval.resolved", approvalId: record.approvalId, decision: record.decision })];
+  }
   if (record.type === "matrix.codex.approval.requested") {
     return [event(context, {
       type: "approval.requested",
@@ -237,8 +254,10 @@ function appServerRecordEvents(
         threadId: context.threadId,
         title: record.title,
         safeDescription: record.safeDescription,
-        required: true,
+        required: record.required ?? true,
         questions: record.questions,
+        ...(record.connectorActionId ? { connectorActionId: record.connectorActionId } : {}),
+        ...(record.connectorUrl ? { connectorUrl: record.connectorUrl } : {}),
         ...(record.autoResolutionMs ? { autoResolutionMs: record.autoResolutionMs } : {}),
         correlationId: record.correlationId,
       },

--- a/packages/gateway/src/coding-agents/codex-request-expiry.mjs
+++ b/packages/gateway/src/coding-agents/codex-request-expiry.mjs
@@ -1,0 +1,25 @@
+/** Remove ownership before emitting any asynchronous resolution. Never grant on expiry. */
+export async function expireNativeRequests({ approvals, inputs, send, persist, now, all = false, reply = true }) {
+  const events = [];
+  for (const [approvalId, entry] of approvals) {
+    if (!all && entry.expiresAt > now) continue;
+    approvals.delete(approvalId);
+    if (reply) cancel(send, { id: entry.nativeRequestId, result: { decision: "cancel" } });
+    events.push({ type: "matrix.codex.approval.resolved", approvalId, decision: "cancel" });
+  }
+  for (const [requestId, entry] of inputs) {
+    if (!all && entry.expiresAt > now) continue;
+    inputs.delete(requestId);
+    if (reply) cancel(send, { id: entry.nativeRequestId, result: { answers: {} } });
+    events.push({ type: "matrix.codex.user_input.resolved", requestId, correlationId: entry.correlationId });
+  }
+  for (const event of events) await persist(event);
+}
+
+export function cancel(send, response) {
+  try { send(response); }
+  catch (error) {
+    if (!(error instanceof Error)) throw error;
+    console.warn("[coding-agents] cancellation transport unavailable");
+  }
+}

--- a/tests/contracts/chat-input-payload.test.ts
+++ b/tests/contracts/chat-input-payload.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { CanonicalChatRunActivitySchema } from "../../packages/contracts/src/index.js";
+import { CanonicalProviderRunEventSchema } from "../../packages/gateway/src/chat/provider-adapter.js";
+
+describe("canonical structured input", () => {
+  it("preserves the complete form between provider and chat activity", () => {
+    const input = { type: "input.requested", requestId: "req_question", title: "Connector request",
+      input: { requestId: "req_question", threadId: "thread_question", title: "Connector request", safeDescription: "Review this request.",
+        required: false, connectorActionId: "question_action", correlationId: "corr_question",
+        questions: [{ questionId: "question_action", header: "Permission", question: "Allow once?", options: [{ label: "Allow once", description: "Run once." }], allowOther: false, secret: false }] } };
+    expect(CanonicalProviderRunEventSchema.parse(input)).toEqual(input);
+    expect(CanonicalChatRunActivitySchema.parse({ ...input, id: "activity_question", runId: "run_question", chatId: "chat_question", occurredAt: "2026-09-07T00:00:00.000Z" })).toMatchObject({ input: input.input });
+  });
+});

--- a/tests/gateway/chat-coding-provider.test.ts
+++ b/tests/gateway/chat-coding-provider.test.ts
@@ -86,6 +86,7 @@ function fakeStore(initialEvents: AgentThreadEvent[]) {
   const abortThread = vi.fn(async () => snapshot([]));
   const steerTurn = vi.fn(async () => undefined);
   const submitApproval = vi.fn(async () => snapshot([]));
+  const submitInput = vi.fn(async () => snapshot([]));
   const registerEventSink = vi.fn((candidate: Sink) => {
     sink = candidate;
     return { dispose: vi.fn() };
@@ -97,6 +98,7 @@ function fakeStore(initialEvents: AgentThreadEvent[]) {
     abortThread,
     steerTurn,
     submitApproval,
+    submitInput,
     registerEventSink,
   } as unknown as CodingAgentThreadStore & CodingAgentTurnStore;
   return {
@@ -107,6 +109,7 @@ function fakeStore(initialEvents: AgentThreadEvent[]) {
     abortThread,
     steerTurn,
     submitApproval,
+    submitInput,
     publish(events: AgentThreadEvent[], tokenUsage?: {
       inputTokens: number;
       outputTokens: number;
@@ -119,6 +122,23 @@ function fakeStore(initialEvents: AgentThreadEvent[]) {
 }
 
 describe("canonical coding Chat Provider adapter", () => {
+  it("forwards structured answers with the pending request's correlation without transcript secrets", async () => {
+    const request = { requestId: "req_connector", threadId: "thread_native", title: "Connector", safeDescription: "Allow?",
+      correlationId: "corr_connector", required: true,
+      questions: [{ questionId: "question_connector", header: "Choice", question: "Choose", allowOther: false, secret: true }] };
+    const pending = event({ type: "user_input.requested", eventId: "evt_input", request });
+    const fake = fakeStore([pending]);
+    const adapter = createCanonicalCodingChatProviderAdapter({ providerId: "codex", threads: fake.store });
+    const submission = { owner, chatId: "chat_coding", runId: "run_coding", requestId: request.requestId,
+      answers: { question_connector: ["private answer"] }, clientRequestId: "req_submit", state: { conversationId: "thread_native" } };
+    await adapter.submitInput!(submission);
+    expect(fake.submitInput).toHaveBeenCalledWith(expect.objectContaining({ userId: owner.ownerId }), "thread_native", request.requestId, {
+      structuredAnswers: submission.answers, answer: "Structured response submitted.", correlationId: request.correlationId, clientRequestId: "req_submit",
+    });
+    fake.getThread.mockResolvedValue(snapshot([pending, event({ type: "user_input.answered", eventId: "evt_answer", requestId: request.requestId, correlationId: request.correlationId })]));
+    await expect(adapter.submitInput!(submission)).rejects.toThrow("Input request unavailable");
+    expect(fake.submitInput).toHaveBeenCalledTimes(1);
+  });
   it("routes Pi through the shared coding seam with its exact model and enforceable sandbox", async () => {
     const createThread = vi.fn(async () => ({
       snapshot: {

--- a/tests/gateway/chat-coding-provider.test.ts
+++ b/tests/gateway/chat-coding-provider.test.ts
@@ -391,6 +391,7 @@ describe("canonical coding Chat Provider adapter", () => {
       type: "approval.requested",
       approvalId: "appr_command",
       title: "Run command",
+      description: "Run a medium-risk command.",
       risk: "medium",
       allowedDecisions: ["approve", "approve_for_session", "decline"],
     });

--- a/tests/gateway/chat-input-orchestration.test.ts
+++ b/tests/gateway/chat-input-orchestration.test.ts
@@ -1,0 +1,51 @@
+import { KyselyPGlite } from "kysely-pglite";
+import { expect, it, vi } from "vitest";
+import { CanonicalProviderCatalogSchema } from "@matrix-os/contracts";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository.js";
+import { CanonicalChatOrchestrator } from "../../packages/gateway/src/chat/orchestrator.js";
+import { CanonicalChatProviderRegistry, type CanonicalChatProviderAdapter } from "../../packages/gateway/src/chat/provider-adapter.js";
+
+it("persists a form, authorizes its answer, and resumes the same provider run", async () => {
+  const db = await KyselyPGlite.create();
+  const repository = new ChatRepository(db.dialect);
+  await repository.bootstrap();
+  const owner = { type: "personal" as const, ownerId: "owner_input" };
+  let release!: () => void;
+  const released = new Promise<void>((resolve) => { release = resolve; });
+  const submitInput = vi.fn(async () => { release(); });
+  const provider: CanonicalChatProviderAdapter = {
+    driverKind: "codex", stateSchemaVersion: 1, parseState: (v) => v, serializeState: (v) => v, submitInput,
+    async *start() {
+      yield { type: "state.updated", state: { sessionId: "native_input" } };
+      yield { type: "input.requested", requestId: "req_prompt", title: "Permission", input: {
+        requestId: "req_prompt", threadId: "thread_input", title: "Permission", safeDescription: "Allow once?", required: true,
+        correlationId: "corr_input", questions: [{ questionId: "question_permission", header: "Permission", question: "Allow once?", secret: false, allowOther: false }],
+      } };
+      await released;
+      yield { type: "input.resolved", requestId: "req_prompt" };
+      yield { type: "run.completed", outcome: "completed" };
+    },
+  };
+  const catalog = CanonicalProviderCatalogSchema.parse({ revision: "catalog_input", drivers: [{ kind: "codex", displayName: "Codex", adapterVersion: "1.0.0", capabilityClass: "coding_agent" }],
+    instances: [{ id: "codex_default", driverKind: "codex", displayName: "Codex", availability: "available", workspaceRequirement: "project_optional", catalogRevision: "catalog_input",
+      models: [{ id: "model", displayName: "Model", availability: "available", capabilities: ["tools"], supportsVision: false, supportsToolUse: true }],
+      options: [], skills: [], commands: [], setupActions: [], supports: { rootChat: true, resume: true, cancellation: true, steering: "none", attachments: [], tools: [], approvals: true, userInput: true, worktrees: "optional", resources: [], interactionModes: ["default"], permissionModes: ["supervised"] },
+    }],
+  });
+  const orchestrator = new CanonicalChatOrchestrator({ repository, catalog: { getCatalog: async () => catalog }, adapters: new CanonicalChatProviderRegistry([provider]) });
+  try {
+    await repository.create(owner, { id: "chat_input", clientRequestId: "req_create", title: "Input" });
+    const admitted = await orchestrator.admitTurn({ userId: owner.ownerId, source: "jwt" }, owner, "chat_input", {
+      clientRequestId: "req_turn", baseRevision: 0, parts: [{ type: "text", text: "Connect" }], selection: { instanceId: "codex_default", model: "model" }, interactionMode: "default", permissionMode: "supervised",
+    });
+    await vi.waitFor(async () => expect(await repository.getPendingInput(owner, { chatId: "chat_input", runId: admitted.run.id, requestId: "req_prompt" })).not.toBeNull());
+    const answer = { clientRequestId: "req_answer", answers: { question_permission: ["Allow once"] } };
+    await expect(orchestrator.submitInput({ ...owner, ownerId: "other" }, "chat_input", admitted.run.id, "req_prompt", answer)).rejects.toMatchObject({ status: 409 });
+    await expect(orchestrator.submitInput(owner, "chat_input", admitted.run.id, "req_missing", answer)).rejects.toMatchObject({ status: 409 });
+    expect(submitInput).not.toHaveBeenCalled();
+    await expect(orchestrator.submitInput(owner, "chat_input", admitted.run.id, "req_prompt", answer)).resolves.toEqual({ requestId: "req_prompt", submission: "accepted" });
+    expect(submitInput).toHaveBeenCalledWith(expect.objectContaining({ state: { sessionId: "native_input" }, answers: answer.answers }));
+    await orchestrator.drain();
+    expect(await repository.getPendingInput(owner, { chatId: "chat_input", runId: admitted.run.id, requestId: "req_prompt" })).toBeNull();
+  } finally { release(); await orchestrator.drain(); await repository.kysely.destroy(); }
+}, 20_000);

--- a/tests/gateway/chat-input-routes.test.ts
+++ b/tests/gateway/chat-input-routes.test.ts
@@ -1,0 +1,22 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createCanonicalChatRoutes, type CanonicalChatRouteService } from "../../packages/gateway/src/chat/routes.js";
+
+describe("chat input submission", () => {
+  it("validates bounded structured answers and passes authenticated ownership to the service", async () => {
+    const submitInput = vi.fn(async () => ({ requestId: "req_prompt", submission: "accepted" }));
+    const app = new Hono().route("/", createCanonicalChatRoutes({
+      service: { submitInput } as unknown as CanonicalChatRouteService,
+      getPrincipal: () => ({ userId: "owner_1", source: "jwt" }),
+    }));
+    const body = { clientRequestId: "req_answer", answers: { question_1: ["Allow once"] } };
+    const send = (payload: unknown) => app.request("/api/chats/chat_one/runs/run_one/inputs/req_prompt", {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
+    });
+    expect((await send(body)).status).toBe(200);
+    expect(submitInput).toHaveBeenCalledWith({ type: "personal", ownerId: "owner_1" }, "chat_one", "run_one", "req_prompt", body);
+    expect((await send({ ...body, answers: { question_1: ["x".repeat(50_000)] } })).status).toBe(413);
+    expect(submitInput).toHaveBeenCalledTimes(1);
+    expect((await send({ ...body, answers: {} })).status).toBe(400);
+  });
+});

--- a/tests/gateway/codex-connector-requests.test.ts
+++ b/tests/gateway/codex-connector-requests.test.ts
@@ -12,6 +12,53 @@ function harness() {
 const raw = { id: 42, method: "mcpServer/elicitation/request", params: { threadId: "thread", turnId: "turn", serverName: "connector", mode: "openai/form", message: "Allow once?", requestedSchema: null } };
 
 describe("connector request lifetime", () => {
+  it("validates answers, rejects expired/replayed controls, and keeps unexpired requests", async () => {
+    const h = harness();
+    expect(h.requests.answer("missing", {})).toBeUndefined();
+    await h.requests.handle(raw);
+    const request = h.persist.mock.calls[0]![0] as { requestId: string; connectorActionId: string };
+    await h.requests.expire();
+    expect(h.persist).toHaveBeenCalledTimes(1);
+    expect(h.requests.answer(request.requestId, {})).toBe(false);
+    expect(h.requests.answer(request.requestId, { [request.connectorActionId]: ["Allow once"] })).toBe(true);
+    expect(h.send).toHaveBeenCalledWith({ id: 42, result: { action: "accept", content: {}, _meta: null } });
+    expect(h.requests.answer(request.requestId, {})).toBeUndefined();
+    await h.requests.handle({ ...raw, id: 43 });
+    const expired = h.persist.mock.calls[1]![0] as { requestId: string };
+    h.tick();
+    expect(h.requests.answer(expired.requestId, {})).toBe(false);
+  });
+  it("fails malformed forms closed and cancels if persistence fails", async () => {
+    const h = harness();
+    expect(await h.requests.handle({ id: null, method: "bad" })).toBe(false);
+    await h.requests.handle({ ...raw, params: { ...raw.params, requestedSchema: { type: "array" } } });
+    expect(h.send).toHaveBeenCalledWith({ id: 42, error: { code: -32602, message: "This connector form is not supported." } });
+    h.persist.mockRejectedValueOnce(new Error("disk unavailable"));
+    await expect(h.requests.handle(raw)).rejects.toThrow("disk unavailable");
+    expect(h.send).toHaveBeenLastCalledWith({ id: 42, result: { action: "cancel", content: null, _meta: null } });
+    await h.requests.handle(raw);
+    expect(h.persist).toHaveBeenCalledTimes(2);
+  });
+  it("persists explicit URL authorization and enforces the request cap", async () => {
+    const h = harness();
+    await h.requests.handle({ ...raw, params: { ...raw.params, mode: "url", url: "https://connect.example.com/authorize", elicitationId: "auth" } });
+    expect(h.persist.mock.calls[0]?.[0]).toMatchObject({ connectorUrl: "https://connect.example.com/authorize" });
+    for (let id = 100; id < 120; id++) await h.requests.handle({ ...raw, id });
+    expect(h.persist).toHaveBeenCalledTimes(20);
+    expect(h.send).toHaveBeenLastCalledWith({ id: 119, result: { action: "cancel", content: null, _meta: null } });
+  });
+  it.each([undefined, "another-turn"])("rejects absent/mismatched active turns (%s)", async (turnId) => {
+    const send = vi.fn();
+    const requests = createConnectorRequests({ send, persist: vi.fn(), safeText: (value: string) => value,
+      scope: () => ({ threadId: "thread", turnId }) });
+    await requests.handle(raw);
+    expect(send).toHaveBeenCalledWith({ id: 42, result: { action: "cancel", content: null, _meta: null } });
+  });
+  it("does not misclassify non-Error programming failures as unsupported forms", async () => {
+    const requests = createConnectorRequests({ send: vi.fn(), persist: vi.fn(), safeText: () => { throw "unexpected"; },
+      scope: () => ({ threadId: "thread", turnId: "turn" }) });
+    await expect(requests.handle(raw)).rejects.toBe("unexpected");
+  });
   it("resolves completed-turn requests without replying on the closed native turn", async () => {
     const h = harness();
     await h.requests.handle(raw);

--- a/tests/gateway/codex-connector-requests.test.ts
+++ b/tests/gateway/codex-connector-requests.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { createConnectorRequests } from "../../packages/gateway/src/coding-agents/codex-connector-requests.mjs";
+
+function harness() {
+  let time = 0;
+  const send = vi.fn();
+  const persist = vi.fn(async () => {});
+  const requests = createConnectorRequests({ send, persist, safeText: (value: string) => value,
+    scope: () => ({ threadId: "thread", turnId: "turn" }), now: () => time });
+  return { requests, send, persist, tick: () => { time = 300_001; } };
+}
+const raw = { id: 42, method: "mcpServer/elicitation/request", params: { threadId: "thread", turnId: "turn", serverName: "connector", mode: "openai/form", message: "Allow once?", requestedSchema: null } };
+
+describe("connector request lifetime", () => {
+  it("resolves completed-turn requests without replying on the closed native turn", async () => {
+    const h = harness();
+    await h.requests.handle(raw);
+    await h.requests.expire(true, false);
+    expect(h.send).not.toHaveBeenCalled();
+    expect(h.persist.mock.calls.at(-1)?.[0]).toMatchObject({ type: "matrix.codex.user_input.resolved" });
+  });
+  it("does not cancel an outstanding request when the same frame is replayed", async () => {
+    const h = harness();
+    await h.requests.handle(raw);
+    await h.requests.handle(raw);
+    expect(h.send).not.toHaveBeenCalled();
+    expect(h.persist).toHaveBeenCalledTimes(1);
+  });
+  it("cancels expired requests and persists resolution without answer content", async () => {
+    const h = harness();
+    await h.requests.handle(raw);
+    expect(h.send).not.toHaveBeenCalled();
+    h.tick();
+    await h.requests.expire();
+    expect(h.send).toHaveBeenCalledWith({ id: 42, result: { action: "cancel", content: null, _meta: null } });
+    expect(h.persist.mock.calls.at(-1)?.[0]).toMatchObject({ type: "matrix.codex.user_input.resolved" });
+    await h.requests.expire();
+    expect(h.send).toHaveBeenCalledTimes(1);
+  });
+  it("answers unknown requests, but does not answer notifications", async () => {
+    const h = harness();
+    expect(await h.requests.handle({ id: 0, method: "future/request", params: {} })).toBe(true);
+    expect(h.send).toHaveBeenCalledWith({ id: 0, error: { code: -32601, message: "This request is not supported." } });
+    expect(await h.requests.handle({ method: "future/notification" })).toBe(false);
+  });
+  it("fails requests for another thread closed and drains outstanding consent", async () => {
+    const h = harness();
+    await h.requests.handle({ ...raw, params: { ...raw.params, threadId: "other" } });
+    expect(h.persist).not.toHaveBeenCalled();
+    await h.requests.handle(raw);
+    await h.requests.expire(true);
+    expect(h.send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/gateway/codex-elicitation.test.ts
+++ b/tests/gateway/codex-elicitation.test.ts
@@ -34,6 +34,13 @@ describe("connector elicitation", () => {
     { type: "object", properties: { value: { type: "number", enum: ["one"] } } },
     { type: "object", properties: { value: { type: "boolean", minimum: 1 } } },
     { type: "object", properties: { value: { type: "string", items: { enum: ["one"] } } } },
+    { type: "object", properties: { value: { type: "string", minLength: 401 } }, required: ["value"] },
+    { type: "object", properties: { value: { type: "string", maxLength: 0 } }, required: ["value"] },
+    { type: "object", properties: { value: { type: "string", minLength: 4, maxLength: 3 } } },
+    { type: "object", properties: { value: { type: "array", items: { enum: ["a", "b", "c", "d", "e"] }, minItems: 5 } }, required: ["value"] },
+    { type: "object", properties: { value: { type: "array", items: { enum: ["a"] }, maxItems: 0 } }, required: ["value"] },
+    { type: "object", properties: { value: { type: "array", items: { enum: ["a"] }, minItems: 2 } } },
+    { type: "object", properties: { value: { type: "integer", minimum: 1.1, maximum: 1.9 } } },
   ])("fails unsupported schemas closed", (schema) => {
     expect(() => compileElicitation(request(schema), safeText)).toThrow();
   });

--- a/tests/gateway/codex-elicitation.test.ts
+++ b/tests/gateway/codex-elicitation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { compileElicitation } from "../../packages/gateway/src/coding-agents/codex-elicitation.mjs";
+
+const safeText = (value: string, fallback: string) => value || fallback;
+const request = (requestedSchema: unknown) => ({
+  id: 42, method: "mcpServer/elicitation/request",
+  params: { threadId: "native-thread", turnId: "native-turn", serverName: "connector", mode: "openai/form", message: "Allow this action?", requestedSchema },
+});
+
+describe("connector elicitation", () => {
+  it.each(["form", "openai/form", "openaiForm"])("supports %s with titled enums and optional fields", (mode) => {
+    const raw = request({ type: "object", properties: {
+      plan: { type: "string", oneOf: [{ const: "basic", title: "Basic" }] },
+      note: { type: "string", minLength: 2, maxLength: 4 },
+    } });
+    raw.params.mode = mode;
+    const form = compileElicitation(raw, safeText);
+    const [plan, note] = form.questions;
+    expect(form.respond({ [form.actionId]: ["Allow once"], [plan.questionId]: ["1. Basic"] })?.content).toEqual({ plan: "basic" });
+    expect(form.respond({ [form.actionId]: ["Allow once"], [note.questionId]: ["x"] })).toBeNull();
+    expect(form.respond({ [form.actionId]: ["toString"] })).toBeNull();
+    expect(form.respond({ [form.actionId]: ["Allow once"], unknown: ["x"] })).toBeNull();
+  });
+  it.each(["http://example.com", "https://localhost", "https://127.0.0.1", "https://user:pass@example.com", "https://[::1]"])("rejects unsafe navigation %s", (url) => {
+    const raw = request(null);
+    Object.assign(raw.params, { mode: "url", url, elicitationId: "auth-1" });
+    expect(() => compileElicitation(raw, safeText)).toThrow();
+  });
+  it.each([
+    { type: "object", properties: { nested: { type: "object", properties: {} } } },
+    { type: "object", properties: {}, required: ["missing"] },
+    { type: "object", properties: Object.fromEntries(Array.from({ length: 8 }, (_, i) => [String(i), { type: "string" }])) },
+    { type: "object", properties: { value: { type: "array" } } },
+    { type: "object", properties: { value: { type: "number", enum: ["one"] } } },
+    { type: "object", properties: { value: { type: "boolean", minimum: 1 } } },
+    { type: "object", properties: { value: { type: "string", items: { enum: ["one"] } } } },
+  ])("fails unsupported schemas closed", (schema) => {
+    expect(() => compileElicitation(request(schema), safeText)).toThrow();
+  });
+  it("validates number syntax, integer precision, required fields and date formats", () => {
+    const form = compileElicitation(request({ type: "object", properties: { n: { type: "integer" }, date: { type: "string", format: "date" } }, required: ["n"] }), safeText);
+    const [number, date] = form.questions;
+    expect(form.respond({ [form.actionId]: ["Allow once"] })).toBeNull();
+    for (const invalid of ["1.5", "Infinity", "1e400", "9007199254740992", "0x10"]) {
+      expect(form.respond({ [form.actionId]: ["Allow once"], [number.questionId]: [invalid] })).toBeNull();
+    }
+    expect(form.respond({ [form.actionId]: ["Allow once"], [number.questionId]: ["1"], [date.questionId]: ["not-a-date"] })).toBeNull();
+    expect(form.respond({ [form.actionId]: ["Allow once"], [number.questionId]: ["1"], [date.questionId]: ["2026-09-07"] })?.content).toEqual({ n: 1, date: "2026-09-07" });
+  });
+  it("exposes a safe URL for explicit user navigation, never automatic navigation", () => {
+    const raw = request(null);
+    Object.assign(raw.params, { mode: "url", url: "https://connect.example.com/authorize", elicitationId: "auth-1" });
+    const form = compileElicitation(raw, safeText);
+    expect(form.connectorUrl).toBe("https://connect.example.com/authorize");
+    expect(form.respond({ [form.actionId]: ["Allow once"] })).toEqual({ action: "accept", content: null, _meta: null });
+    Object.assign(raw.params, { url: "javascript:alert(1)" });
+    expect(() => compileElicitation(raw, safeText)).toThrow();
+  });
+  it("validates typed form answers and allows cancellation without filling required fields", () => {
+    const form = compileElicitation(request({ type: "object", properties: {
+      count: { type: "integer", minimum: 1, maximum: 5 },
+      enabled: { type: "boolean" },
+      tags: { type: "array", items: { type: "string", enum: ["a", "b"] }, minItems: 1 },
+    }, required: ["count", "enabled", "tags"] }), safeText);
+    const [count, enabled, tags] = form.questions;
+    const answers = { [form.actionId]: ["Allow once"], [count.questionId]: ["3"], [enabled.questionId]: ["True"], [tags.questionId]: ["1. a", "2. b"] };
+    expect(form.respond(answers)).toEqual({ action: "accept", content: { count: 3, enabled: true, tags: ["a", "b"] }, _meta: null });
+    expect(form.respond({ ...answers, [count.questionId]: ["99"] })).toBeNull();
+    expect(form.respond({ [form.actionId]: ["Cancel"] })?.action).toBe("cancel");
+  });
+  it("requires explicit consent and returns the native response without a session grant", () => {
+    const form = compileElicitation(request(null), safeText);
+    expect(form.questions).toHaveLength(1);
+    expect(form.respond({})).toBeNull();
+    expect(form.respond({ [form.actionId]: ["Allow once"] })).toEqual({ action: "accept", content: {}, _meta: null });
+    expect(form.respond({ [form.actionId]: ["Decline"] })).toEqual({ action: "decline", content: null, _meta: null });
+    expect(form.respond({ [form.actionId]: ["Cancel"] })).toEqual({ action: "cancel", content: null, _meta: null });
+  });
+});

--- a/tests/gateway/codex-elicitation.test.ts
+++ b/tests/gateway/codex-elicitation.test.ts
@@ -8,6 +8,22 @@ const request = (requestedSchema: unknown) => ({
 });
 
 describe("connector elicitation", () => {
+  it("rejects malformed selections and enforces text/selection maxima", () => {
+    const form = compileElicitation(request({ type: "object", properties: {
+      text: { type: "string", maxLength: 2 },
+      tags: { type: "array", items: { anyOf: [{ const: "a", title: "A" }, { const: "b", title: "B" }] }, maxItems: 1 },
+    } }), safeText);
+    const [text, tags] = form.questions;
+    const accept = { [form.actionId]: ["Allow once"] };
+    expect(form.respond({ ...accept, [text.questionId]: ["a", "b"] })).toBeNull();
+    expect(form.respond({ ...accept, [tags.questionId]: ["1. A", "1. A"] })).toBeNull();
+    expect(form.respond({ ...accept, [tags.questionId]: ["unknown"] })).toBeNull();
+    expect(form.respond({ ...accept, [tags.questionId]: ["1. A", "2. B"] })).toBeNull();
+    expect(form.respond({ ...accept, [text.questionId]: ["long"] })).toBeNull();
+    const noTurn = request(null);
+    Object.assign(noTurn.params, { turnId: null });
+    expect(compileElicitation(noTurn, safeText, "active-turn").requestId).not.toBe(form.requestId);
+  });
   it.each(["form", "openai/form", "openaiForm"])("supports %s with titled enums and optional fields", (mode) => {
     const raw = request({ type: "object", properties: {
       plan: { type: "string", oneOf: [{ const: "basic", title: "Basic" }] },

--- a/tests/gateway/codex-request-expiry.test.ts
+++ b/tests/gateway/codex-request-expiry.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, vi } from "vitest";
-import { expireNativeRequests } from "../../packages/gateway/src/coding-agents/codex-request-expiry.mjs";
+import { cancel, expireNativeRequests } from "../../packages/gateway/src/coding-agents/codex-request-expiry.mjs";
 
 it("cancels expired command approvals and resolves the UI request without authorizing anything", async () => {
   const approvals = new Map([["appr_one", { nativeRequestId: 1, expiresAt: 5 }], ["appr_two", { nativeRequestId: 2, expiresAt: 50 }]]);
@@ -11,6 +11,16 @@ it("cancels expired command approvals and resolves the UI request without author
   expect(persist).toHaveBeenCalledWith({ type: "matrix.codex.user_input.resolved", requestId: "req_one", correlationId: "corr_one" });
   expect(approvals.size).toBe(1);
   expect(inputs.size).toBe(0);
+});
+
+it("keeps live input requests and isolates closed cancellation transports", async () => {
+  const inputs = new Map([["req_live", { nativeRequestId: 1, expiresAt: 50, correlationId: "corr_live" }]]);
+  const send = vi.fn();
+  await expireNativeRequests({ approvals: new Map(), inputs, send, persist: vi.fn(), now: 10 });
+  expect(inputs.size).toBe(1);
+  expect(send).not.toHaveBeenCalled();
+  expect(() => cancel(() => { throw new Error("closed"); }, {})).not.toThrow();
+  expect(() => cancel(() => { throw "unexpected"; }, {})).toThrow("unexpected");
 });
 
 it("clears completed-turn requests without writing to an already exiting provider", async () => {

--- a/tests/gateway/codex-request-expiry.test.ts
+++ b/tests/gateway/codex-request-expiry.test.ts
@@ -1,0 +1,24 @@
+import { expect, it, vi } from "vitest";
+import { expireNativeRequests } from "../../packages/gateway/src/coding-agents/codex-request-expiry.mjs";
+
+it("cancels expired command approvals and resolves the UI request without authorizing anything", async () => {
+  const approvals = new Map([["appr_one", { nativeRequestId: 1, expiresAt: 5 }], ["appr_two", { nativeRequestId: 2, expiresAt: 50 }]]);
+  const inputs = new Map([["req_one", { nativeRequestId: 3, expiresAt: 5, correlationId: "corr_one" }]]);
+  const send = vi.fn(); const persist = vi.fn(async () => {});
+  await expireNativeRequests({ approvals, inputs, send, persist, now: 10 });
+  expect(send.mock.calls).toEqual([[{ id: 1, result: { decision: "cancel" } }], [{ id: 3, result: { answers: {} } }]]);
+  expect(persist).toHaveBeenCalledWith({ type: "matrix.codex.approval.resolved", approvalId: "appr_one", decision: "cancel" });
+  expect(persist).toHaveBeenCalledWith({ type: "matrix.codex.user_input.resolved", requestId: "req_one", correlationId: "corr_one" });
+  expect(approvals.size).toBe(1);
+  expect(inputs.size).toBe(0);
+});
+
+it("clears completed-turn requests without writing to an already exiting provider", async () => {
+  const approvals = new Map([["appr_one", { nativeRequestId: 1, expiresAt: 50 }]]);
+  const inputs = new Map([["req_one", { nativeRequestId: 2, expiresAt: 50, correlationId: "corr_one" }]]);
+  const send = vi.fn(); const persist = vi.fn(async () => {});
+  await expireNativeRequests({ approvals, inputs, send, persist, now: 10, all: true, reply: false });
+  expect(send).not.toHaveBeenCalled();
+  expect(persist).toHaveBeenCalledTimes(2);
+  expect(approvals.size + inputs.size).toBe(0);
+});

--- a/tests/gateway/coding-agents-codex-app-server-contract.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-contract.test.ts
@@ -66,6 +66,7 @@ describe("Codex app-server contract", () => {
         "item/fileChange/requestApproval",
         "item/tool/requestUserInput",
         "item/permissions/requestApproval",
+        "mcpServer/elicitation/request",
       ],
       requiredServerNotifications: [
         "item/started",

--- a/tests/gateway/coding-agents-codex-app-server-reliability.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-reliability.test.ts
@@ -182,6 +182,28 @@ const initialize = "if (message.method === 'initialize') console.log(JSON.string
 const startThread = "else if (message.method === 'thread/start') console.log(JSON.stringify({ id: message.id, result: { thread: { id: 'native-thread' }, model: 'codex', modelProvider: 'openai', cwd: '/private/project', approvalPolicy: 'on-request', approvalsReviewer: 'user', sandbox: {} } }));";
 
 describe("Codex app-server runner reliability", () => {
+  it("surfaces connector consent and resumes only after an explicit answer", async () => {
+    const runtime = await startFakeRuntime("connector", [
+      initialize, startThread,
+      "else if (message.method === 'turn/start') {",
+      " console.log(JSON.stringify({ id: message.id, result: { turn: { id: 'native-turn' } } }));",
+      " console.log(JSON.stringify({ id: 42, method: 'mcpServer/elicitation/request', params: { threadId: 'native-thread', turnId: 'native-turn', serverName: 'connector', mode: 'openai/form', message: 'Allow this tool?', requestedSchema: null } }));",
+      "} else if (message.id === 42 && message.result?.action === 'accept') {",
+      " console.log(JSON.stringify({ method: 'turn/completed', params: { turn: { status: 'completed' } } }));",
+      " process.exit(0);",
+      "}",
+    ]);
+    try {
+      const transcript = await waitForTranscript(runtime.eventPath, /user_input\.requested/);
+      const event = transcript.trim().split("\n").map((line) => JSON.parse(line)).find((event) => event.type === "matrix.codex.user_input.requested");
+      expect((await replayTranscript(runtime.eventPath)).some((event) => event.type === "user_input.requested")).toBe(true);
+      expect(runtime.child.exitCode).toBeNull();
+      await expect(sendControl(runtime.controlPath, {
+        type: "input", requestId: event.requestId, structuredAnswers: { [event.questions[0].questionId]: ["Allow once"] }, clientRequestId: "req_connector_answer",
+      })).resolves.toEqual({ ok: true });
+      await expect(waitForExit(runtime.child)).resolves.toBe(0);
+    } finally { await cleanup(runtime); }
+  });
   it("settles an in-flight assistant item before a completed turn is replayed", async () => {
     const runtime = await startFakeRuntime("assistant_cleanup", [
       initialize,


### PR DESCRIPTION
## Summary

Stack 1/2. UI companion: #1561. Both layers must ship to fix invisible approval stalls.

- Handle Codex `mcpServer/elicitation/request` instead of leaving native connector execution blocked behind an unanswered server request. Supports bounded primitive forms, message-only explicit consent, and user-opened HTTPS authorization links; unsupported shapes fail closed.
- Preserve structured requests through canonical Chat and add an owner-scoped input submission endpoint through the existing provider control channel. No answer values are copied into transcript text.
- Bound pending consent, cancel on expiry/shutdown, and persist request resolution. Completed native turns clear local controls without writing to an already-closing provider pipe.
- Add protocol contract coverage using the version-matched app-server schema digest and public-safe development documentation.

This addresses missing request handling, not transport latency. A separate UI projection defect is fixed in #1561. Historical connector stalls are consistent with the reproduced missing-handler path; the original raw request frames were not retained, so exact historical attribution is not claimed.

## Tests

- Passed: `bun run typecheck`, `pnpm exec tsc --noEmit -p shell/tsconfig.json`, `bun run check:patterns` (5 warnings, 0 violations), `git diff --check`.
- Passed the combined 24-file focused suite (287 tests), then 41 direct connector boundary tests and 16 web recovery/hook/wiring tests after review updates. Includes real runner/control-socket tests and the reproduced terminal pipe race.
- Focused coverage for the three new connector modules passes the configured gates: 100% lines/functions, 99.41% statements, 99.48% branches.
- Full local `bun run test --maxWorkers=2`: 13,650 tests passed, 21 skipped; command exited nonzero after a fork-worker exit in unchanged `tests/integrations/routes.test.ts`. The whole-file rerun also hit a 60-second database `beforeEach` timeout after 50 passing tests and lost its worker. The exact timed-out Retry-After case passes alone (2.4 seconds). Neither full local invocation is claimed green; exact-head CI remains the broad gate. No out-of-scope integration code or test timeouts were changed.
- No customer data, production state, credentials, or private incident details are included in fixtures or docs.

## Review/Monitoring

- Review this backend layer independently; #1561 supplies the dependent renderers.
- Trusted Greptile 5/5 confirmed on final head `20dfa4c4bdbaf65cb8e2ae6407fdf594d56fb9b4`; all review threads resolved with evidence. `ready-for-ci` is present; [triggered CI](https://github.com/HamedMP/matrix-os/actions/runs/34124180316) passed, including all four unit shards, E2E Tests, and CI Results. Docker build and smoke checks also passed. Not merged or deployed.
- No merge or deployment authorized. Public site documentation: FinnaAI/matrix-os-site#87 (61 tests and rendered 375/768/1440-px checks passed).
- First review found unrepresentable form constraints. Fixed with seven failing-first boundary cases; minimum lengths/selections and contradictory ranges now fail immediately. Sanitized approval descriptions also survive canonical projection.

## Invariants

### Source of truth

- Owner-scoped Postgres Chat/thread events persist display requests and resolution. The live runner owns native request identities and whether a response can still be accepted.
- Existing provider event delivery reconciles durable UI state with live control outcomes. No new database or persistence engine.

### Lock/transaction scope

- Canonical submission performs scoped reads, then invokes the existing thread-store/control operation; it adds no multi-write transaction or network operation inside a new lock.
- Existing thread-store serialization and request/correlation validation remain authoritative. Runner pending entries are removed synchronously before async cleanup persistence.

### Acceptable orphan states

- A disconnected client can leave an unanswered request until the five-minute expiry sweep (30-second interval); expiry never grants permission.
- Terminal turns clear stale controls. Shutdown drains pending consent; unsupported or over-cap requests receive an explicit error/cancellation.
- A persist failure cancels the pending native request. No secrets are added to history as fallback input text.

### Auth source of truth

- Existing authenticated gateway principal determines the owner. Exact owner/chat/run and pending request are checked before provider dispatch; native thread correlation and question identities are validated again.
- Input route has bounded identifiers, Zod payload validation, and a 40-KiB body limit. No public unauthenticated path or automatic connector permission grant.

### Deferred scope

- Persistent connector grants, arbitrary nested JSON Schema forms, automatic browser navigation, transport migration, production rollout, and live account authorization are not included.
- Backend deployment alone does not fix missing UI controls; release with #1561 and update affected clients.
- Pre-existing Hermes native clarification responses remain tracked in #1562; this stack does not invent an unverified native reply protocol for another provider.
