### PR TITLE
fix(auth): recover completed signup redirects

### DIFF
--- a/shell/src/lib/proxy-routes.ts
+++ b/shell/src/lib/proxy-routes.ts
@@ -1,3 +1,44 @@
+const MAX_AUTH_REDIRECT_LENGTH = 2_048;
+const MAX_AUTH_REDIRECT_SEARCH_LENGTH = 4_096;
+
+export function isSignUpShellPath(pathname: string): boolean {
+  return pathname === "/sign-up" || pathname.startsWith("/sign-up/");
+}
+
+function isAuthShellPath(pathname: string): boolean {
+  return (
+    pathname === "/sign-in" ||
+    pathname.startsWith("/sign-in/") ||
+    isSignUpShellPath(pathname)
+  );
+}
+
+/**
+ * Resolve Clerk's client-controlled post-signup destination without allowing
+ * cross-origin redirects or loops back into an auth route. The path is kept
+ * relative so callers choose the configured public origin explicitly.
+ */
+export function resolveCompletedSignupRedirect(search: string, appOrigin: string): string {
+  if (search.length > MAX_AUTH_REDIRECT_SEARCH_LENGTH) return "/";
+  const searchParams = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
+  const requested = searchParams.get("redirect_url");
+  if (!requested || requested.length > MAX_AUTH_REDIRECT_LENGTH) return "/";
+
+  if (!URL.canParse(appOrigin)) return "/";
+  const canonical = new URL(appOrigin);
+  if (canonical.protocol !== "http:" && canonical.protocol !== "https:") return "/";
+
+  const base = `${canonical.origin}/`;
+  if (!URL.canParse(requested, base)) return "/";
+  const destination = new URL(requested, base);
+  if (destination.origin !== canonical.origin || destination.username || destination.password) {
+    return "/";
+  }
+  if (isAuthShellPath(destination.pathname)) return "/";
+
+  return `${destination.pathname}${destination.search}`;
+}
+
 export function isPublicShellPath(pathname: string, search = ""): boolean {
   const searchParams = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
   return (
@@ -10,8 +51,7 @@ export function isPublicShellPath(pathname: string, search = ""): boolean {
     (pathname === "/" && searchParams.get("billing") === "setup") ||
     pathname === "/sign-in" ||
     pathname.startsWith("/sign-in/") ||
-    pathname === "/sign-up" ||
-    pathname.startsWith("/sign-up/")
+    isSignUpShellPath(pathname)
   );
 }
 

--- a/shell/src/proxy.ts
+++ b/shell/src/proxy.ts
@@ -56,6 +56,17 @@ function rewriteGatewayRequest(request: ProxyRequestLike) {
   return NextResponse.rewrite(url, { request: { headers } });
 }
 
+function completedSignupResponse(request: ProxyRequestLike): NextResponse {
+  const publicOrigin = getConfiguredAppOrigin();
+  if (!publicOrigin) {
+    console.error("[auth] completed signup recovery unavailable: app origin is not configured");
+    return new NextResponse("Matrix OS authentication unavailable", { status: 503 });
+  }
+  const redirectPath = resolveCompletedSignupRedirect(request.nextUrl.search, publicOrigin);
+  console.info("[auth] recovered completed signup");
+  return NextResponse.redirect(new URL(redirectPath, publicOrigin), 303);
+}
+
 function platformVerifiedResponse(request: ProxyRequestLike): NextResponse | null {
   const requestHeaders = new Headers(request.headers);
   const platformAuthHeader = request.headers.get("authorization");
@@ -86,6 +97,10 @@ function platformVerifiedResponse(request: ProxyRequestLike): NextResponse | nul
     });
   }
 
+  if (isSignUpShellPath(request.nextUrl.pathname)) {
+    return completedSignupResponse(request);
+  }
+
   if (isGatewayProxy(request)) {
     return rewriteGatewayRequest(request);
   }
