### PR TITLE
fix(ci): stabilize Docker channel restarts and retain diagnostics

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -178,6 +178,7 @@ jobs:
                 MATRIX_DOCKER_CHOWN_SOURCE: "true"
                 MATRIX_AUTH_ALLOW_INSECURE_DEV: "1"
                 MATRIX_SKIP_DEFAULT_APP_BUILD: "true"
+                MATRIX_DEV_DEP_WATCH: "0"
           EOF
 
       - name: Create external volumes
@@ -192,6 +193,7 @@ jobs:
         env:
           COMPOSE_OVERRIDE_FILE: ${{ github.workspace }}/docker-compose.ci.yml
           DOCKER_HEALTH_TIMEOUT: "600"
+          DOCKER_TEST_LOG_DIR: /tmp/docker-test-logs
 
       - name: Collect container logs on failure
         if: failure() && github.event_name == 'pull_request'
@@ -271,6 +273,7 @@ jobs:
                 MATRIX_DOCKER_CHOWN_SOURCE: "true"
                 MATRIX_AUTH_ALLOW_INSECURE_DEV: "1"
                 MATRIX_SKIP_DEFAULT_APP_BUILD: "true"
+                MATRIX_DEV_DEP_WATCH: "0"
           EOF
 
       - name: Create external volumes
@@ -283,6 +286,7 @@ jobs:
         env:
           COMPOSE_OVERRIDE_FILE: ${{ github.workspace }}/docker-compose.ci.yml
           DOCKER_HEALTH_TIMEOUT: "600"
+          DOCKER_TEST_LOG_DIR: /tmp/docker-test-logs
 
       - name: Collect container logs on failure
         if: failure()

