### PR TITLE
fix(chat): show actionable approval and connector input controls

### DIFF
--- a/desktop/src/renderer/src/components/conversation/StructuredInputForm.tsx
+++ b/desktop/src/renderer/src/components/conversation/StructuredInputForm.tsx
@@ -1,0 +1,1 @@
+export { StructuredInputForm } from "@matrix-os/ui";

--- a/desktop/src/renderer/src/components/conversation/presentation.ts
+++ b/desktop/src/renderer/src/components/conversation/presentation.ts
@@ -1,3 +1,4 @@
+import type { UserInputRequest, UserInputAnswerRequest } from "@matrix-os/contracts";
 export type ConversationMessageRole = "user" | "assistant";
 
 export interface ConversationAttachmentPresentation {
@@ -78,6 +79,7 @@ export interface ConversationNoticePresentation {
 }
 
 export interface ConversationRequestPresentation {
+  input?: UserInputRequest;
   kind: "request";
   id: string;
   phase: "commentary" | "final";
@@ -111,6 +113,7 @@ export type ConversationTurnTimelinePresentation =
   | { kind: "user-followup"; message: ConversationMessagePresentation };
 
 export interface ConversationTurnPresentation {
+  waitingFor?: "approval" | "input";
   id: string;
   startedAt: number;
   endedAt: number;
@@ -124,6 +127,7 @@ export interface ConversationTurnPresentation {
 }
 
 export interface ConversationPresentationCallbacks {
+  submitInput?: (requestId: string, answers: NonNullable<UserInputAnswerRequest["structuredAnswers"]>) => Promise<void>;
   copyText: (text: string) => Promise<void>;
   loadImage?: (src: string) => Promise<Blob>;
   performAction?: (action: ConversationActionPresentation, input?: string) => Promise<void>;

--- a/desktop/src/renderer/src/components/conversation/transcript.tsx
+++ b/desktop/src/renderer/src/components/conversation/transcript.tsx
@@ -1,3 +1,4 @@
+import { StructuredInputForm } from "./StructuredInputForm";
 import {
   CheckCircle2,
   ChevronRight,
@@ -38,6 +39,7 @@ function TurnReceipt({
   startedAt,
   endedAt,
   active,
+  waitingFor,
   expanded,
   canToggle,
   onToggle,
@@ -45,6 +47,7 @@ function TurnReceipt({
   startedAt: number;
   endedAt: number;
   active: boolean;
+  waitingFor?: "approval" | "input";
   expanded: boolean;
   canToggle: boolean;
   onToggle: () => void;
@@ -57,7 +60,8 @@ function TurnReceipt({
   }, [active]);
 
   const elapsed = active ? now - startedAt : endedAt - startedAt;
-  const label = `${active ? "Working" : "Worked"} for ${formatTurnDuration(elapsed)}`;
+  const label = waitingFor ? `Waiting for your ${waitingFor === "approval" ? "approval" : "response"}`
+    : `${active ? "Working" : "Worked"} for ${formatTurnDuration(elapsed)}`;
   return (
     <ConversationItem messageId={`receipt:${startedAt}`} className="-mb-1">
       <Marker variant="border" className="min-h-10 pb-1">
@@ -421,7 +425,9 @@ function Request({
               ) : null}
             </div>
             {request.detail ? <p className="mt-1 text-sm" style={{ color: "var(--text-secondary)" }}>{request.detail}</p> : null}
-            {request.state === "waiting" && inputAction ? (
+            {request.state === "waiting" && request.input?.questions && callbacks.submitInput ? (
+              <StructuredInputForm key={request.id} request={request.input} submit={(answers) => callbacks.submitInput!(request.requestId, answers)} />
+            ) : request.state === "waiting" && inputAction ? (
               <form
                 className="mt-2 flex min-w-0 gap-2"
                 onSubmit={(event) => {
@@ -514,6 +520,8 @@ function ConversationTurn({
   initialFinalIds: ReadonlySet<string>;
 }) {
   const [expanded, setExpanded] = useState(turn.expandedByDefault ?? false);
+  const pendingRequests = turn.active ? turn.work.filter((item) => item.kind === "request" && item.state === "waiting") : [];
+  const pendingIds = new Set(pendingRequests.map((item) => item.id));
   const showWork = turn.active || expanded;
   const hasWork = turn.work.length > 0;
   const terminalPartial = !turn.active
@@ -521,19 +529,21 @@ function ConversationTurn({
     && (turn.final.tone === "failed" || turn.final.tone === "stopped")
     ? [...turn.work].reverse().find((item) => item.kind === "message")
     : undefined;
-  const visibleWork = showWork ? turn.work : terminalPartial ? [terminalPartial] : [];
+  const visibleWork = (showWork ? turn.work : terminalPartial ? [terminalPartial] : []).filter((item) => !pendingIds.has(item.id));
   const timeline = turn.timeline;
   const visibleTimeline = timeline?.filter((entry) => (
-    entry.kind === "user-followup" || showWork || (terminalPartial !== undefined && entry.item.id === terminalPartial.id)
+    entry.kind === "user-followup" || (!pendingIds.has(entry.item.id) && (showWork || (terminalPartial !== undefined && entry.item.id === terminalPartial.id)))
   ));
   return (
     <>
       {turn.user ? <UserMessage message={turn.user} callbacks={callbacks} /> : null}
+      {pendingRequests.map((item) => <PresentationItem key={item.id} item={item} callbacks={callbacks} />)}
       {hasWork || turn.final || turn.active ? (
         <TurnReceipt
           startedAt={turn.startedAt}
           endedAt={turn.endedAt}
           active={turn.active}
+          waitingFor={turn.waitingFor}
           expanded={showWork}
           canToggle={!turn.active && hasWork}
           onToggle={() => setExpanded((value) => !value)}

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -737,6 +737,7 @@ export function CanonicalChatWorkspace({
               openFile: openFileInDesktopEditor,
               ...(api ? { loadImage: (src: string) => api.getBlob(src, { maxBytes: 10 * 1024 * 1024 }) } : {}),
               performAction: performTranscriptAction,
+              submitInput: controller.submitInput,
               canPerformAction: canPerformTranscriptAction,
             }} />
             <div className={cn("mx-auto w-full shrink-0 px-5 pb-5", CHAT_CONTENT_WIDTH_CLASS)}>{composer}</div>

--- a/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
+++ b/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
@@ -247,6 +247,7 @@ function selectedModelDisplayName(run: CanonicalChatRun): string {
 
 function activeModelStatus(run: CanonicalChatRun | undefined): ConversationWorkPresentation | undefined {
   if (!run || !isActiveRun(run)) return undefined;
+  if (run.status === "waiting_for_approval" || run.status === "waiting_for_input") return undefined;
   const model = selectedModelDisplayName(run);
   const id = `${run.id}:selected-model`;
   return {
@@ -437,6 +438,7 @@ function runPresentation(
         requestId: activity.requestId,
         state: "waiting",
         label: activity.title,
+        ...(activity.input ? { input: activity.input } : {}),
         timestamp: Date.parse(activity.occurredAt),
         actions: [{ kind: "input", requestId: activity.requestId, label: "Submit" }],
       }, MAX_RUN_ACTIVITY_PROJECTIONS) && isNew) requestOrder.push(key);
@@ -637,6 +639,8 @@ export function canonicalChatPresentation(input: {
       startedAt,
       endedAt,
       active: isActiveRun(run),
+      ...(run?.status === "waiting_for_approval" ? { waitingFor: "approval" as const }
+        : run?.status === "waiting_for_input" ? { waitingFor: "input" as const } : {}),
       ...(userMessage ? { user: messagePresentation(userMessage, "commentary") } : {}),
       ...(userFollowups.length > 0
         ? { userFollowups: userFollowups.map((message) => messagePresentation(message, "commentary")) }

--- a/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
+++ b/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
@@ -412,6 +412,7 @@ function runPresentation(
         requestId: activity.approvalId,
         state: "waiting",
         label: activity.title,
+        ...(activity.description ? { detail: activity.description } : {}),
         risk: activity.risk,
         timestamp: Date.parse(activity.occurredAt),
         actions: activity.allowedDecisions.map((decision) => ({

--- a/desktop/src/renderer/src/features/chat/use-canonical-chat-route-controller.ts
+++ b/desktop/src/renderer/src/features/chat/use-canonical-chat-route-controller.ts
@@ -1,4 +1,5 @@
 import type {
+  CanonicalSubmitChatInputRequest,
   CanonicalChatDetailResponse,
   CanonicalChatApprovalDecision,
   CanonicalChatRecord,
@@ -729,6 +730,20 @@ export function useCanonicalChatRouteController({
     }
   }, [client, loadDetail]);
 
+  const submitInput = useCallback(async (requestId: string, answers: CanonicalSubmitChatInputRequest["answers"]) => {
+    const current = detailRef.current;
+    const activeRun = current?.record.activeRun;
+    if (!current || !activeRun) throw new Error("InputUnavailable");
+    const routeScope = routeScopeRef.current;
+    try {
+      await client.submitInput(current.record.chat.id, activeRun.runId, requestId, { answers, clientRequestId: canonicalChatRequestId() });
+      if (routeScope?.active && routeScopeRef.current === routeScope) await loadDetail(current.record.chat.id);
+    } catch (error: unknown) {
+      console.warn("[canonical-chat] input failed:", diagnosticErrorKind(error));
+      throw new Error("InputSubmissionFailed");
+    }
+  }, [client, loadDetail]);
+
   const retryTurn = useCallback(async (turnId: string) => {
     const current = detailRef.current;
     if (!current || current.record.activeRun) return null;
@@ -803,6 +818,7 @@ export function useCanonicalChatRouteController({
     reorderQueuedTurns,
     cancelQueuedTurn,
     submitApproval,
+    submitInput,
     retryTurn,
     deleteChat,
     startNewChat: () => selectChat(null),

--- a/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentConversationView.tsx
@@ -1,16 +1,13 @@
 import type { AgentAttachment, AgentThreadEvent, AgentThreadSnapshot, RuntimeSummary } from "@matrix-os/contracts";
+import { SystemEvent } from "./AgentSystemEvent";
 import {
   Check,
-  CircleAlert,
-  CircleCheck,
   Copy,
   Eye,
   FileDiff,
   FileText,
   GitPullRequest,
-  Hourglass,
   Image as ImageIcon,
-  Info,
   Link2,
   MessageSquarePlus,
   Minus,
@@ -467,151 +464,6 @@ function WorkedRow({ label }: { label: string }) {
   );
 }
 
-function eventCopy(event: AgentThreadEvent): { title: string; detail: string } {
-  switch (event.type) {
-    case "turn.accepted": return { title: "Message accepted", detail: "Waiting for the agent run" };
-    case "turn.status": return { title: "Message status", detail: event.status };
-    case "thread.created": return { title: "Thread created", detail: event.thread.title };
-    case "thread.status": return { title: "Status changed", detail: event.status.replaceAll("_", " ") };
-    case "approval.requested": return { title: "Approval needed", detail: event.approval.safeDescription };
-    case "approval.resolved": return { title: "Approval resolved", detail: event.decision };
-    case "user_input.requested": return { title: "Input needed", detail: event.request.safeDescription };
-    case "user_input.answered": return { title: "Input answered", detail: "Input answer received" };
-    case "file.changed": return { title: `File ${event.changeKind}`, detail: `${event.changeKind} file` };
-    case "review.ready": return { title: "Review ready", detail: `${event.summary.changedFileCount} ${event.summary.changedFileCount === 1 ? "file" : "files"} changed, +${event.summary.additions} -${event.summary.deletions}${event.summary.partial ? ", partial" : ""}` };
-    case "terminal.bound": return { title: "Terminal bound", detail: event.terminalSessionId };
-    case "thread.error": return { title: "Thread needs attention", detail: event.error.retryable ? "Refresh the thread or check the runtime." : "Open the workspace again." };
-    case "thread.completed": return { title: "Thread completed", detail: event.outcome };
-    case "user.message": return { title: "You", detail: event.text };
-    case "assistant.text.delta":
-    case "assistant.text.completed": return { title: "Assistant update", detail: "Text update received" };
-    case "tool.started":
-    case "tool.output":
-    case "tool.completed": return { title: "Tool activity", detail: "Tool state updated" };
-  }
-}
-
-function approvalLabel(decision: string) {
-  if (decision === "approve") return "Approve";
-  if (decision === "approve_for_session") return "Approve for session";
-  if (decision === "decline") return "Decline";
-  if (decision === "cancel") return "Cancel";
-  return "Decide";
-}
-
-// Pure status events ("Thread created", "Terminal bound", "Thread
-// completed", …) render as compact single-line timeline rows: a small
-// leading glyph, the bounded copy, and the timestamp at the right — no card
-// background, border, or shadow, so they read as history instead of
-// dominating the conversation.
-function systemEventIcon(event: AgentThreadEvent) {
-  switch (event.type) {
-    case "thread.created": return MessageSquarePlus;
-    case "thread.completed": return CircleCheck;
-    case "thread.error": return CircleAlert;
-    case "terminal.bound": return SquareTerminal;
-    case "turn.accepted": return Hourglass;
-    case "approval.resolved":
-    case "user_input.answered": return CircleCheck;
-    case "approval.requested":
-    case "user_input.requested": return CircleAlert;
-    case "file.changed": return FileDiff;
-    default: return Info;
-  }
-}
-
-function SystemEvent({ event, answeredInputs, resolvedApprovals }: {
-  event: AgentThreadEvent;
-  answeredInputs: ReadonlySet<string>;
-  resolvedApprovals: ReadonlySet<string>;
-}) {
-  const copy = eventCopy(event);
-  const pendingApprovalKeys = useCodingAgentWorkspace((state) => state.pendingApprovalKeys);
-  const approvalErrors = useCodingAgentWorkspace((state) => state.approvalActionErrors);
-  const submitApproval = useCodingAgentWorkspace((state) => state.submitApprovalDecision);
-  const pendingInputKeys = useCodingAgentWorkspace((state) => state.pendingInputRequestKeys);
-  const inputErrors = useCodingAgentWorkspace((state) => state.inputActionErrors);
-  const submitInput = useCodingAgentWorkspace((state) => state.submitInputAnswer);
-  const selectReview = useCodingAgentWorkspace((state) => state.selectReview);
-  const [answer, setAnswer] = useState("");
-  const approval = event.type === "approval.requested" ? event.approval : null;
-  const input = event.type === "user_input.requested" ? event.request : null;
-  const approvalKey = approval ? codingAgentApprovalActionKey(approval.threadId, approval.approvalId) : null;
-  const inputKey = input ? codingAgentInputActionKey(input.threadId, input.requestId) : null;
-  // Events carrying a live action — a pending approval decision, a pending
-  // input answer, or an openable review — keep the card treatment; every
-  // other status event collapses to a compact timeline row.
-  const interactive = Boolean(
-    (approval && approvalKey && !resolvedApprovals.has(approvalKey))
-    || (input && inputKey && !answeredInputs.has(inputKey))
-    || event.type === "review.ready",
-  );
-  if (!interactive) {
-    const Glyph = systemEventIcon(event);
-    const failed = event.type === "thread.error";
-    return (
-      <div className="flex w-full items-center gap-2 px-1 py-0.5" data-slot="system-event-row">
-        <Glyph
-          size={12}
-          className="shrink-0"
-          style={{ color: failed ? "var(--danger)" : "var(--text-tertiary)" }}
-          aria-hidden="true"
-        />
-        <p className="min-w-0 flex-1 truncate text-[12px]" style={{ color: "var(--text-tertiary)" }}>
-          <span className="font-medium" style={{ color: failed ? "var(--danger)" : "var(--text-secondary)" }}>
-            {copy.title}
-          </span>
-          {copy.detail ? (
-            <>
-              <span aria-hidden="true"> · </span>
-              <span>{copy.detail}</span>
-            </>
-          ) : null}
-        </p>
-        <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--text-tertiary)" }}>
-          {occurredAtLabel(event.occurredAt)}
-        </span>
-      </div>
-    );
-  }
-  return (
-    <div className="w-full rounded-lg border px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}>
-      <div className="flex items-center justify-between gap-3">
-        <h3 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>{copy.title}</h3>
-        <span className="text-[10px] tabular-nums" style={{ color: "var(--text-tertiary)" }}>{occurredAtLabel(event.occurredAt)}</span>
-      </div>
-      <p className="mt-0.5 text-xs" style={{ color: "var(--text-secondary)" }}>{copy.detail}</p>
-      {approval && approvalKey && !resolvedApprovals.has(approvalKey) ? (
-        <div className="mt-2 flex flex-wrap items-center gap-2">
-          {approval.allowedDecisions.map((decision) => (
-            <Button key={decision} variant={decision.startsWith("approve") ? "primary" : "danger"} aria-label={`${approvalLabel(decision)} ${approval.title}`} disabled={Boolean(approvalKey && pendingApprovalKeys.includes(approvalKey))} onClick={() => void submitApproval({ threadId: approval.threadId, approvalId: approval.approvalId, decision, correlationId: approval.correlationId })}>
-              {approvalKey && pendingApprovalKeys.includes(approvalKey) ? "Sending..." : approvalLabel(decision)}
-            </Button>
-          ))}
-          {approvalKey && approvalErrors[approvalKey] ? <span className="text-xs" style={{ color: "var(--danger)" }}>{approvalErrors[approvalKey]}</span> : null}
-        </div>
-      ) : null}
-      {input && inputKey && !answeredInputs.has(inputKey) ? (
-        <div className="mt-2 grid gap-2">
-          <textarea aria-label={`Answer ${input.title}`} className="min-h-20 resize-y rounded-md border px-3 py-2 text-sm outline-none" maxLength={8000} placeholder={input.placeholder ?? "Answer"} style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)", color: "var(--text-primary)" }} value={answer} onChange={(event) => setAnswer(event.currentTarget.value)} />
-          <div className="flex items-center gap-2">
-            <Button variant="primary" aria-label={`Send ${input.title}`} disabled={pendingInputKeys.includes(inputKey) || (input.required && !answer.trim())} onClick={() => void submitInput({ threadId: input.threadId, inputRequestId: input.requestId, answer, correlationId: input.correlationId })}>
-              {pendingInputKeys.includes(inputKey) ? "Sending..." : "Send"}
-            </Button>
-            {inputErrors[inputKey] ? <span className="text-xs" style={{ color: "var(--danger)" }}>{inputErrors[inputKey]}</span> : null}
-          </div>
-        </div>
-      ) : null}
-      {event.type === "review.ready" ? (
-        <div className="mt-2">
-          <Button variant="subtle" aria-label="Open review from thread" onClick={() => void selectReview(event.reviewId)}>
-            <GitPullRequest size={14} /> Open review
-          </Button>
-        </div>
-      ) : null}
-    </div>
-  );
-}
 
 function TranscriptItem({
   item,

--- a/desktop/src/renderer/src/features/coding-agents/AgentSystemEvent.tsx
+++ b/desktop/src/renderer/src/features/coding-agents/AgentSystemEvent.tsx
@@ -1,0 +1,161 @@
+import type { AgentThreadEvent } from "@matrix-os/contracts";
+import { CircleAlert, CircleCheck, FileDiff, GitPullRequest, Hourglass, Info, MessageSquarePlus, SquareTerminal } from "@renderer/lib/hugeicons";
+import { useState } from "react";
+import { StructuredInputForm } from "../../components/conversation/StructuredInputForm";
+import { Button } from "../../design/primitives";
+import { codingAgentApprovalActionKey, codingAgentInputActionKey, useCodingAgentWorkspace } from "../../stores/coding-agent-workspace";
+
+function occurredAtLabel(value: string): string {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? "" : parsed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function eventCopy(event: AgentThreadEvent): { title: string; detail: string } {
+  switch (event.type) {
+    case "turn.accepted": return { title: "Message accepted", detail: "Waiting for the agent run" };
+    case "turn.status": return { title: "Message status", detail: event.status };
+    case "thread.created": return { title: "Thread created", detail: event.thread.title };
+    case "thread.status": return { title: "Status changed", detail: event.status.replaceAll("_", " ") };
+    case "approval.requested": return { title: "Approval needed", detail: event.approval.safeDescription };
+    case "approval.resolved": return { title: "Approval resolved", detail: event.decision };
+    case "user_input.requested": return { title: "Input needed", detail: event.request.safeDescription };
+    case "user_input.answered": return { title: "Input answered", detail: "Input answer received" };
+    case "file.changed": return { title: `File ${event.changeKind}`, detail: `${event.changeKind} file` };
+    case "review.ready": return { title: "Review ready", detail: `${event.summary.changedFileCount} ${event.summary.changedFileCount === 1 ? "file" : "files"} changed, +${event.summary.additions} -${event.summary.deletions}${event.summary.partial ? ", partial" : ""}` };
+    case "terminal.bound": return { title: "Terminal bound", detail: event.terminalSessionId };
+    case "thread.error": return { title: "Thread needs attention", detail: event.error.retryable ? "Refresh the thread or check the runtime." : "Open the workspace again." };
+    case "thread.completed": return { title: "Thread completed", detail: event.outcome };
+    case "user.message": return { title: "You", detail: event.text };
+    case "assistant.text.delta":
+    case "assistant.text.completed": return { title: "Assistant update", detail: "Text update received" };
+    case "tool.started":
+    case "tool.output":
+    case "tool.completed": return { title: "Tool activity", detail: "Tool state updated" };
+  }
+}
+
+function approvalLabel(decision: string) {
+  if (decision === "approve") return "Approve";
+  if (decision === "approve_for_session") return "Approve for session";
+  if (decision === "decline") return "Decline";
+  if (decision === "cancel") return "Cancel";
+  return "Decide";
+}
+
+// Pure status events ("Thread created", "Terminal bound", "Thread
+// completed", …) render as compact single-line timeline rows: a small
+// leading glyph, the bounded copy, and the timestamp at the right — no card
+// background, border, or shadow, so they read as history instead of
+// dominating the conversation.
+function systemEventIcon(event: AgentThreadEvent) {
+  switch (event.type) {
+    case "thread.created": return MessageSquarePlus;
+    case "thread.completed": return CircleCheck;
+    case "thread.error": return CircleAlert;
+    case "terminal.bound": return SquareTerminal;
+    case "turn.accepted": return Hourglass;
+    case "approval.resolved":
+    case "user_input.answered": return CircleCheck;
+    case "approval.requested":
+    case "user_input.requested": return CircleAlert;
+    case "file.changed": return FileDiff;
+    default: return Info;
+  }
+}
+
+export function SystemEvent({ event, answeredInputs, resolvedApprovals }: {
+  event: AgentThreadEvent;
+  answeredInputs: ReadonlySet<string>;
+  resolvedApprovals: ReadonlySet<string>;
+}) {
+  const copy = eventCopy(event);
+  const pendingApprovalKeys = useCodingAgentWorkspace((state) => state.pendingApprovalKeys);
+  const approvalErrors = useCodingAgentWorkspace((state) => state.approvalActionErrors);
+  const submitApproval = useCodingAgentWorkspace((state) => state.submitApprovalDecision);
+  const pendingInputKeys = useCodingAgentWorkspace((state) => state.pendingInputRequestKeys);
+  const inputErrors = useCodingAgentWorkspace((state) => state.inputActionErrors);
+  const submitInput = useCodingAgentWorkspace((state) => state.submitInputAnswer);
+  const selectReview = useCodingAgentWorkspace((state) => state.selectReview);
+  const [answer, setAnswer] = useState("");
+  const approval = event.type === "approval.requested" ? event.approval : null;
+  const input = event.type === "user_input.requested" ? event.request : null;
+  const approvalKey = approval ? codingAgentApprovalActionKey(approval.threadId, approval.approvalId) : null;
+  const inputKey = input ? codingAgentInputActionKey(input.threadId, input.requestId) : null;
+  // Events carrying a live action — a pending approval decision, a pending
+  // input answer, or an openable review — keep the card treatment; every
+  // other status event collapses to a compact timeline row.
+  const interactive = Boolean(
+    (approval && approvalKey && !resolvedApprovals.has(approvalKey))
+    || (input && inputKey && !answeredInputs.has(inputKey))
+    || event.type === "review.ready",
+  );
+  if (!interactive) {
+    const Glyph = systemEventIcon(event);
+    const failed = event.type === "thread.error";
+    return (
+      <div className="flex w-full items-center gap-2 px-1 py-0.5" data-slot="system-event-row">
+        <Glyph
+          size={12}
+          className="shrink-0"
+          style={{ color: failed ? "var(--danger)" : "var(--text-tertiary)" }}
+          aria-hidden="true"
+        />
+        <p className="min-w-0 flex-1 truncate text-[12px]" style={{ color: "var(--text-tertiary)" }}>
+          <span className="font-medium" style={{ color: failed ? "var(--danger)" : "var(--text-secondary)" }}>
+            {copy.title}
+          </span>
+          {copy.detail ? (
+            <>
+              <span aria-hidden="true"> · </span>
+              <span>{copy.detail}</span>
+            </>
+          ) : null}
+        </p>
+        <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--text-tertiary)" }}>
+          {occurredAtLabel(event.occurredAt)}
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="w-full rounded-lg border px-3 py-2" style={{ borderColor: "var(--border-subtle)", background: "var(--bg-overlay)" }}>
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>{copy.title}</h3>
+        <span className="text-[10px] tabular-nums" style={{ color: "var(--text-tertiary)" }}>{occurredAtLabel(event.occurredAt)}</span>
+      </div>
+      <p className="mt-0.5 text-xs" style={{ color: "var(--text-secondary)" }}>{copy.detail}</p>
+      {approval && approvalKey && !resolvedApprovals.has(approvalKey) ? (
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          {approval.allowedDecisions.map((decision) => (
+            <Button key={decision} variant={decision.startsWith("approve") ? "primary" : "danger"} aria-label={`${approvalLabel(decision)} ${approval.title}`} disabled={Boolean(approvalKey && pendingApprovalKeys.includes(approvalKey))} onClick={() => void submitApproval({ threadId: approval.threadId, approvalId: approval.approvalId, decision, correlationId: approval.correlationId })}>
+              {approvalKey && pendingApprovalKeys.includes(approvalKey) ? "Sending..." : approvalLabel(decision)}
+            </Button>
+          ))}
+          {approvalKey && approvalErrors[approvalKey] ? <span className="text-xs" style={{ color: "var(--danger)" }}>{approvalErrors[approvalKey]}</span> : null}
+        </div>
+      ) : null}
+      {input && inputKey && !answeredInputs.has(inputKey) ? (
+        input.questions ? <StructuredInputForm key={inputKey} request={input} submit={async (structuredAnswers) => {
+          await submitInput({ threadId: input.threadId, inputRequestId: input.requestId, answer: "Structured response submitted.", structuredAnswers, correlationId: input.correlationId });
+          if (useCodingAgentWorkspace.getState().inputActionErrors[inputKey]) throw new Error("InputSubmissionFailed");
+        }} /> :
+        <div className="mt-2 grid gap-2">
+          <textarea aria-label={`Answer ${input.title}`} className="min-h-20 resize-y rounded-md border px-3 py-2 text-sm outline-none" maxLength={8000} placeholder={input.placeholder ?? "Answer"} style={{ borderColor: "var(--border-subtle)", background: "var(--bg-surface)", color: "var(--text-primary)" }} value={answer} onChange={(event) => setAnswer(event.currentTarget.value)} />
+          <div className="flex items-center gap-2">
+            <Button variant="primary" aria-label={`Send ${input.title}`} disabled={pendingInputKeys.includes(inputKey) || (input.required && !answer.trim())} onClick={() => void submitInput({ threadId: input.threadId, inputRequestId: input.requestId, answer, correlationId: input.correlationId })}>
+              {pendingInputKeys.includes(inputKey) ? "Sending..." : "Send"}
+            </Button>
+            {inputErrors[inputKey] ? <span className="text-xs" style={{ color: "var(--danger)" }}>{inputErrors[inputKey]}</span> : null}
+          </div>
+        </div>
+      ) : null}
+      {event.type === "review.ready" ? (
+        <div className="mt-2">
+          <Button variant="subtle" aria-label="Open review from thread" onClick={() => void selectReview(event.reviewId)}>
+            <GitPullRequest size={14} /> Open review
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/lib/canonical-chat-client.ts
+++ b/desktop/src/renderer/src/lib/canonical-chat-client.ts
@@ -1,4 +1,8 @@
 import {
+  CanonicalSubmitChatInputRequestSchema,
+  CanonicalChatInputSubmissionResponseSchema,
+  type CanonicalSubmitChatInputRequest,
+  type CanonicalChatInputSubmissionResponse,
   CanonicalAcknowledgeChatCompletionRequestSchema,
   CanonicalCancelChatRunRequestSchema,
   CanonicalCancelQueuedChatTurnRequestSchema,
@@ -486,6 +490,7 @@ export interface CanonicalChatClient {
     approvalId: string,
     input: CanonicalSubmitChatApprovalRequest,
   ): Promise<CanonicalChatApprovalSubmissionResponse>;
+  submitInput(chatId: string, runId: string, requestId: string, input: CanonicalSubmitChatInputRequest): Promise<CanonicalChatInputSubmissionResponse>;
   retryTurn(
     chatId: string,
     turnId: string,
@@ -733,6 +738,15 @@ export function createCanonicalChatClient(
       return CanonicalChatApprovalSubmissionResponseSchema.parse(await api.post(
         `/api/chats/${encodeURIComponent(parsedChatId)}/runs/${encodeURIComponent(parsedRunId)}/approvals/${encodeURIComponent(parsedApprovalId)}`,
         request,
+      ));
+    },
+    async submitInput(chatId, runId, requestId, input) {
+      const parsedChatId = CanonicalChatIdSchema.parse(chatId);
+      const parsedRunId = CanonicalChatRunIdSchema.parse(runId);
+      const parsedRequestId = z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/).parse(requestId);
+      return CanonicalChatInputSubmissionResponseSchema.parse(await api.post(
+        `/api/chats/${encodeURIComponent(parsedChatId)}/runs/${encodeURIComponent(parsedRunId)}/inputs/${encodeURIComponent(parsedRequestId)}`,
+        CanonicalSubmitChatInputRequestSchema.parse(input),
       ));
     },
 

--- a/desktop/src/renderer/src/stores/coding-agent-workspace.ts
+++ b/desktop/src/renderer/src/stores/coding-agent-workspace.ts
@@ -141,6 +141,7 @@ interface CodingAgentWorkspaceState {
     threadId: string;
     inputRequestId: string;
     answer: UserInputAnswerRequest["answer"];
+    structuredAnswers?: UserInputAnswerRequest["structuredAnswers"];
     correlationId: string;
   }) => Promise<void>;
   requestComposerFocus: () => void;
@@ -907,7 +908,7 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
     }
   },
 
-  submitInputAnswer: async ({ threadId, inputRequestId, answer, correlationId }) => {
+  submitInputAnswer: async ({ threadId, inputRequestId, answer, structuredAnswers, correlationId }) => {
     const inputKey = codingAgentInputActionKey(threadId, inputRequestId);
     const { pendingInputRequestKeys } = useCodingAgentWorkspace.getState();
     if (pendingInputRequestKeys.includes(inputKey)) return;
@@ -924,6 +925,7 @@ export const useCodingAgentWorkspace = create<CodingAgentWorkspaceState>()((set)
         threadId,
         inputRequestId,
         answer,
+        ...(structuredAnswers ? { structuredAnswers } : {}),
         correlationId,
         clientRequestId: nextActionRequestId(),
       });

--- a/packages/ui/src/StructuredInputForm.tsx
+++ b/packages/ui/src/StructuredInputForm.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useRef, useState } from "react";
+import type { UserInputAnswerRequest, UserInputRequest } from "@matrix-os/contracts";
+
+type Answers = NonNullable<UserInputAnswerRequest["structuredAnswers"]>;
+
+/** Values stay in this form until an explicit submit; never copy them into transcript text. */
+export function StructuredInputForm({ request, submit }: {
+  request: UserInputRequest;
+  submit(answers: Answers): Promise<void>;
+}) {
+  const [answers, setAnswers] = useState<Answers>({});
+  const [pending, setPending] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const busy = useRef(false);
+  const questions = request.questions ?? [];
+  const action = questions.find((question) => question.questionId === request.connectorActionId);
+  const fields = questions.filter((question) => question !== action);
+  const ready = fields.every((question) => !(question.required ?? request.required)
+    || answers[question.questionId]?.some((value) => value.trim()));
+  const send = async (decision?: string) => {
+    if (busy.current) return;
+    const cancel = Boolean(action && decision !== "Allow once");
+    if (!cancel && !ready) return;
+    const values: Answers = cancel ? {} : Object.fromEntries(Object.entries(answers)
+      .filter(([, values]) => values.length && values.some((value) => value.trim())));
+    if (action && decision) values[action.questionId] = [decision];
+    busy.current = true;
+    setPending(true);
+    setFailed(false);
+    try { await submit(values); }
+    catch (error: unknown) {
+      console.warn("[conversation] input submission failed:", error instanceof Error ? error.name : "UnknownError");
+      setFailed(true);
+    } finally { busy.current = false; setPending(false); }
+  };
+  return (
+    <div className="mt-2 grid gap-3 ph-no-capture" data-slot="structured-input-form">
+      {request.connectorUrl ? (
+        <a href={request.connectorUrl} target="_blank" rel="noopener noreferrer" className="underline">
+          Open connector authorization ({new URL(request.connectorUrl).hostname})
+        </a>
+      ) : null}
+      {fields.map((question) => (
+        <fieldset key={question.questionId} disabled={pending} className="grid gap-1">
+          <legend className="text-sm font-medium">{question.question}</legend>
+          {question.options ? (
+            <div className="grid gap-1">
+              {question.options.map((option) => (
+                <label key={option.label} className="flex items-start gap-2 text-sm">
+                  <input type={question.multiple ? "checkbox" : "radio"}
+                    name={`${request.requestId}:${question.questionId}`}
+                    checked={answers[question.questionId]?.includes(option.label) ?? false}
+                    onChange={(event) => setAnswers((current) => {
+                      const selected = current[question.questionId] ?? [];
+                      const next = question.multiple
+                        ? event.target.checked ? [...selected, option.label].slice(0, 4) : selected.filter((value) => value !== option.label)
+                        : [option.label];
+                      return { ...current, [question.questionId]: next };
+                    })} />
+                  <span>{option.label}<span className="block text-xs opacity-70">{option.description}</span></span>
+                </label>
+              ))}
+            </div>
+          ) : null}
+          {!question.options || question.allowOther ? (
+            <input aria-label={question.question} type={question.secret ? "password" : "text"}
+              autoComplete="off" maxLength={400}
+              className="min-w-0 rounded border bg-transparent px-2 py-1 text-sm"
+              value={answers[question.questionId]?.[0] ?? ""}
+              onChange={(event) => setAnswers((current) => ({ ...current, [question.questionId]: [event.target.value] }))} />
+          ) : null}
+        </fieldset>
+      ))}
+      {action ? <p className="text-sm">{action.question}</p> : null}
+      <div className="flex flex-wrap gap-2">
+        {(action?.options?.map((option) => option.label) ?? ["Submit"]).map((label) => (
+          <button key={label} type="button" disabled={pending || ((label === "Allow once" || !action) && !ready)}
+            className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+            onClick={() => void send(action ? label : undefined)}>{pending ? "Sending…" : label}</button>
+        ))}
+      </div>
+      {failed ? <p role="alert" className="text-sm">The response could not be submitted. Check your answers and try again.</p> : null}
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -50,3 +50,4 @@ export type {
 export { TerminalControls } from './terminal/TerminalControls.js';
 export { useTerminalControls } from './terminal/use-terminal-controls.js';
 export type { TerminalControlsState, TerminalControlsTransport, TerminalControlsOptions } from './terminal/use-terminal-controls.js';
+export { StructuredInputForm } from "./StructuredInputForm.js";

--- a/shell/src/components/ChatApp.tsx
+++ b/shell/src/components/ChatApp.tsx
@@ -131,6 +131,7 @@ interface ChatAppProps {
     decision: CanonicalChatApprovalDecision,
   ) => Promise<boolean>;
   onSubmitInput?: (runId: string, requestId: string, answers: CanonicalSubmitChatInputRequest["answers"]) => Promise<boolean>;
+  onStopRun?: () => void;
   composerDraftRequest?: { id: number; text: string } | null;
   onComposerDraftConsumed?: (id: number) => void;
   onProviderSetupAction?: (
@@ -181,6 +182,7 @@ export function ChatApp({
   providerSelection,
   onSubmitApproval,
   onSubmitInput,
+  onStopRun,
   composerDraftRequest,
   onComposerDraftConsumed,
   onProviderSetupAction,
@@ -490,7 +492,7 @@ export function ChatApp({
                           </MessageContent>
                         </Message>
                       ) : msg.role === "system" ? (
-                        canonicalInput(msg) ? <CanonicalInputMessage message={msg} onSubmit={onSubmitInput} /> :
+                        canonicalInput(msg) ? <CanonicalInputMessage message={msg} onSubmit={onSubmitInput} onStop={onStopRun} /> :
                         <CanonicalApprovalMessage
                           message={msg}
                           submitting={(() => {
@@ -513,7 +515,7 @@ export function ChatApp({
                 })}
 
                 {busy && messages.some((message) => canonicalApproval(message)?.pending || canonicalInput(message)?.pending) ? (
-                  <p role="status" className="text-sm text-muted-foreground">Waiting for your approval or response above.</p>
+                  <p role="status" className="text-sm text-muted-foreground">A request needs your attention above.</p>
                 ) : busy && (
                   <div className="flex items-center gap-2.5 text-sm text-muted-foreground py-1">
                     <div className="flex gap-1">

--- a/shell/src/components/ChatApp.tsx
+++ b/shell/src/components/ChatApp.tsx
@@ -2,12 +2,14 @@
 
 import { useState, useMemo, useRef, useEffect } from "react";
 import type {
+  CanonicalSubmitChatInputRequest,
   CanonicalChatApprovalDecision,
   CanonicalChatModelSelection,
   CanonicalProviderInstanceDescriptor,
   CanonicalProviderSetupAction,
 } from "@matrix-os/contracts";
 import { type ChatMessage, groupMessages } from "@/lib/chat";
+import { CanonicalInputMessage, canonicalInput } from "./chat/CanonicalInputMessage";
 import {
   Conversation,
   ConversationContent,
@@ -128,6 +130,7 @@ interface ChatAppProps {
     approvalId: string,
     decision: CanonicalChatApprovalDecision,
   ) => Promise<boolean>;
+  onSubmitInput?: (runId: string, requestId: string, answers: CanonicalSubmitChatInputRequest["answers"]) => Promise<boolean>;
   composerDraftRequest?: { id: number; text: string } | null;
   onComposerDraftConsumed?: (id: number) => void;
   onProviderSetupAction?: (
@@ -177,6 +180,7 @@ export function ChatApp({
   onSubmit,
   providerSelection,
   onSubmitApproval,
+  onSubmitInput,
   composerDraftRequest,
   onComposerDraftConsumed,
   onProviderSetupAction,
@@ -486,6 +490,7 @@ export function ChatApp({
                           </MessageContent>
                         </Message>
                       ) : msg.role === "system" ? (
+                        canonicalInput(msg) ? <CanonicalInputMessage message={msg} onSubmit={onSubmitInput} /> :
                         <CanonicalApprovalMessage
                           message={msg}
                           submitting={(() => {
@@ -507,7 +512,9 @@ export function ChatApp({
                   );
                 })}
 
-                {busy && (
+                {busy && messages.some((message) => canonicalApproval(message)?.pending || canonicalInput(message)?.pending) ? (
+                  <p role="status" className="text-sm text-muted-foreground">Waiting for your approval or response above.</p>
+                ) : busy && (
                   <div className="flex items-center gap-2.5 text-sm text-muted-foreground py-1">
                     <div className="flex gap-1">
                       <span className="size-1.5 rounded-full bg-foreground/40 animate-pulse" style={{ animationDelay: "0ms" }} />

--- a/shell/src/components/ChatApp.tsx
+++ b/shell/src/components/ChatApp.tsx
@@ -131,7 +131,7 @@ interface ChatAppProps {
     decision: CanonicalChatApprovalDecision,
   ) => Promise<boolean>;
   onSubmitInput?: (runId: string, requestId: string, answers: CanonicalSubmitChatInputRequest["answers"]) => Promise<boolean>;
-  onStopRun?: () => void;
+  onStopRun?: (runId: string) => void;
   composerDraftRequest?: { id: number; text: string } | null;
   onComposerDraftConsumed?: (id: number) => void;
   onProviderSetupAction?: (

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -531,7 +531,7 @@ export function CanvasWindow({ win, iconUrl, hidden = false, deferAppContent = f
               onSubmit={chatState.submitMessage}
               onSubmitApproval={chatState.submitApproval}
               onSubmitInput={chatState.submitInput}
-              onStopRun={chatState.abortCurrent}
+              onStopRun={chatState.cancelRun}
               providerSelection={chatState.providerSelection}
               composerDraftRequest={chatState.composerDraftRequest}
               onComposerDraftConsumed={chatState.consumeComposerDraft}

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -530,6 +530,7 @@ export function CanvasWindow({ win, iconUrl, hidden = false, deferAppContent = f
               onRenameConversation={chatState.renameConversation}
               onSubmit={chatState.submitMessage}
               onSubmitApproval={chatState.submitApproval}
+              onSubmitInput={chatState.submitInput}
               providerSelection={chatState.providerSelection}
               composerDraftRequest={chatState.composerDraftRequest}
               onComposerDraftConsumed={chatState.consumeComposerDraft}

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -531,6 +531,7 @@ export function CanvasWindow({ win, iconUrl, hidden = false, deferAppContent = f
               onSubmit={chatState.submitMessage}
               onSubmitApproval={chatState.submitApproval}
               onSubmitInput={chatState.submitInput}
+              onStopRun={chatState.abortCurrent}
               providerSelection={chatState.providerSelection}
               composerDraftRequest={chatState.composerDraftRequest}
               onComposerDraftConsumed={chatState.consumeComposerDraft}

--- a/shell/src/components/chat/CanonicalInputMessage.tsx
+++ b/shell/src/components/chat/CanonicalInputMessage.tsx
@@ -14,7 +14,7 @@ export function canonicalInput(message: ChatMessage) {
 
 export function CanonicalInputMessage({ message, onSubmit, onStop }: {
   message: ChatMessage;
-  onStop?: () => void;
+  onStop?: (runId: string) => void;
   onSubmit?: (runId: string, requestId: string, answers: CanonicalSubmitChatInputRequest["answers"]) => Promise<boolean>;
 }) {
   const input = canonicalInput(message);
@@ -23,7 +23,7 @@ export function CanonicalInputMessage({ message, onSubmit, onStop }: {
     <p className="font-medium">{"request" in input ? input.request.title : input.title}</p>
     {input.pending ? <>
       <p>This request cannot be answered in this view. Stop the run, then retry with your clarification.</p>
-      {onStop ? <button type="button" className="mt-2 rounded border px-3 py-1" onClick={onStop}>Stop run to retry</button> : null}
+      {onStop ? <button type="button" className="mt-2 rounded border px-3 py-1" onClick={() => onStop(input.runId)}>Stop run to retry</button> : null}
     </> : <p>Resolved</p>}
   </div>;
   return <div className="rounded-md border border-warning/30 bg-warning/5 p-3 text-sm">

--- a/shell/src/components/chat/CanonicalInputMessage.tsx
+++ b/shell/src/components/chat/CanonicalInputMessage.tsx
@@ -1,0 +1,24 @@
+import { z } from "zod/v4";
+import { CanonicalChatRunIdSchema, UserInputRequestSchema, type CanonicalSubmitChatInputRequest } from "@matrix-os/contracts";
+import { StructuredInputForm } from "@matrix-os/ui";
+import type { ChatMessage } from "@/lib/chat";
+
+const Input = z.object({ runId: CanonicalChatRunIdSchema, request: UserInputRequestSchema, pending: z.boolean() }).strict();
+export function canonicalInput(message: ChatMessage) {
+  const parsed = Input.safeParse(message.metadata?.canonicalInput);
+  return parsed.success ? parsed.data : null;
+}
+
+export function CanonicalInputMessage({ message, onSubmit }: {
+  message: ChatMessage;
+  onSubmit?: (runId: string, requestId: string, answers: CanonicalSubmitChatInputRequest["answers"]) => Promise<boolean>;
+}) {
+  const input = canonicalInput(message);
+  if (!input) return null;
+  return <div className="rounded-md border border-warning/30 bg-warning/5 p-3 text-sm">
+    <p className="font-medium">{input.request.title}</p>
+    {input.pending && onSubmit ? <StructuredInputForm key={input.request.requestId} request={input.request} submit={async (answers) => {
+      if (!await onSubmit(input.runId, input.request.requestId, answers)) throw new Error("InputSubmissionFailed");
+    }} /> : <p>{input.pending ? "Input unavailable" : "Resolved"}</p>}
+  </div>;
+}

--- a/shell/src/components/chat/CanonicalInputMessage.tsx
+++ b/shell/src/components/chat/CanonicalInputMessage.tsx
@@ -3,18 +3,29 @@ import { CanonicalChatRunIdSchema, UserInputRequestSchema, type CanonicalSubmitC
 import { StructuredInputForm } from "@matrix-os/ui";
 import type { ChatMessage } from "@/lib/chat";
 
-const Input = z.object({ runId: CanonicalChatRunIdSchema, request: UserInputRequestSchema, pending: z.boolean() }).strict();
+const Input = z.union([
+  z.object({ runId: CanonicalChatRunIdSchema, request: UserInputRequestSchema, pending: z.boolean() }).strict(),
+  z.object({ runId: CanonicalChatRunIdSchema, requestId: z.string().min(1).max(128), title: z.string().min(1).max(160), pending: z.boolean() }).strict(),
+]);
 export function canonicalInput(message: ChatMessage) {
   const parsed = Input.safeParse(message.metadata?.canonicalInput);
   return parsed.success ? parsed.data : null;
 }
 
-export function CanonicalInputMessage({ message, onSubmit }: {
+export function CanonicalInputMessage({ message, onSubmit, onStop }: {
   message: ChatMessage;
+  onStop?: () => void;
   onSubmit?: (runId: string, requestId: string, answers: CanonicalSubmitChatInputRequest["answers"]) => Promise<boolean>;
 }) {
   const input = canonicalInput(message);
   if (!input) return null;
+  if (!("request" in input) || !input.request.questions?.length) return <div className="rounded-md border p-3 text-sm">
+    <p className="font-medium">{"request" in input ? input.request.title : input.title}</p>
+    {input.pending ? <>
+      <p>This request cannot be answered in this view. Stop the run, then retry with your clarification.</p>
+      {onStop ? <button type="button" className="mt-2 rounded border px-3 py-1" onClick={onStop}>Stop run to retry</button> : null}
+    </> : <p>Resolved</p>}
+  </div>;
   return <div className="rounded-md border border-warning/30 bg-warning/5 p-3 text-sm">
     <p className="font-medium">{input.request.title}</p>
     {input.pending && onSubmit ? <StructuredInputForm key={input.request.requestId} request={input.request} submit={async (answers) => {

--- a/shell/src/components/desktop/DesktopWindow.tsx
+++ b/shell/src/components/desktop/DesktopWindow.tsx
@@ -219,6 +219,7 @@ export function DesktopWindow({
                 onSubmit={chat.submitMessage}
                 onSubmitApproval={chat.submitApproval}
                 onSubmitInput={chat.submitInput}
+                onStopRun={chat.abortCurrent}
                 providerSelection={chat.providerSelection}
                 composerDraftRequest={chat.composerDraftRequest}
                 onComposerDraftConsumed={chat.consumeComposerDraft}

--- a/shell/src/components/desktop/DesktopWindow.tsx
+++ b/shell/src/components/desktop/DesktopWindow.tsx
@@ -219,7 +219,7 @@ export function DesktopWindow({
                 onSubmit={chat.submitMessage}
                 onSubmitApproval={chat.submitApproval}
                 onSubmitInput={chat.submitInput}
-                onStopRun={chat.abortCurrent}
+                onStopRun={chat.cancelRun}
                 providerSelection={chat.providerSelection}
                 composerDraftRequest={chat.composerDraftRequest}
                 onComposerDraftConsumed={chat.consumeComposerDraft}

--- a/shell/src/components/desktop/DesktopWindow.tsx
+++ b/shell/src/components/desktop/DesktopWindow.tsx
@@ -218,6 +218,7 @@ export function DesktopWindow({
                 onRenameConversation={chat.renameConversation}
                 onSubmit={chat.submitMessage}
                 onSubmitApproval={chat.submitApproval}
+                onSubmitInput={chat.submitInput}
                 providerSelection={chat.providerSelection}
                 composerDraftRequest={chat.composerDraftRequest}
                 onComposerDraftConsumed={chat.consumeComposerDraft}

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -542,7 +542,7 @@ function MobileAppFrame({
         onSubmit={chat.submitMessage}
         onSubmitApproval={chat.submitApproval}
         onSubmitInput={chat.submitInput}
-        onStopRun={chat.abortCurrent}
+        onStopRun={chat.cancelRun}
         providerSelection={chat.providerSelection}
         composerDraftRequest={chat.composerDraftRequest}
         onComposerDraftConsumed={chat.consumeComposerDraft}

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -541,6 +541,7 @@ function MobileAppFrame({
         onRenameConversation={chat.renameConversation}
         onSubmit={chat.submitMessage}
         onSubmitApproval={chat.submitApproval}
+        onSubmitInput={chat.submitInput}
         providerSelection={chat.providerSelection}
         composerDraftRequest={chat.composerDraftRequest}
         onComposerDraftConsumed={chat.consumeComposerDraft}

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -542,6 +542,7 @@ function MobileAppFrame({
         onSubmit={chat.submitMessage}
         onSubmitApproval={chat.submitApproval}
         onSubmitInput={chat.submitInput}
+        onStopRun={chat.abortCurrent}
         providerSelection={chat.providerSelection}
         composerDraftRequest={chat.composerDraftRequest}
         onComposerDraftConsumed={chat.consumeComposerDraft}

--- a/shell/src/hooks/useCanonicalChatState.ts
+++ b/shell/src/hooks/useCanonicalChatState.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
+  CanonicalSubmitChatInputRequest,
   CanonicalChatApprovalDecision,
   CanonicalChatDetailResponse,
   CanonicalChatRecord,
@@ -9,6 +10,7 @@ import type {
 import { useSocket } from "@/hooks/useSocket";
 import type { ChatState, ChatSubmitOptions } from "@/hooks/useChatState";
 import { getGatewayUrl } from "@/lib/gateway";
+import { projectCanonicalRequests } from "@/lib/canonical-chat-requests";
 import {
   createCanonicalShellChatClient,
   isDefinitiveCanonicalChatRejection,
@@ -279,6 +281,19 @@ export function useCanonicalChatState(): ChatState {
     }
   }, [client, loadDetail]);
 
+  const submitInput = useCallback(async (runId: string, inputRequestId: string, answers: CanonicalSubmitChatInputRequest["answers"]) => {
+    const current = detailRef.current;
+    if (!current?.record.activeRun || current.record.chat.id !== activeChatIdRef.current || current.record.activeRun.runId !== runId) return false;
+    try {
+      await client.submitInput(current.record.chat.id, runId, inputRequestId, { answers, clientRequestId: requestId() });
+      await loadDetail(current.record.chat.id);
+      return true;
+    } catch (error: unknown) {
+      console.warn("[canonical-chat] Shell input failed:", error instanceof Error ? error.name : "UnknownError");
+      return false;
+    }
+  }, [client, loadDetail]);
+
   const renameConversation = useCallback(async (chatId: string, title: string) => {
     const current = detailRef.current?.record.chat.id === chatId
       ? detailRef.current.record
@@ -318,7 +333,8 @@ export function useCanonicalChatState(): ChatState {
     }
   }, [client, records]);
 
-  const messages = detail ? projectCanonicalMessages(detail.messages) : [];
+  const messages = detail ? projectCanonicalRequests(detail.activities, detail.runs,
+    projectCanonicalMessages(detail.messages)) : [];
   if (safeError) {
     messages.push({ id: "canonical-safe-error", role: "system", content: safeError, timestamp: Date.now() });
   }
@@ -345,5 +361,6 @@ export function useCanonicalChatState(): ChatState {
     switchConversation,
     abortCurrent,
     submitApproval,
+    submitInput,
   };
 }

--- a/shell/src/hooks/useCanonicalChatState.ts
+++ b/shell/src/hooks/useCanonicalChatState.ts
@@ -241,16 +241,25 @@ export function useCanonicalChatState(): ChatState {
     setSafeError(null);
   }, []);
 
-  const abortCurrent = useCallback(() => {
+  const cancelRun = useCallback(async (runId: string) => {
     const current = detailRef.current;
-    if (!current?.record.activeRun) return;
-    void client.cancelRun(current.record.chat.id, current.record.activeRun.runId, requestId())
-      .then(() => loadDetail(current.record.chat.id))
-      .catch((error: unknown) => {
-        console.warn("[canonical-chat] Shell cancellation failed:", error instanceof Error ? error.name : "UnknownError");
-        setSafeError("The run could not be stopped. Try again.");
-      });
+    if (!current?.record.activeRun || current.record.chat.id !== activeChatIdRef.current
+      || current.record.activeRun.runId !== runId) return false;
+    try {
+      await client.cancelRun(current.record.chat.id, runId, requestId());
+      await loadDetail(current.record.chat.id);
+      return true;
+    } catch (error: unknown) {
+      console.warn("[canonical-chat] Shell cancellation failed:", error instanceof Error ? error.name : "UnknownError");
+      setSafeError("The run could not be stopped. Try again.");
+      return false;
+    }
   }, [client, loadDetail]);
+
+  const abortCurrent = useCallback(() => {
+    const runId = detailRef.current?.record.activeRun?.runId;
+    if (runId) void cancelRun(runId);
+  }, [cancelRun]);
 
   const submitApproval = useCallback(async (
     runId: string,
@@ -360,6 +369,7 @@ export function useCanonicalChatState(): ChatState {
     newChat,
     switchConversation,
     abortCurrent,
+    cancelRun,
     submitApproval,
     submitInput,
   };

--- a/shell/src/hooks/useChatState.ts
+++ b/shell/src/hooks/useChatState.ts
@@ -6,6 +6,7 @@ import { useConversation } from "@/hooks/useConversation";
 import { reduceChat, hydrateMessages, type ChatMessage } from "@/lib/chat";
 import { getGatewayUrl } from "@/lib/gateway";
 import type { CanonicalChatApprovalDecision, CanonicalChatModelSelection } from "@matrix-os/contracts";
+import type { CanonicalSubmitChatInputRequest } from "@matrix-os/contracts";
 
 const GATEWAY_URL = getGatewayUrl();
 const GATEWAY_FETCH_TIMEOUT_MS = 10_000;
@@ -51,6 +52,7 @@ export interface ChatState {
     approvalId: string,
     decision: CanonicalChatApprovalDecision,
   ) => Promise<boolean>;
+  submitInput?: (runId: string, inputRequestId: string, answers: CanonicalSubmitChatInputRequest["answers"]) => Promise<boolean>;
 }
 
 export interface ChatSubmitOptions {

--- a/shell/src/hooks/useChatState.ts
+++ b/shell/src/hooks/useChatState.ts
@@ -47,6 +47,7 @@ export interface ChatState {
   switchConversation: (id: string) => void;
   /** Stops the in-flight agent run. No-op if nothing is running. */
   abortCurrent: () => void;
+  cancelRun?: (runId: string) => Promise<boolean>;
   submitApproval?: (
     runId: string,
     approvalId: string,

--- a/shell/src/lib/canonical-chat-client.ts
+++ b/shell/src/lib/canonical-chat-client.ts
@@ -1,4 +1,8 @@
 import {
+  CanonicalSubmitChatInputRequestSchema,
+  CanonicalChatInputSubmissionResponseSchema,
+  type CanonicalSubmitChatInputRequest,
+  type CanonicalChatInputSubmissionResponse,
   CanonicalChatDetailResponseSchema,
   CanonicalChatApprovalDecisionSchema,
   CanonicalChatApprovalSubmissionResponseSchema,
@@ -31,6 +35,7 @@ import type { ChatMessage } from "@/lib/chat";
 const REQUEST_TIMEOUT_MS = 10_000;
 
 export interface CanonicalShellChatClient {
+  submitInput(chatId: string, runId: string, requestId: string, input: CanonicalSubmitChatInputRequest): Promise<CanonicalChatInputSubmissionResponse>;
   list(): Promise<CanonicalChatListResponse>;
   create(input: CanonicalCreateChatRequest): Promise<CanonicalChatRecord>;
   detail(chatId: string): Promise<CanonicalChatDetailResponse>;
@@ -224,6 +229,16 @@ export function createCanonicalShellChatClient(options: {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         },
+      ));
+    },
+    async submitInput(chatId, runId, requestId, input) {
+      const id = CanonicalChatIdSchema.parse(chatId);
+      const parsedRunId = CanonicalChatRunIdSchema.parse(runId);
+      const parsedRequestId = safeReference(requestId);
+      const body = CanonicalSubmitChatInputRequestSchema.parse(input);
+      return CanonicalChatInputSubmissionResponseSchema.parse(await request(
+        `/api/chats/${encodeURIComponent(id)}/runs/${encodeURIComponent(parsedRunId)}/inputs/${encodeURIComponent(parsedRequestId)}`,
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) },
       ));
     },
   };

--- a/shell/src/lib/canonical-chat-requests.ts
+++ b/shell/src/lib/canonical-chat-requests.ts
@@ -3,14 +3,18 @@ import type { ChatMessage } from "./chat";
 
 /** Run activities are the source of live consent; message parts alone omit Codex requests. */
 export function projectCanonicalRequests(activities: CanonicalChatRunActivity[], runs: CanonicalChatRun[], messages: ChatMessage[] = []): ChatMessage[] {
-  const requests = new Map<string, ChatMessage>(); // Bounded by the API's message and 500-event replay windows.
+  const requests = new Map<string, ChatMessage>(); // Local cap: 500, evict oldest insertion first.
+  const setRequest = (id: string, message: ChatMessage) => {
+    if (!requests.has(id) && requests.size >= 500) requests.delete(requests.keys().next().value!);
+    requests.set(id, message);
+  };
   const isActive = (id: string) => runs.some((run) => run.id === id
     && ["accepted", "running", "waiting_for_approval", "waiting_for_input"].includes(run.status));
   const ordinary = messages.filter((message) => {
     const approval = message.metadata?.canonicalApproval;
     if (!approval || typeof approval !== "object" || !("runId" in approval) || !("approvalId" in approval)
       || typeof approval.runId !== "string" || typeof approval.approvalId !== "string") return true;
-    requests.set(`${approval.runId}:approval:${approval.approvalId}`, { ...message,
+    setRequest(`${approval.runId}:approval:${approval.approvalId}`, { ...message,
       metadata: { ...message.metadata, canonicalApproval: { ...approval, pending: isActive(approval.runId) && "pending" in approval && approval.pending === true } } });
     return false;
   });
@@ -21,19 +25,20 @@ export function projectCanonicalRequests(activities: CanonicalChatRunActivity[],
     if (event.type === "approval.requested") {
       const id = `${event.runId}:approval:${event.approvalId}`;
       if (requests.has(id)) continue;
-      requests.set(id, { id, role: "system", content: event.title, timestamp: Date.parse(event.occurredAt),
+      setRequest(id, { id, role: "system", content: event.title, timestamp: Date.parse(event.occurredAt),
         metadata: { canonicalApproval: { runId: event.runId, approvalId: event.approvalId, title: event.title,
-          description: "Review this request to continue.", risk: event.risk, allowedDecisions: event.allowedDecisions, pending: active } } });
-    } else if (event.type === "input.requested" && event.input) {
+          description: event.description ?? "Review this request to continue.", risk: event.risk, allowedDecisions: event.allowedDecisions, pending: active } } });
+    } else if (event.type === "input.requested") {
       const id = `${event.runId}:input:${event.requestId}`;
-      requests.set(id, { id, role: "system", content: event.title, timestamp: Date.parse(event.occurredAt),
-        metadata: { canonicalInput: { runId: event.runId, request: event.input, pending: active } } });
+      setRequest(id, { id, role: "system", content: event.title, timestamp: Date.parse(event.occurredAt),
+        metadata: { canonicalInput: { runId: event.runId, pending: active,
+          ...(event.input ? { request: event.input } : { requestId: event.requestId, title: event.title }) } } });
     } else if (event.type === "approval.resolved" || event.type === "input.resolved") {
       const id = event.type === "approval.resolved" ? `${event.runId}:approval:${event.approvalId}` : `${event.runId}:input:${event.requestId}`;
       const request = requests.get(id);
       const key = event.type === "approval.resolved" ? "canonicalApproval" : "canonicalInput";
       const value = request?.metadata?.[key];
-      if (request && value && typeof value === "object") requests.set(id, { ...request, metadata: { [key]: { ...value, pending: false } } });
+      if (request && value && typeof value === "object") setRequest(id, { ...request, metadata: { [key]: { ...value, pending: false } } });
     }
   }
   return [...ordinary, ...requests.values()].sort((left, right) => left.timestamp - right.timestamp);

--- a/shell/src/lib/canonical-chat-requests.ts
+++ b/shell/src/lib/canonical-chat-requests.ts
@@ -1,0 +1,40 @@
+import type { CanonicalChatRunActivity, CanonicalChatRun } from "@matrix-os/contracts";
+import type { ChatMessage } from "./chat";
+
+/** Run activities are the source of live consent; message parts alone omit Codex requests. */
+export function projectCanonicalRequests(activities: CanonicalChatRunActivity[], runs: CanonicalChatRun[], messages: ChatMessage[] = []): ChatMessage[] {
+  const requests = new Map<string, ChatMessage>(); // Bounded by the API's message and 500-event replay windows.
+  const isActive = (id: string) => runs.some((run) => run.id === id
+    && ["accepted", "running", "waiting_for_approval", "waiting_for_input"].includes(run.status));
+  const ordinary = messages.filter((message) => {
+    const approval = message.metadata?.canonicalApproval;
+    if (!approval || typeof approval !== "object" || !("runId" in approval) || !("approvalId" in approval)
+      || typeof approval.runId !== "string" || typeof approval.approvalId !== "string") return true;
+    requests.set(`${approval.runId}:approval:${approval.approvalId}`, { ...message,
+      metadata: { ...message.metadata, canonicalApproval: { ...approval, pending: isActive(approval.runId) && "pending" in approval && approval.pending === true } } });
+    return false;
+  });
+  for (const event of activities.slice(-500)) {
+    const run = runs.find((run) => run.id === event.runId);
+    if (!run) continue;
+    const active = isActive(run.id);
+    if (event.type === "approval.requested") {
+      const id = `${event.runId}:approval:${event.approvalId}`;
+      if (requests.has(id)) continue;
+      requests.set(id, { id, role: "system", content: event.title, timestamp: Date.parse(event.occurredAt),
+        metadata: { canonicalApproval: { runId: event.runId, approvalId: event.approvalId, title: event.title,
+          description: "Review this request to continue.", risk: event.risk, allowedDecisions: event.allowedDecisions, pending: active } } });
+    } else if (event.type === "input.requested" && event.input) {
+      const id = `${event.runId}:input:${event.requestId}`;
+      requests.set(id, { id, role: "system", content: event.title, timestamp: Date.parse(event.occurredAt),
+        metadata: { canonicalInput: { runId: event.runId, request: event.input, pending: active } } });
+    } else if (event.type === "approval.resolved" || event.type === "input.resolved") {
+      const id = event.type === "approval.resolved" ? `${event.runId}:approval:${event.approvalId}` : `${event.runId}:input:${event.requestId}`;
+      const request = requests.get(id);
+      const key = event.type === "approval.resolved" ? "canonicalApproval" : "canonicalInput";
+      const value = request?.metadata?.[key];
+      if (request && value && typeof value === "object") requests.set(id, { ...request, metadata: { [key]: { ...value, pending: false } } });
+    }
+  }
+  return [...ordinary, ...requests.values()].sort((left, right) => left.timestamp - right.timestamp);
+}

--- a/tests/desktop/chat-pending-attention.test.ts
+++ b/tests/desktop/chat-pending-attention.test.ts
@@ -1,0 +1,11 @@
+import { expect, it } from "vitest";
+import { createCanonicalChatFixture } from "../contracts/fixtures/canonical-chat";
+import { canonicalChatPresentation } from "../../desktop/src/renderer/src/features/chat/canonical-chat-presentation";
+
+it.each(["waiting_for_approval", "waiting_for_input"] as const)("does not describe %s as ongoing model work", (status) => {
+  const { snapshot } = createCanonicalChatFixture("accepted");
+  snapshot.runs[0]!.status = status;
+  const [turn] = canonicalChatPresentation(snapshot);
+  expect(turn?.waitingFor).toBe(status === "waiting_for_approval" ? "approval" : "input");
+  expect(turn?.work.some((item) => item.kind === "activity-group" && item.activities.some((activity) => activity.label === "Working"))).toBe(false);
+});

--- a/tests/desktop/structured-input-form.test.tsx
+++ b/tests/desktop/structured-input-form.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StructuredInputForm } from "../../desktop/src/renderer/src/components/conversation/StructuredInputForm";
+import type { UserInputRequest } from "@matrix-os/contracts";
+afterEach(cleanup);
+const request: UserInputRequest = {
+  requestId: "req_form", threadId: "thread_form", title: "Connector request", safeDescription: "Review this request.", correlationId: "corr_form", required: false,
+  connectorActionId: "question_action", questions: [
+    { questionId: "question_name", header: "Name", question: "Enter a name", required: true, allowOther: false, secret: true },
+    { questionId: "question_action", header: "Permission", question: "Allow this request?", allowOther: false, secret: false,
+      options: ["Allow once", "Decline", "Cancel"].map((label) => ({ label, description: label })) },
+  ],
+};
+describe("structured consent", () => {
+  it("does not auto-submit and permits cancellation without required field values", async () => {
+    const submit = vi.fn(async () => {});
+    render(<StructuredInputForm request={request} submit={submit} />);
+    expect(submit).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(submit).toHaveBeenCalledWith({ question_action: ["Cancel"] }));
+  });
+  it("submits structured values with consent and retains them after failure", async () => {
+    const submit = vi.fn(async () => { throw new Error("private failure"); });
+    render(<StructuredInputForm request={request} submit={submit} />);
+    fireEvent.change(screen.getByLabelText("Enter a name"), { target: { value: "Ada" } });
+    fireEvent.click(screen.getByRole("button", { name: "Allow once" }));
+    await waitFor(() => expect(submit).toHaveBeenCalledWith({ question_name: ["Ada"], question_action: ["Allow once"] }));
+    expect((await screen.findByRole("alert")).textContent).not.toContain("private failure");
+    expect((screen.getByLabelText("Enter a name") as HTMLInputElement).value).toBe("Ada");
+  });
+});

--- a/tests/shell/canonical-chat-requests.test.ts
+++ b/tests/shell/canonical-chat-requests.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "vitest";
+import { projectCanonicalRequests } from "../../shell/src/lib/canonical-chat-requests";
+import { createCanonicalChatFixture } from "../contracts/fixtures/canonical-chat";
+
+it("projects a run-activity approval even when no saved message contains it", () => {
+  const { snapshot } = createCanonicalChatFixture("accepted");
+  const run = snapshot.runs[0]!;
+  const event = { id: "activity_approval", chatId: run.chatId, runId: run.id, occurredAt: run.createdAt,
+    type: "approval.requested" as const, approvalId: "appr_command", title: "Run command", risk: "medium" as const, allowedDecisions: ["approve" as const, "cancel" as const] };
+  const messages = projectCanonicalRequests([event], snapshot.runs);
+  expect(messages).toHaveLength(1);
+  expect(messages[0]?.metadata?.canonicalApproval).toMatchObject({ runId: run.id, approvalId: "appr_command", pending: true });
+  expect(projectCanonicalRequests([event, { id: "activity_resolved", chatId: run.chatId, runId: run.id, occurredAt: run.createdAt, type: "approval.resolved", approvalId: "appr_command", decision: "cancel" }], snapshot.runs)[0]?.metadata?.canonicalApproval).toMatchObject({ pending: false });
+});
+
+it("reconciles saved approvals with activities without duplicate or stale controls", () => {
+  const { snapshot } = createCanonicalChatFixture("accepted");
+  const run = snapshot.runs[0]!;
+  const message = { id: "saved", role: "system" as const, content: "Command details", timestamp: 1,
+    metadata: { canonicalApproval: { runId: run.id, approvalId: "appr_command", title: "Run", description: "git fetch origin", pending: true } } };
+  const event = { id: "requested", chatId: run.chatId, runId: run.id, occurredAt: run.createdAt,
+    type: "approval.requested" as const, approvalId: "appr_command", title: "Run", risk: "medium" as const, allowedDecisions: ["approve" as const] };
+  expect(projectCanonicalRequests([event], snapshot.runs, [message])).toHaveLength(1);
+  const resolved = { id: "resolved", chatId: run.chatId, runId: run.id, occurredAt: run.createdAt,
+    type: "approval.resolved" as const, approvalId: "appr_command", decision: "cancel" as const };
+  expect(projectCanonicalRequests([resolved], snapshot.runs, [message])[0]?.metadata?.canonicalApproval).toMatchObject({ pending: false, description: "git fetch origin" });
+  expect(projectCanonicalRequests([], [{ ...run, status: "completed" }], [message])[0]?.metadata?.canonicalApproval).toMatchObject({ pending: false });
+});

--- a/tests/shell/canonical-chat-requests.test.ts
+++ b/tests/shell/canonical-chat-requests.test.ts
@@ -6,10 +6,10 @@ it("projects a run-activity approval even when no saved message contains it", ()
   const { snapshot } = createCanonicalChatFixture("accepted");
   const run = snapshot.runs[0]!;
   const event = { id: "activity_approval", chatId: run.chatId, runId: run.id, occurredAt: run.createdAt,
-    type: "approval.requested" as const, approvalId: "appr_command", title: "Run command", risk: "medium" as const, allowedDecisions: ["approve" as const, "cancel" as const] };
+    type: "approval.requested" as const, approvalId: "appr_command", title: "Run command", description: "Fetch the project changes.", risk: "medium" as const, allowedDecisions: ["approve" as const, "cancel" as const] };
   const messages = projectCanonicalRequests([event], snapshot.runs);
   expect(messages).toHaveLength(1);
-  expect(messages[0]?.metadata?.canonicalApproval).toMatchObject({ runId: run.id, approvalId: "appr_command", pending: true });
+  expect(messages[0]?.metadata?.canonicalApproval).toMatchObject({ runId: run.id, approvalId: "appr_command", pending: true, description: event.description });
   expect(projectCanonicalRequests([event, { id: "activity_resolved", chatId: run.chatId, runId: run.id, occurredAt: run.createdAt, type: "approval.resolved", approvalId: "appr_command", decision: "cancel" }], snapshot.runs)[0]?.metadata?.canonicalApproval).toMatchObject({ pending: false });
 });
 
@@ -25,4 +25,17 @@ it("reconciles saved approvals with activities without duplicate or stale contro
     type: "approval.resolved" as const, approvalId: "appr_command", decision: "cancel" as const };
   expect(projectCanonicalRequests([resolved], snapshot.runs, [message])[0]?.metadata?.canonicalApproval).toMatchObject({ pending: false, description: "git fetch origin" });
   expect(projectCanonicalRequests([], [{ ...run, status: "completed" }], [message])[0]?.metadata?.canonicalApproval).toMatchObject({ pending: false });
+});
+
+it("retains unstructured input notices and bounds request projection locally", () => {
+  const { snapshot } = createCanonicalChatFixture("accepted");
+  const run = snapshot.runs[0]!;
+  const event = { id: "unstructured", chatId: run.chatId, runId: run.id, occurredAt: run.createdAt,
+    type: "input.requested" as const, requestId: "req_unstructured", title: "Clarification needed" };
+  expect(projectCanonicalRequests([event], snapshot.runs)[0]?.metadata?.canonicalInput).toMatchObject({ requestId: "req_unstructured", title: "Clarification needed", pending: true });
+  const messages = Array.from({ length: 1001 }, (_, i) => ({ id: `message_${i}`, role: "system" as const, content: "Approval", timestamp: i,
+    metadata: { canonicalApproval: { runId: run.id, approvalId: `appr_${i}`, pending: true } } }));
+  const projected = projectCanonicalRequests([], snapshot.runs, messages);
+  expect(projected).toHaveLength(500);
+  expect(projected.at(-1)?.id).toBe("message_1000");
 });

--- a/tests/shell/canonical-chat-state.test.tsx
+++ b/tests/shell/canonical-chat-state.test.tsx
@@ -3,6 +3,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCanonicalChatState } from "../../shell/src/hooks/useCanonicalChatState.js";
+import { createCanonicalChatFixture } from "../contracts/fixtures/canonical-chat";
 
 vi.mock("@/hooks/useSocket", () => ({ useSocket: () => ({ connected: true }) }));
 
@@ -34,6 +35,39 @@ beforeEach(() => {
 });
 
 describe("canonical shell Chat state", () => {
+  it("never cancels a replacement run from a stale input recovery action", async () => {
+    const currentRecord = { ...record("chat_a", "A"), activeRun: { runId: "run_current", turnId: "cturn_current", status: "waiting_for_input" as const } };
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes("/api/chats?")) return Response.json({ items: [currentRecord] });
+      if (url.includes("/api/chats/chat_a?") && !init?.method) return Response.json({ ...detail("chat_a", "A"), record: currentRecord });
+      throw new Error("Unexpected request");
+    });
+    vi.stubGlobal("fetch", fetchFn);
+    const { result } = renderHook(() => useCanonicalChatState());
+    await waitFor(() => expect(result.current.messages[0]?.content).toBe("A"));
+    await act(async () => { expect(await result.current.cancelRun!("run_previous")).toBe(false); });
+    expect(fetchFn.mock.calls.some(([url]) => url.includes("/cancel"))).toBe(false);
+  });
+  it("cancels only the notice run and surfaces cancellation failures safely", async () => {
+    const currentRecord = { ...record("chat_a", "A"), activeRun: { runId: "run_current", turnId: "cturn_current", status: "waiting_for_input" as const } };
+    let fail = false;
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes("/api/chats?")) return Response.json({ items: [currentRecord] });
+      if (url.includes("/api/chats/chat_a?") && !init?.method) return Response.json({ ...detail("chat_a", "A"), record: currentRecord });
+      if (url.endsWith("/api/chats/chat_a/runs/run_current/cancel") && init?.method === "POST") {
+        if (fail) return Response.json({ error: "private detail" }, { status: 503 });
+        return Response.json({ run: { ...createCanonicalChatFixture("aborted").snapshot.runs[0], id: "run_current", chatId: "chat_a", turnId: "cturn_current" }, cancellation: "aborted" });
+      }
+      throw new Error("Unexpected request");
+    });
+    vi.stubGlobal("fetch", fetchFn);
+    const { result } = renderHook(() => useCanonicalChatState());
+    await waitFor(() => expect(result.current.messages[0]?.content).toBe("A"));
+    await act(async () => { expect(await result.current.cancelRun!("run_current")).toBe(true); });
+    fail = true;
+    await act(async () => { expect(await result.current.cancelRun!("run_current")).toBe(false); });
+    expect(result.current.messages.at(-1)?.content).toBe("The run could not be stopped. Try again.");
+  });
   it("renames through canonical persistence and synchronizes list and active title projections", async () => {
     const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
       if (url.includes("/api/chats?") && init?.method === undefined) {

--- a/tests/shell/canonical-input-message.test.tsx
+++ b/tests/shell/canonical-input-message.test.tsx
@@ -12,7 +12,7 @@ it("shows unsupported unstructured requests with an explicit stop-and-retry reco
   expect(screen.getByText("Clarification needed")).toBeTruthy();
   expect(screen.getByText(/cannot be answered in this view/)).toBeTruthy();
   fireEvent.click(screen.getByRole("button", { name: "Stop run to retry" }));
-  expect(stop).toHaveBeenCalledTimes(1);
+  expect(stop).toHaveBeenCalledWith("run_coding");
 });
 it("keeps web connector consent visible and submits only an explicit choice", async () => {
   const request = { requestId: "req_connector", threadId: "thread_native", title: "Connector request", safeDescription: "Review", correlationId: "corr_connector", required: false,

--- a/tests/shell/canonical-input-message.test.tsx
+++ b/tests/shell/canonical-input-message.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { CanonicalInputMessage } from "../../shell/src/components/chat/CanonicalInputMessage";
+
+afterEach(cleanup);
+it("keeps web connector consent visible and submits only an explicit choice", async () => {
+  const request = { requestId: "req_connector", threadId: "thread_native", title: "Connector request", safeDescription: "Review", correlationId: "corr_connector", required: false,
+    connectorActionId: "question_action", questions: [{ questionId: "question_action", header: "Permission", question: "Allow access?", allowOther: false, secret: false,
+      options: ["Allow once", "Decline", "Cancel"].map((label) => ({ label, description: label })) }] };
+  const message = { id: "input", role: "system" as const, content: "Request", timestamp: 1,
+    metadata: { canonicalInput: { runId: "run_coding", request, pending: true } } };
+  const submit = vi.fn(async () => false);
+  const view = render(<CanonicalInputMessage message={message} onSubmit={submit} />);
+  expect(submit).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByRole("button", { name: "Allow once" }));
+  await waitFor(() => expect(submit).toHaveBeenCalledWith("run_coding", "req_connector", { question_action: ["Allow once"] }));
+  expect(await screen.findByRole("alert")).toBeTruthy();
+  view.rerender(<CanonicalInputMessage message={{ ...message, metadata: { canonicalInput: { runId: "run_coding", request, pending: false } } }} onSubmit={submit} />);
+  expect(screen.queryByRole("button", { name: "Allow once" })).toBeNull();
+});

--- a/tests/shell/canonical-input-message.test.tsx
+++ b/tests/shell/canonical-input-message.test.tsx
@@ -5,6 +5,15 @@ import { afterEach, expect, it, vi } from "vitest";
 import { CanonicalInputMessage } from "../../shell/src/components/chat/CanonicalInputMessage";
 
 afterEach(cleanup);
+it("shows unsupported unstructured requests with an explicit stop-and-retry recovery", () => {
+  const stop = vi.fn();
+  render(<CanonicalInputMessage message={{ id: "input", role: "system", content: "Clarification", timestamp: 1,
+    metadata: { canonicalInput: { runId: "run_coding", requestId: "req_clarify", title: "Clarification needed", pending: true } } }} onStop={stop} />);
+  expect(screen.getByText("Clarification needed")).toBeTruthy();
+  expect(screen.getByText(/cannot be answered in this view/)).toBeTruthy();
+  fireEvent.click(screen.getByRole("button", { name: "Stop run to retry" }));
+  expect(stop).toHaveBeenCalledTimes(1);
+});
 it("keeps web connector consent visible and submits only an explicit choice", async () => {
   const request = { requestId: "req_connector", threadId: "thread_native", title: "Connector request", safeDescription: "Review", correlationId: "corr_connector", required: false,
     connectorActionId: "question_action", questions: [{ questionId: "question_action", header: "Permission", question: "Allow access?", allowOther: false, secret: false,


### PR DESCRIPTION
## Summary

Stack 2/2, based on #1560. Keep the backend dependency when reviewing/testing this layer.

- Project approvals/input from persisted run activities into web Chat. Codex approvals were present in activities but absent from saved message parts, leaving a spinner without a consent control.
- Reconcile duplicate message/activity approvals and remove pending controls for resolved or terminal runs.
- Share explicit structured form controls across Canvas, Desktop mode, mobile web, native canonical Chat, and the legacy coding-agent view. Forward structured answers instead of collapsing questions into a single textarea.
- Distinguish waiting for approval/input from active work and elevate native desktop pending requests above work history.
- Extract legacy system-event rendering before adding behavior to its large composition file.

## Tests

- Passed workspace and shell TypeScript checks, pattern scan (5 warnings, 0 violations), and whitespace checks.
- Passed focused shared-form, web projection/rendering, canonical presentation, client, route-controller, workspace, and legacy approval regressions.
- Passed the combined 24-file focused suite: 287 tests. Final review changes additionally passed 41 connector boundary tests and 16 web recovery/hook/wiring tests; shell typecheck passes.
- Full local `bun run test --maxWorkers=2`: 13,650 tests passed, 21 skipped; command exited nonzero after a fork-worker exit in unchanged `tests/integrations/routes.test.ts`. Whole-file rerun also hit a 60-second database setup timeout after 50 passes; the exact timed-out case passes alone (2.4 seconds). Full local invocations are not claimed green; exact-head CI is the broad gate. No production UI or live connector authorization was exercised.

## Review/Monitoring

- Trusted Greptile 5/5 confirmed on final head `8a7a12a8551ab96b37c8a4598efcd1c12ffbc01e`; all review threads resolved with evidence. `ready-for-ci` is present; [triggered CI](https://github.com/HamedMP/matrix-os/actions/runs/34124182514) passed, including all four unit shards, E2E Tests, and CI Results. Not merged or deployed.
- Do not merge or deploy automatically. Ship together with #1560; a transport-only update does not provide the missing consent flow.
- Public docs companion: FinnaAI/matrix-os-site#87 (61 tests and three rendered viewport checks passed).
- Review fixes enforce a local 500-request FIFO cap and retain unstructured input notices. These unsupported requests expose stop-and-retry recovery, not a nonfunctional submit button.
- Recovery cancellation carries the notice run ID and verifies exact active run/chat identity before posting; stale notices cannot cancel replacement runs.

## Invariants

- Backend request/owner/correlation validation remains authoritative; UI never auto-submits or preselects permission choices.
- Form values stay in local component state and travel only through the authenticated input endpoint, not transcript messages. Capture-sensitive controls use `ph-no-capture`.
- Failure retains answers and shows a generic retry message. Decline/cancel does not require completing required fields.
- No database writes, auth changes, deployment, or permanent connector grants are introduced by this layer.
- Existing Hermes clarification events include only a request ID and generic title; its adapter has no input-response callback. Full native Hermes clarification replies are explicitly tracked in #1562. This PR fixes notice visibility/recovery without pretending that an unverified reply protocol is implemented.
