### PR TITLE
fix(platform): serialize startup schema migration

### DIFF
--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -1218,6 +1218,15 @@ function wrapDb(
 }
 
 async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
+  await db.transaction().execute(async (trx) => {
+    await sql`
+      SELECT pg_advisory_xact_lock(hashtext('matrix_os_platform_schema_migration'))
+    `.execute(trx);
+    await migrateSchema(trx);
+  });
+}
+
+async function migrateSchema(db: Executor): Promise<void> {
   await sql`
     CREATE TABLE IF NOT EXISTS users (
       id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/tests/platform/platform-db-migration-lock.test.ts
+++ b/tests/platform/platform-db-migration-lock.test.ts
@@ -1,0 +1,19 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("platform database startup migration", () => {
+  it("serializes the full schema migration on one transaction-scoped advisory lock", async () => {
+    const source = await readFile("packages/platform/src/db.ts", "utf8");
+    const wrapperStart = source.indexOf("async function migrate(");
+    const schemaStart = source.indexOf("async function migrateSchema(");
+
+    expect(wrapperStart).toBeGreaterThanOrEqual(0);
+    expect(schemaStart).toBeGreaterThan(wrapperStart);
+
+    const wrapper = source.slice(wrapperStart, schemaStart);
+    expect(wrapper).toContain("db.transaction().execute");
+    expect(wrapper).toContain("pg_advisory_xact_lock");
+    expect(wrapper).toContain("matrix_os_platform_schema_migration");
+    expect(wrapper).toContain("await migrateSchema(trx)");
+  });
+});

--- a/tests/platform/platform-db-migration-lock.test.ts
+++ b/tests/platform/platform-db-migration-lock.test.ts
@@ -11,9 +11,21 @@ describe("platform database startup migration", () => {
     expect(schemaStart).toBeGreaterThan(wrapperStart);
 
     const wrapper = source.slice(wrapperStart, schemaStart);
-    expect(wrapper).toContain("db.transaction().execute");
-    expect(wrapper).toContain("pg_advisory_xact_lock");
-    expect(wrapper).toContain("matrix_os_platform_schema_migration");
-    expect(wrapper).toContain("await migrateSchema(trx)");
+    const transactionStart = wrapper.indexOf("await db.transaction().execute");
+    const callbackStart = wrapper.indexOf("=> {", transactionStart);
+    const lockStart = wrapper.indexOf("pg_advisory_xact_lock", callbackStart);
+    const lockExecution = wrapper.indexOf(".execute(trx)", lockStart);
+    const schemaMigration = wrapper.indexOf("await migrateSchema(trx)", lockExecution);
+    const transactionEnd = wrapper.lastIndexOf("});");
+
+    expect(transactionStart).toBeGreaterThanOrEqual(0);
+    expect(callbackStart).toBeGreaterThan(transactionStart);
+    expect(lockStart).toBeGreaterThan(callbackStart);
+    expect(lockExecution).toBeGreaterThan(lockStart);
+    expect(schemaMigration).toBeGreaterThan(lockExecution);
+    expect(transactionEnd).toBeGreaterThan(schemaMigration);
+    expect(wrapper.slice(lockStart, lockExecution)).toContain(
+      "matrix_os_platform_schema_migration",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- serialize the full platform schema bootstrap with a transaction-scoped PostgreSQL advisory lock
- make the startup migration atomic so a failed DDL statement rolls back before the lock is released
- add a regression test that preserves the transaction and advisory-lock boundary

## Incident evidence

- correlated client error `mx-1euqak8-9a723cf1` to `Loading chunk 5818 failed` at 2026-09-07 16:01:24 Europe/Rome
- traced the chunk request to a Cloud Run HTTP 503: the selected instance failed its readiness check
- correlated four simultaneous cold starts with two startup crashes on PostgreSQL error `23505`, duplicate key `(idx_golden_snapshots_identity, 2200)` in `pg_class_relname_nsp_index`
- confirmed signup, checkout, billing settlement, and the post-checkout return had completed before the shell asset request failed

## Verification

- `pnpm exec vitest run tests/platform/platform-db-migration-lock.test.ts tests/platform/db.test.ts tests/platform/journey.test.ts tests/platform/journey-routes.test.ts tests/platform/signup-billing-handoff-page.test.ts tests/platform/signup-billing-handoff-routing.test.ts tests/shell/boot-sequence.test.tsx tests/shell/signup-billing-handoff-ui.test.tsx` — 88 passed
- `pnpm run check:patterns` — 0 violations (5 pre-existing manual-review warnings)
- full monorepo typecheck command — passed
- `pnpm run test` — 13,647 passed; one unrelated test hook timed out under the 47-minute parallel run, then passed alone in 3.3 seconds
- no React files changed; React Doctor and screenshot evidence are not applicable

## Invariants

- **Source of truth:** the platform PostgreSQL schema remains canonical; no alternate store or migration state is introduced.
- **Lock/transaction scope:** one transaction-scoped advisory lock covers the complete startup schema migration. All schema reads and writes are inside that transaction; no network calls occur in the critical section.
- **Acceptable orphan states:** none. A migration error rolls back the transaction and PostgreSQL releases the advisory lock automatically; a later instance can retry from the last committed schema.
- **Auth source of truth:** unchanged. Clerk/session/JWT authentication and route authorization are outside this patch.
- **Deferred scope:** a versioned migration ledger and generic client-side hard-refresh recovery for transient chunk failures are not included.