--- a/distro/docker-dev-entrypoint.sh
+++ b/distro/docker-dev-entrypoint.sh
@@ -12,7 +12,7 @@ export PATH="/app/node_modules/.bin:$PATH"
 # then breaks with "Module not found" even after a restart. md5sum -c compares
 # the real content, so a restart always reinstalls iff the lockfile changed.
 ensure_deps() {
-  if [ -d "node_modules/.pnpm" ] && md5sum --status -c node_modules/.pnpm-lock-hash 2>/dev/null; then
+  if [ -d "node_modules/.pnpm" ] && md5sum -c node_modules/.pnpm-lock-hash >/dev/null 2>&1; then
     return 0
   fi
   echo "[matrix-os-dev] Installing dependencies (lockfile changed)..."
@@ -191,7 +191,7 @@ if [ "${MATRIX_DEV_DEP_WATCH:-1}" != "0" ]; then
   (
     while true; do
       sleep 5
-      md5sum --status -c node_modules/.pnpm-lock-hash 2>/dev/null && continue
+      md5sum -c node_modules/.pnpm-lock-hash >/dev/null 2>&1 && continue
       echo "[matrix-os-dev] Lockfile changed -- reinstalling dependencies..."
       if pnpm install --frozen-lockfile --config.enableGlobalVirtualStore=false; then
         md5sum pnpm-lock.yaml > node_modules/.pnpm-lock-hash 2>/dev/null || true

--- a/scripts/docker-test/channels.sh
+++ b/scripts/docker-test/channels.sh
@@ -37,8 +37,9 @@ INNEREOF'
 
 # Restart to pick up channel config
 echo -e "${YELLOW}[SETUP]${NC} Restarting to load channel config..."
-$COMPOSE stop dev
-$COMPOSE up $COMPOSE_UP_FLAGS -d dev
+# Request an actual restart: up only reconciles desired state and can reuse a
+# container reported as running during a stop/exit race.
+$COMPOSE restart --timeout 30 dev
 
 wait_for_healthy "dev" "${DOCKER_HEALTH_TIMEOUT:-180}"
 

--- a/scripts/docker-test/lib.sh
+++ b/scripts/docker-test/lib.sh
@@ -214,8 +214,20 @@ pull_compose_images() {
 }
 
 cleanup() {
+  local exit_code=$?
+  # EXIT traps run before the workflow's failure steps. Preserve diagnostics
+  # before down removes the containers; CI uploads them with seven-day retention.
+  if [ "$exit_code" -ne 0 ] && [ -n "${DOCKER_TEST_LOG_DIR:-}" ]; then
+    if mkdir -p "$DOCKER_TEST_LOG_DIR"; then
+      $COMPOSE logs --no-color --timestamps --tail 200 > "$DOCKER_TEST_LOG_DIR/compose-pre-cleanup.log" 2>&1 || true
+      $COMPOSE ps -a > "$DOCKER_TEST_LOG_DIR/containers-pre-cleanup.log" 2>&1 || true
+    else
+      echo "Could not create Docker test diagnostics directory" >&2
+    fi
+  fi
   echo -e "${YELLOW}[CLEANUP]${NC} Stopping containers..."
   $COMPOSE down -v --timeout 5 2>/dev/null || true
+  return "$exit_code"
 }
 
 summary() {

--- a/tests/scripts/docker-restart.test.ts
+++ b/tests/scripts/docker-restart.test.ts
@@ -1,0 +1,119 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const temporaryDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of temporaryDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), "matrix-docker-restart-"));
+  temporaryDirs.push(dir);
+  mkdirSync(join(dir, "bin"));
+  return dir;
+}
+
+function executable(dir: string, name: string, body: string) {
+  writeFileSync(join(dir, "bin", name), `#!/bin/bash\n${body}\n`, { mode: 0o755 });
+}
+
+function run(dir: string, script: string, env: Record<string, string> = {}) {
+  return spawnSync("bash", ["-c", script], {
+    cwd: dir,
+    env: { ...process.env, PATH: `${join(dir, "bin")}:${process.env.PATH}`, FIXTURE: dir, ...env },
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+}
+
+describe("Docker restart regressions", () => {
+  it.each([false, true])("only installs dependencies when the lockfile changed (%s)", (changed) => {
+    const dir = fixture();
+    mkdirSync(join(dir, "node_modules", ".pnpm"), { recursive: true });
+    writeFileSync(join(dir, "pnpm-lock.yaml"), changed ? "new" : "old");
+    writeFileSync(join(dir, "node_modules", ".pnpm-lock-hash"), `${createHash("md5").update("old").digest("hex")}  pnpm-lock.yaml\n`);
+    // Model BusyBox's documented interface: -c is supported; --status is not.
+    writeFileSync(join(dir, "bin", "md5sum"), `#!${process.execPath}
+const fs = require("node:fs");
+const crypto = require("node:crypto");
+const args = process.argv.slice(2);
+if (args.includes("--status")) process.exit(1);
+const digest = crypto.createHash("md5").update(fs.readFileSync("pnpm-lock.yaml")).digest("hex");
+if (args[0] === "-c") process.exit(fs.readFileSync(args[1], "utf8").startsWith(digest + "  ") ? 0 : 1);
+console.log(digest + "  pnpm-lock.yaml");
+`, { mode: 0o755 });
+    executable(dir, "pnpm", 'echo install >> "$FIXTURE/installs"');
+    const entrypoint = readFileSync(join(root, "distro/docker-dev-entrypoint.sh"), "utf8");
+    const setup = entrypoint.match(/ensure_deps\(\) \{[\s\S]*?\n\}\nensure_deps/);
+    expect(setup).not.toBeNull();
+    const result = run(dir, `set -e\n${setup![0]}\nensure_deps`);
+    expect(result.status, result.stderr).toBe(0);
+    if (changed) expect(readFileSync(join(dir, "installs"), "utf8")).toBe("install\n");
+    else expect(result.stdout).not.toContain("Installing dependencies");
+  });
+
+  it("explicitly restarts even when stop/up could reuse an unhealthy running container", () => {
+    const dir = fixture();
+    executable(dir, "docker", `
+echo "$*" >> "$FIXTURE/commands"
+case " $* " in
+  *" down "*) rm -f "$FIXTURE/started" "$FIXTURE/unhealthy" ;;
+  *" restart "*) rm -f "$FIXTURE/unhealthy" ;;
+  *" stop "*) touch "$FIXTURE/unhealthy" ;;
+  *" up "*) touch "$FIXTURE/started" ;;
+  *" ps "*) echo '[]' ;;
+esac`);
+    executable(dir, "curl", `
+[ ! -f "$FIXTURE/unhealthy" ] || exit 1
+case " $* " in
+  *" -w "*) printf 200 ;;
+  *) echo '{"status":"ok"}' ;;
+esac`);
+    executable(dir, "jq", 'cat >/dev/null; echo ok');
+    executable(dir, "sleep", ":");
+    const result = run(dir, 'bash "$SCENARIO"', {
+      SCENARIO: join(root, "scripts/docker-test/channels.sh"),
+      DOCKER_HEALTH_TIMEOUT: "1",
+    });
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(result.stdout).toContain("Passed: 3");
+    expect(readFileSync(join(dir, "commands"), "utf8")).toMatch(/restart --timeout \d+ dev/);
+  });
+
+  it.each([false, true])("preserves the failure exit code and cleans up even if diagnostics fail (%s)", (diagnosticsFail) => {
+    const dir = fixture();
+    executable(dir, "docker", `
+echo "$*" >> "$FIXTURE/commands"
+case " $* " in
+  *" logs "*|*" ps "*) echo diagnostic; ${diagnosticsFail ? "exit 1" : ":"} ;;
+  *" down "*) echo removed ;;
+esac`);
+    const result = run(dir, 'source "$HARNESS"\ntrap cleanup EXIT\nexit 7', {
+      HARNESS: join(root, "scripts/docker-test/lib.sh"),
+      DOCKER_TEST_LOG_DIR: join(dir, "logs"),
+    });
+    expect(result.status).toBe(7);
+    const commands = readFileSync(join(dir, "commands"), "utf8");
+    expect(commands.indexOf("logs ")).toBeGreaterThanOrEqual(0);
+    expect(commands.indexOf("logs ")).toBeLessThan(commands.indexOf("down "));
+    expect(readFileSync(join(dir, "logs/compose-pre-cleanup.log"), "utf8")).toContain("diagnostic");
+    expect(readFileSync(join(dir, "logs/containers-pre-cleanup.log"), "utf8")).toContain("diagnostic");
+  });
+
+  it("does not collect failure diagnostics for successful scenarios", () => {
+    const dir = fixture();
+    executable(dir, "docker", 'echo "$*" >> "$FIXTURE/commands"');
+    const result = run(dir, 'source "$HARNESS"\ntrap cleanup EXIT\ntrue', {
+      HARNESS: join(root, "scripts/docker-test/lib.sh"),
+      DOCKER_TEST_LOG_DIR: join(dir, "logs"),
+    });
+    expect(result.status).toBe(0);
+    expect(readFileSync(join(dir, "commands"), "utf8")).not.toContain("logs ");
+  });
+});


### PR DESCRIPTION
## Summary

The Docker channels scenario can leave its container stopped after reporting a successful stop/up. The failed main runner image ships Docker Engine 28.0.4 and Compose 2.38.2. That engine has the upstream stop-state visibility race [moby#50133](https://github.com/moby/moby/issues/50133), fixed in [moby#50136](https://github.com/moby/moby/pull/50136) and first released in [Engine 28.3.0](https://docs.docker.com/engine/release-notes/28/#2830).

Use `docker compose restart --timeout 30 dev` so the scenario requests a real restart instead of making its start decision from stale list state. Also correct GNU-only checksum flags on Alpine, disable dependency watching for fixed CI checkouts, and capture bounded failure logs before cleanup removes the containers.

Fixes MAT-517

## Root cause and reproduction

1. Docker 28.0.4 signals the stop waiter before checkpointing the exited state into the database used by the container-list API.
2. The stop API returns success while that database can still report `running`.
3. Compose 2.38.2 prints `Running` for that snapshot and skips `ContainerStart` in [startService](https://github.com/docker/compose/blob/v2.38.2/pkg/compose/convergence.go#L892).
4. The container remains exited. Waiting longer for gateway health cannot start it.

The [failed CI job](https://github.com/HamedMP/matrix-os/actions/runs/34115622802/job/101723467862) shows `Stopped` at 11:44:53.862 UTC, then `Running` at 11:44:53.952, with no second `Starting`/`Started`. The [runner image manifest](https://github.com/actions/runner-images/blob/ubuntu24/20260831.293/images/ubuntu/Ubuntu2404-Readme.md) identifies the affected versions. The previous passing run shows a fresh start instead.

On 2026-09-09, isolated real Linux/arm64 Docker daemons reproduced the problem with minimal BusyBox containers and the exact Engine/Compose versions. No mocked Docker responses, artificial delay, or application dependency installation was involved:

| Experiment | Result |
| --- | --- |
| Engine 28.0.4, immediate stop/list/inspect | 97/100 lists said running while inspection said exited |
| Engine 28.3.0, identical API test | 0/100 stale results |
| Engine 28.0.4 + Compose 2.38.2, stop/up, SIGKILL | 1/100 containers left exited after printing Stopped then Running |
| Same versions, stop/up, graceful SIGTERM via init | 1/100 containers left exited, exit code 143, same log sequence |
| Explicit Compose restart, same two fixtures | 0/200 failures; each inspected running with a changed StartedAt |

This reproduces the original failure signature and explains intermittent green runs. It is a minimal engine/lifecycle reproduction, not a replay of the expired original Matrix image or full channels scenario. Original container state was removed by cleanup. The checksum incompatibility is a separate confirmed defect, not established as the cause of that timeout.

Current main `7551bfbf79fade6982a6fe6e6171af71d58c63a7` still uses stop/up; its passing channels run does not mean this race was fixed. Host-bundle publishing is independent: the original failed-Docker commit successfully published v2026.09.07-1172 to dev; skipped deployment on a normal main push is expected.

<details>
<summary>Minimal Compose reproduction</summary>

Use a disposable Docker 28.0.4 daemon and the official Compose 2.38.2 binary. Run the following against only that daemon. The race is timing-dependent, so an individual batch may pass.

```yaml
# compose.yml
services:
  dev:
    image: busybox:1.37.0
    command: [sleep, '3600']
    init: true
    network_mode: none
```

```sh
docker compose -p mat517 up -d dev
for i in $(seq 1 100); do
  docker compose -p mat517 stop dev
  docker compose -p mat517 up --no-build -d dev
  running=$(docker inspect -f '{{.State.Running}}' mat517-dev-1)
  if [ "$running" != true ]; then
    echo "Reproduced on iteration $i"
    docker inspect -f '{{json .State}}' mat517-dev-1
    break
  fi
done
docker compose -p mat517 down -v
```

For the mitigation, replace each stop/up pair with `docker compose -p mat517 restart --timeout 30 dev` and check both running state and a changed `StartedAt`. The API reproducer is also documented in upstream issue #50133.

</details>

## Other validation and remaining checks

- 112 tests passed across docker-restart, docker-dev-entrypoint, docker-relevance, and ci-workflows suites. Five executable regression cases failed before the fix; all six new cases pass afterward.
- The committed restart regression uses a simulated unhealthy-running state; the real engine reproductions above are separate experiments.
- Bash syntax, diff check, and pattern scan passed (zero violations; existing warnings in unchanged application code).
- Broad `bun run typecheck` and `bun run test` stop at the integrations-MCP prerequisite build with Zod type errors using the existing local dependency installation. Full-suite execution was not reached.
- Exact-head full Matrix Linux Docker workflow and PR review remain pending. Keep this PR draft until those gates are satisfied.

## Invariants

- Source of truth: Compose configuration, lockfile contents, and actual gateway health. Restart preserves the scenario's home/config volume.
- Lock/transaction scope: no database or production changes; CI no longer starts a background dependency writer. Explicit restart bypasses Compose's stale container-list start decision.
- Acceptable orphan states: diagnostic collection is best-effort; cleanup still runs and preserves the original failure exit code. CI artifacts retain bounded log tails for seven days.
- Auth source of truth: unchanged; test credentials and existing CI dev-auth settings remain scoped to disposable containers.
- Deferred scope: production deployments, Docker process-supervisor redesign, dependency upgrades, and unrelated integrations-MCP build failures. No user-facing documentation changes are needed for this test-harness fix.