@@ -106,15 +121,7 @@ const withClerk = clerkMiddleware(async (auth, request) => {
   if (isSignUpShellPath(request.nextUrl.pathname)) {
     const { userId } = await auth();
     if (!userId) return NextResponse.next();
-
-    const publicOrigin = getConfiguredAppOrigin();
-    if (!publicOrigin) {
-      console.error("[auth] completed signup recovery unavailable: app origin is not configured");
-      return new NextResponse("Matrix OS authentication unavailable", { status: 503 });
-    }
-    const redirectPath = resolveCompletedSignupRedirect(request.nextUrl.search, publicOrigin);
-    console.info("[auth] recovered completed signup");
-    return NextResponse.redirect(new URL(redirectPath, publicOrigin), 303);
+    return completedSignupResponse(request);
   }
 
   // Layer 1: Clerk authentication (skip public routes)

--- a/shell/src/proxy.ts
+++ b/shell/src/proxy.ts
@@ -8,8 +8,10 @@ import {
   isGatewayProxyPath,
   isPlatformMobileAppSessionRequest,
   isPublicShellPath,
+  isSignUpShellPath,
+  resolveCompletedSignupRedirect,
 } from "./lib/proxy-routes";
-import { getPublicOrigin } from "./lib/public-origin";
+import { getConfiguredAppOrigin, getPublicOrigin } from "./lib/public-origin";
 import {
   canPlatformUserAccessShell,
   isPlatformBearerValid,
@@ -97,6 +99,24 @@ function platformVerifiedResponse(request: ProxyRequestLike): NextResponse | nul
 
 // Clerk handler for authenticated routes
 const withClerk = clerkMiddleware(async (auth, request) => {
+  // Clerk normally performs this navigation in the browser after signup. If
+  // that one-shot redirect is interrupted, Clerk has already established the
+  // session and its <SignUp> component renders nothing. Recover at the request
+  // boundary for both the verification POST and later page reloads.
+  if (isSignUpShellPath(request.nextUrl.pathname)) {
+    const { userId } = await auth();
+    if (!userId) return NextResponse.next();
+
+    const publicOrigin = getConfiguredAppOrigin();
+    if (!publicOrigin) {
+      console.error("[auth] completed signup recovery unavailable: app origin is not configured");
+      return new NextResponse("Matrix OS authentication unavailable", { status: 503 });
+    }
+    const redirectPath = resolveCompletedSignupRedirect(request.nextUrl.search, publicOrigin);
+    console.info("[auth] recovered completed signup");
+    return NextResponse.redirect(new URL(redirectPath, publicOrigin), 303);
+  }
+
   // Layer 1: Clerk authentication (skip public routes)
   if (!isPublicShellPath(request.nextUrl.pathname, request.nextUrl.search)) {
     const { userId } = await auth();
@@ -170,7 +190,10 @@ export function proxy(
   ) {
     return new NextResponse("Forbidden", { status: 403 });
   }
-  if (isPublicShellPath(request.nextUrl.pathname, request.nextUrl.search)) {
+  if (
+    isPublicShellPath(request.nextUrl.pathname, request.nextUrl.search) &&
+    !isSignUpShellPath(request.nextUrl.pathname)
+  ) {
     return NextResponse.next();
   }
   // All requests -- including gateway-proxy paths -- flow through Clerk so the

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -3098,6 +3098,53 @@ describe("platform proxy routing", () => {
     delete process.env.AUTH_SHELL_PORT;
   });
 
+  it("preserves the auth-shell completed-signup redirect before a VPS exists", async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
+    process.env.AUTH_SHELL_HOST = "auth-shell.test";
+    process.env.AUTH_SHELL_PORT = "3200";
+    await deleteContainer(db, "alice");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, {
+        status: 303,
+        headers: { location: "https://app.matrix-os.com/" },
+      }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request(
+      "/sign-up/verify-email-address?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2F",
+      {
+        headers: {
+          host: "app.matrix-os.com",
+          cookie: "__session=clerk-new",
+        },
+      },
+    );
+
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toBe("https://app.matrix-os.com/");
+    expect(res.headers.get("cache-control")).toBe("no-store, private");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "http://auth-shell.test:3200/sign-up/verify-email-address?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2F",
+    );
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        method: "GET",
+        redirect: "manual",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    delete process.env.AUTH_SHELL_HOST;
+    delete process.env.AUTH_SHELL_PORT;
+  });
+
   it("serves anonymous app-domain sign-in from auth-shell before a VPS exists", async () => {
     process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
     process.env.AUTH_SHELL_HOST = "auth-shell.test";

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -932,6 +932,57 @@ describe("platform proxy routing", () => {
     expect(res.headers.get("set-cookie")).toContain("matrix_shell_route=alice-staging");
   });
 
+  it("preserves completed-signup recovery from a provisioned user's VPS shell", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff154",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123498,
+      publicIPv4: "203.0.113.68",
+      imageVersion: "matrix-os-host-2026.09.07-1",
+      provisionedAt: "2026-09-07T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, {
+        status: 303,
+        headers: { location: "https://app.matrix-os.com/auth/device?user_code=BCDF-GHJK" },
+      }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request(
+      "/sign-up/verify-email-address?redirect_url=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+      {
+        headers: {
+          host: "app.matrix-os.com",
+          authorization: "Bearer clerk-session",
+        },
+      },
+    );
+
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toBe(
+      "https://app.matrix-os.com/auth/device?user_code=BCDF-GHJK",
+    );
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://203.0.113.68:443/sign-up/verify-email-address?redirect_url=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+    );
+    const forwardedHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers as HeadersInit);
+    expect(forwardedHeaders.get("x-platform-user-id")).toBe("user_alice");
+    expect(forwardedHeaders.get("x-platform-verified")).toMatch(/^[0-9a-f]{64}$/);
+    expect(forwardedHeaders.get("authorization")).not.toBe("Bearer clerk-session");
+  });
+
   it("does not persist a selected runtime slot through the Clerk sign-in handoff", async () => {
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
     const app = createApp({

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -176,14 +176,26 @@ describe("proxy auth: completed signup recovery", () => {
     vi.doUnmock("next/server");
   });
 
-  async function loadProxy(userId: string | null, configuredAppUrl = "https://app.matrix-os.com") {
+  async function loadProxy(
+    userId: string | null,
+    configuredAppUrl = "https://app.matrix-os.com",
+    additionalEnv: Record<string, string> = {},
+  ) {
     vi.resetModules();
     vi.stubEnv("NEXT_PUBLIC_MATRIX_APP_URL", configuredAppUrl);
+    for (const [key, value] of Object.entries(additionalEnv)) {
+      vi.stubEnv(key, value);
+    }
     const recoveryLog = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const recoveryError = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
+    const clerkRequestHandler = vi.fn(async (
+      handler: (...args: unknown[]) => unknown,
+      request: unknown,
+      event: unknown,
+    ) => handler(async () => ({ userId }), request, event));
     const clerkMiddleware = vi.fn((handler) => async (request: unknown, event: unknown) =>
-      handler(async () => ({ userId }), request, event)
+      clerkRequestHandler(handler, request, event)
     );
     vi.doMock("@clerk/nextjs/server", () => ({ clerkMiddleware }));
 
@@ -201,7 +213,15 @@ describe("proxy auth: completed signup recovery", () => {
     vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
 
     const { proxy } = await import("../../shell/src/proxy");
-    return { proxy, nextResponseNext, nextResponseRedirect, recoveryLog, recoveryError };
+    return {
+      proxy,
+      clerkMiddleware,
+      clerkRequestHandler,
+      nextResponseNext,
+      nextResponseRedirect,
+      recoveryLog,
+      recoveryError,
+    };
   }
 
   function signupRequest(
@@ -290,6 +310,44 @@ describe("proxy auth: completed signup recovery", () => {
       url: new URL("https://app.matrix-os.com/"),
       status: 303,
     });
+  });
+
+  it("recovers a provisioned user through the trusted platform fast path", async () => {
+    const platformSecret = "platform-secret-123";
+    const handle = "alice";
+    const platformToken = buildPlatformVerificationToken(handle, platformSecret);
+    const { proxy, clerkMiddleware, clerkRequestHandler } = await loadProxy(
+      null,
+      "https://app.matrix-os.com",
+      {
+        UPGRADE_TOKEN: platformToken,
+        MATRIX_CLERK_USER_ID: "user_alice",
+        MATRIX_HANDLE: handle,
+        MATRIX_RUNTIME_SLOT: "primary",
+      },
+    );
+    const request = signupRequest(
+      "?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+    );
+    request.headers.set("authorization", `Bearer ${platformToken}`);
+    request.headers.set("x-platform-user-id", "user_alice");
+    request.headers.set(
+      "x-platform-verified",
+      buildPlatformUserProof(handle, "user_alice", platformSecret),
+    );
+
+    const response = await proxy(
+      request as Parameters<typeof proxy>[0],
+      {} as Parameters<typeof proxy>[1],
+    );
+
+    expect(response).toEqual({
+      kind: "redirect",
+      url: new URL("https://app.matrix-os.com/auth/device?user_code=BCDF-GHJK"),
+      status: 303,
+    });
+    expect(clerkMiddleware).toHaveBeenCalledOnce();
+    expect(clerkRequestHandler).not.toHaveBeenCalled();
   });
 
   it("continues rendering the Clerk flow for an anonymous signup", async () => {

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -6,6 +6,8 @@ import { buildPlatformUserProof } from "../../packages/platform/src/session-rout
 import {
   isPlatformMobileAppSessionRequest,
   isPublicShellPath,
+  isSignUpShellPath,
+  resolveCompletedSignupRedirect,
 } from "../../shell/src/lib/proxy-routes";
 
 /**
@@ -69,6 +71,13 @@ describe("proxy auth: route classification", () => {
     expect(isPublicShellPath("/sign-up/verify-email-address")).toBe(true);
   });
 
+  it("identifies only sign-up pages as completed-signup recovery paths", () => {
+    expect(isSignUpShellPath("/sign-up")).toBe(true);
+    expect(isSignUpShellPath("/sign-up/verify-email-address")).toBe(true);
+    expect(isSignUpShellPath("/sign-in")).toBe(false);
+    expect(isSignUpShellPath("/sign-up-malicious")).toBe(false);
+  });
+
   it("classifies only the exact runtime HTML route as public", () => {
     expect(isPublicShellPath("/runtime")).toBe(true);
     expect(isPublicShellPath("/runtime/other")).toBe(false);
@@ -117,6 +126,199 @@ describe("proxy auth: route classification", () => {
     expect(isGatewayProxy("/")).toBe(false);
     expect(isGatewayProxy("/settings")).toBe(false);
     expect(isGatewayProxy("/health")).toBe(false);
+  });
+});
+
+describe("completed signup redirect validation", () => {
+  const appOrigin = "https://app.matrix-os.com";
+
+  it("accepts absolute and relative same-origin destinations", () => {
+    expect(resolveCompletedSignupRedirect(
+      "?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2F",
+      appOrigin,
+    )).toBe("/");
+    expect(resolveCompletedSignupRedirect(
+      "?redirect_url=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+      appOrigin,
+    )).toBe("/auth/device?user_code=BCDF-GHJK");
+  });
+
+  it("rejects external, protocol-relative, auth-loop, and oversized destinations", () => {
+    expect(resolveCompletedSignupRedirect(
+      "?redirect_url=https%3A%2F%2Fevil.example%2Fsteal",
+      appOrigin,
+    )).toBe("/");
+    expect(resolveCompletedSignupRedirect(
+      "?redirect_url=%2F%2Fevil.example%2Fsteal",
+      appOrigin,
+    )).toBe("/");
+    expect(resolveCompletedSignupRedirect(
+      "?redirect_url=%2Fsign-up%2Fverify-email-address",
+      appOrigin,
+    )).toBe("/");
+    expect(resolveCompletedSignupRedirect(
+      `?redirect_url=${encodeURIComponent(`/${"a".repeat(2_048)}`)}`,
+      appOrigin,
+    )).toBe("/");
+    expect(resolveCompletedSignupRedirect(
+      `?padding=${"a".repeat(8_192)}&redirect_url=%2Fauth%2Fdevice`,
+      appOrigin,
+    )).toBe("/");
+  });
+});
+
+describe("proxy auth: completed signup recovery", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.doUnmock("@clerk/nextjs/server");
+    vi.doUnmock("next/server");
+  });
+
+  async function loadProxy(userId: string | null, configuredAppUrl = "https://app.matrix-os.com") {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_MATRIX_APP_URL", configuredAppUrl);
+    const recoveryLog = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const recoveryError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const clerkMiddleware = vi.fn((handler) => async (request: unknown, event: unknown) =>
+      handler(async () => ({ userId }), request, event)
+    );
+    vi.doMock("@clerk/nextjs/server", () => ({ clerkMiddleware }));
+
+    const nextResponseNext = vi.fn((init?: unknown) => ({ kind: "next", init }));
+    const nextResponseRedirect = vi.fn((url: URL, status?: number) => ({
+      kind: "redirect",
+      url,
+      status,
+    }));
+    class MockNextResponse extends Response {
+      static next = nextResponseNext;
+      static rewrite = vi.fn((url: URL, init?: unknown) => ({ kind: "rewrite", url, init }));
+      static redirect = nextResponseRedirect;
+    }
+    vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
+
+    const { proxy } = await import("../../shell/src/proxy");
+    return { proxy, nextResponseNext, nextResponseRedirect, recoveryLog, recoveryError };
+  }
+
+  function signupRequest(
+    search: string,
+    method = "GET",
+    pathname = "/sign-up/verify-email-address",
+  ) {
+    return {
+      method,
+      headers: new Headers({
+        host: "127.0.0.1:3200",
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "http",
+      }),
+      nextUrl: {
+        host: "127.0.0.1:3200",
+        pathname,
+        protocol: "http:",
+        search,
+      },
+    };
+  }
+
+  it("redirects a completed verification POST to the configured app origin with 303", async () => {
+    const { proxy, nextResponseRedirect, recoveryLog } = await loadProxy("user_complete");
+
+    const response = await proxy(
+      signupRequest(
+        "?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2F",
+        "POST",
+      ) as Parameters<typeof proxy>[0],
+      {} as Parameters<typeof proxy>[1],
+    );
+
+    expect(response).toEqual({
+      kind: "redirect",
+      url: new URL("https://app.matrix-os.com/"),
+      status: 303,
+    });
+    expect(nextResponseRedirect).toHaveBeenCalledOnce();
+    expect(recoveryLog).toHaveBeenCalledWith("[auth] recovered completed signup");
+  });
+
+  it("preserves a validated same-origin device approval destination", async () => {
+    const { proxy } = await loadProxy("user_complete");
+
+    const response = await proxy(
+      signupRequest(
+        "?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+      ) as Parameters<typeof proxy>[0],
+      {} as Parameters<typeof proxy>[1],
+    );
+
+    expect(response).toEqual({
+      kind: "redirect",
+      url: new URL("https://app.matrix-os.com/auth/device?user_code=BCDF-GHJK"),
+      status: 303,
+    });
+  });
+
+  it("recovers an authenticated reload of the direct sign-up route", async () => {
+    const { proxy } = await loadProxy("user_complete");
+
+    const response = await proxy(
+      signupRequest("", "GET", "/sign-up") as Parameters<typeof proxy>[0],
+      {} as Parameters<typeof proxy>[1],
+    );
+
+    expect(response).toEqual({
+      kind: "redirect",
+      url: new URL("https://app.matrix-os.com/"),
+      status: 303,
+    });
+  });
+
+  it("falls back to the app root for an external destination", async () => {
+    const { proxy } = await loadProxy("user_complete");
+
+    const response = await proxy(
+      signupRequest("?redirect_url=https%3A%2F%2Fevil.example%2Fsteal") as Parameters<typeof proxy>[0],
+      {} as Parameters<typeof proxy>[1],
+    );
+
+    expect(response).toEqual({
+      kind: "redirect",
+      url: new URL("https://app.matrix-os.com/"),
+      status: 303,
+    });
+  });
+
+  it("continues rendering the Clerk flow for an anonymous signup", async () => {
+    const { proxy, nextResponseNext, nextResponseRedirect } = await loadProxy(null);
+
+    const response = await proxy(
+      signupRequest("?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2F") as Parameters<typeof proxy>[0],
+      {} as Parameters<typeof proxy>[1],
+    );
+
+    expect(response).toEqual({ kind: "next", init: undefined });
+    expect(nextResponseNext).toHaveBeenCalledOnce();
+    expect(nextResponseRedirect).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the canonical app origin is not configured", async () => {
+    const { proxy, nextResponseRedirect, recoveryError } = await loadProxy("user_complete", "");
+
+    const response = await proxy(
+      signupRequest("?redirect_url=https%3A%2F%2Fevil.example%2Fsteal") as Parameters<typeof proxy>[0],
+      {} as Parameters<typeof proxy>[1],
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(503);
+    expect(nextResponseRedirect).not.toHaveBeenCalled();
+    expect(recoveryError).toHaveBeenCalledWith(
+      "[auth] completed signup recovery unavailable: app origin is not configured",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- recover authenticated users who revisit a Clerk sign-up route after signup has already completed, including trusted platform-routed VPS sessions
- redirect with `303 See Other` to a bounded, same-origin destination, preserving CLI device-approval handoffs and rejecting external/auth-loop targets
- keep anonymous users in the normal Clerk signup flow and emit a privacy-safe recovery log for occurrence counting
- verify that the platform-owned no-VPS auth-shell proxy preserves the recovery redirect

Closes #1565

## Tests

- `pnpm exec vitest run tests/shell/proxy-auth.test.ts` (47 passed)
- targeted platform recovery checks for both no-VPS and provisioned-VPS paths (2 passed)
- `pnpm exec vitest run tests/platform/proxy-routing.test.ts` (134 passed)
- full TypeScript gate, using the pnpm subcommands directly because Bun is unavailable in this environment
- `pnpm run check:patterns` (0 violations; existing repository warnings only)
- changed-source ESLint: `shell/src/lib/proxy-routes.ts` and `shell/src/proxy.ts` pass
- production `shell` build passes with a local dummy `pk_test_...` Clerk key

The broader `pnpm test` run was stopped after reproducing unrelated baseline failures in `customer-vps-host-bundle.test.ts` (permission-dependent log assertion) and all 13 Codex app-server runtime tests. The full-shell lint command also reports 51 pre-existing errors outside this diff; linting the changed source files passes.

Screenshot evidence is not applicable to this server-side redirect change: no rendered component, copy, styling, or layout changes. A real completed-signup browser capture would require Clerk test credentials, which are not present in this environment; production credentials were not used.

## Review/Monitoring

- GitHub PR title and preview gates pass on the latest commit
- Claude Code Review passes on the latest commit
- Greptile reports 5/5 on exact head `56f43da2f32014b1f9833372694a6f5615a55e7c`; all review threads are resolved

## Invariants

- **Source of truth:** Clerk session state determines whether signup is complete. `NEXT_PUBLIC_MATRIX_APP_URL` is the canonical redirect origin; request forwarding headers are never trusted for this redirect.
- **Lock/transaction scope:** no persistence or multi-write workflow is introduced. Recovery is a read-only request-boundary decision.
- **Acceptable orphan states:** an established Clerk session may remain on a signup URL until its next request; that request deterministically redirects. Missing canonical-origin configuration fails closed with a generic `503`.
- **Auth source of truth:** the awaited Clerk middleware `auth()` result for direct auth-shell requests, or the validated platform bearer/user proof for provisioned VPS routes. Anonymous requests continue to the Clerk signup UI unchanged.
- **Deferred scope:** this does not reconstruct historical affected-user counts or change Clerk internals. It adds a static recovery log so future occurrences can be counted without recording email, user ID, or redirect contents.

## Deployment

This affects the pre-VPS `app.matrix-os.com` auth surface and the customer VPS shell fast path. After merge, redeploy the platform/app-shell service from the control VPS and verify the no-VPS signup flow. A later host-bundle rollout carries the same recovery behavior to already provisioned runtimes; publishing only that bundle will not update the pre-VPS screen.
