### PR TITLE
fix(terminal): preserve input in sessions created before updates

### DIFF
--- a/distro/customer-vps/host-bin/matrix-terminal-attach.mjs
+++ b/distro/customer-vps/host-bin/matrix-terminal-attach.mjs
@@ -87,7 +87,9 @@ try {
 }
 
 const configDir = join(homePath, "system", "zellij");
-const child = spawn(zellijPath, ["attach", descriptor.sessionName, ...remainingArgs], {
+// Match the gateway adapter: Normal is a typing fallback for old Normal-mode
+// servers and new Locked-mode servers, without changing their initial mode.
+const child = spawn(zellijPath, ["attach", descriptor.sessionName, ...remainingArgs, "options", "--default-mode", "normal"], {
   cwd: homePath,
   env: {
     ...process.env,

--- a/docs/dev/terminal-session-ownership.md
+++ b/docs/dev/terminal-session-ownership.md
@@ -37,6 +37,35 @@ and reacquires ownership when the user returns. If another renderer takes over
 while mobile is visible, mobile closes the displaced socket and requires an
 explicit **Resume here** action before it requests a new exclusive lease.
 
+## Compatibility with sessions created before an update
+
+The shared gateway adapter attaches with `options --default-mode normal`.
+Zellij 0.44 initializes the attached client's current mode from the running
+server's saved configuration, while interpreting keys against the new client's
+default-mode options. If a server saved Normal and an updated client defaults
+to Locked, unbound ordinary keys become no-ops. Paste follows a separate action
+path and can still work, making the terminal appear to freeze after pasting.
+
+Normal is the attachment fallback for both supported saved modes: Normal then
+writes unbound keys, and Locked always writes them regardless of the fallback.
+New Matrix sessions still start Locked. This override changes neither session
+identity nor running processes, and all gateway-coordinated surfaces inherit it.
+Do not remove it merely because a newly created session passes a typing test.
+
+The host-bundle build runs `scripts/smoke-zellij-session-config.ts` against its
+staged Zellij binary. It creates isolated servers with Normal and Locked saved
+configurations, attaches through the real gateway adapter using the updated
+configuration, and checks typing, backspace, paste, and repeated attachment
+without replacing the pane process. Run it locally with:
+
+```bash
+pnpm exec tsx scripts/smoke-zellij-session-config.ts /absolute/path/to/zellij
+```
+
+An affected running session needs a fresh gateway attachment after the fixed
+gateway is installed. Closing a Terminal window alone does not restart its
+durable shell, and deleting/recreating sessions is unnecessary for this defect.
+
 ## Direct Zellij attachment
 
 `zellij attach <session>` talks directly to the Zellij server and bypasses the

--- a/docs/dev/terminal-session-ownership.md
+++ b/docs/dev/terminal-session-ownership.md
@@ -55,8 +55,10 @@ Do not remove it merely because a newly created session passes a typing test.
 The host-bundle build runs `scripts/smoke-zellij-session-config.ts` against its
 staged Zellij binary. It creates isolated servers with Normal and Locked saved
 configurations, attaches through the real gateway adapter using the updated
-configuration, and checks typing, backspace, paste, and repeated attachment
-without replacing the pane process. Run it locally with:
+configuration, and checks typing, backspace, paste, and repeated/indexed
+attachment without replacing the pane process. A supervisor owns the temporary
+directories and session cleanup, including when the test worker times out or
+is interrupted. Run it locally with:
 
 ```bash
 pnpm exec tsx scripts/smoke-zellij-session-config.ts /absolute/path/to/zellij

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -424,7 +424,12 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
   }
 
   function attachProcess(name: string, options: AttachOptions = {}): ShellAttachProcess {
-    const pty = spawnPty(binaryPath, ["attach", name], {
+    // Zellij 0.44 attaches in the server's saved mode, but interprets unbound
+    // keys against the new client's default. Old Normal servers + a Locked
+    // client silently discard typing. Normal is the compatible fallback for
+    // both generations: Locked always writes keys, regardless of the default.
+    // Keep new sessions starting Locked; override only the attach fallback.
+    const pty = spawnPty(binaryPath, ["attach", name, "options", "--default-mode", "normal"], {
       name: "xterm-256color",
       cols: options.size?.cols ?? 120,
       rows: options.size?.rows ?? 40,

--- a/packages/gateway/src/zellij-runtime.ts
+++ b/packages/gateway/src/zellij-runtime.ts
@@ -286,11 +286,11 @@ export function createZellijRuntime(options: {
     },
 
     attachCommand(sessionId: string): string[] {
-      return ["zellij", "attach", sessionName(sessionId)];
+      return ["zellij", "attach", sessionName(sessionId), "options", "--default-mode", "normal"];
     },
 
     observeCommand(sessionId: string): string[] {
-      return ["zellij", "attach", sessionName(sessionId), "--index", "0"];
+      return ["zellij", "attach", sessionName(sessionId), "--index", "0", "options", "--default-mode", "normal"];
     },
 
     async sendInput(sessionId: string, input: string, signal?: AbortSignal): Promise<void> {

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -94,6 +94,7 @@ ZELLIJ_ACTUAL_VERSION="$("$STAGE_DIR/bin/zellij" --version)"
 }
 timeout --signal=KILL 15s node "$ROOT_DIR/scripts/smoke-zellij-host-query.mjs" "$STAGE_DIR/bin/zellij"
 timeout --signal=KILL 15s node "$ROOT_DIR/scripts/smoke-zellij-watcher-sizing.mjs" "$STAGE_DIR/bin/zellij"
+timeout --signal=KILL 35s node --import tsx "$ROOT_DIR/scripts/smoke-zellij-session-config.ts" "$STAGE_DIR/bin/zellij"
 TERMINAL_RUNTIME_GENERATION="$(
   "$ROOT_DIR/distro/customer-vps/host-bin/matrix-terminal-generation-id" \
     "$STAGE_DIR/bin/zellij" \

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -94,7 +94,7 @@ ZELLIJ_ACTUAL_VERSION="$("$STAGE_DIR/bin/zellij" --version)"
 }
 timeout --signal=KILL 15s node "$ROOT_DIR/scripts/smoke-zellij-host-query.mjs" "$STAGE_DIR/bin/zellij"
 timeout --signal=KILL 15s node "$ROOT_DIR/scripts/smoke-zellij-watcher-sizing.mjs" "$STAGE_DIR/bin/zellij"
-timeout --signal=KILL 35s node --import tsx "$ROOT_DIR/scripts/smoke-zellij-session-config.ts" "$STAGE_DIR/bin/zellij"
+node --import tsx "$ROOT_DIR/scripts/smoke-zellij-session-config.ts" "$STAGE_DIR/bin/zellij"
 TERMINAL_RUNTIME_GENERATION="$(
   "$ROOT_DIR/distro/customer-vps/host-bin/matrix-terminal-generation-id" \
     "$STAGE_DIR/bin/zellij" \

--- a/scripts/smoke-zellij-session-config.ts
+++ b/scripts/smoke-zellij-session-config.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env -S node --import tsx
+// Exercise the real adapter against a server retaining an earlier configuration.
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { createZellijAdapter, type ShellAttachProcess } from "../packages/gateway/src/shell/zellij.js";
+
+const run = promisify(execFile);
+const binary = resolve(process.argv[2] ?? "");
+if (!process.argv[2]) throw new Error("usage: smoke-zellij-session-config.ts <zellij-binary>");
+const delay = (ms: number) => new Promise((done) => setTimeout(done, ms));
+
+async function waitFor(check: () => Promise<boolean>, label: string) {
+  const deadline = Date.now() + 4_000;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await delay(50);
+  }
+  throw new Error(label);
+}
+
+for (const savedMode of ["normal", "locked"]) {
+  const root = await mkdtemp(join(tmpdir(), "mzc-"));
+  const serverConfig = join(root, "server.kdl");
+  const clientConfig = join(root, "client.kdl");
+  const inputPath = join(root, "input");
+  const pidPath = join(root, "pane-pid");
+  const probe = join(root, "probe.mjs");
+  const layout = join(root, "layout.kdl");
+  const session = `mzc-${randomUUID().slice(0, 8)}`;
+  const env = {
+    HOME: root,
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    TERM: "xterm-256color",
+    LANG: "C.UTF-8",
+    XDG_RUNTIME_DIR: join(root, "runtime"),
+    XDG_CACHE_HOME: join(root, "cache"),
+    XDG_DATA_HOME: join(root, "data"),
+    XDG_CONFIG_HOME: join(root, "config"),
+    TMPDIR: join(root, "tmp"),
+    ZELLIJ_CONFIG_DIR: root,
+    ZELLIJ_CONFIG_FILE: clientConfig,
+    ZELLIJ_SOCKET_DIR: join(root, "s"),
+  };
+  let created = false;
+  let client: ShellAttachProcess | undefined;
+  try {
+    await Promise.all([env.XDG_RUNTIME_DIR, env.XDG_CACHE_HOME, env.XDG_DATA_HOME, env.XDG_CONFIG_HOME, env.TMPDIR]
+      .map((path) => mkdir(path, { recursive: true })));
+    const common = "pane_frames false\nshow_startup_tips false\nshow_release_notes false\nsession_serialization false\n";
+    await writeFile(serverConfig, `${common}default_mode "${savedMode}"\n`);
+    await writeFile(clientConfig, `${common}default_mode "locked"\n`);
+    await writeFile(inputPath, "");
+    await writeFile(probe, `
+import { appendFile, writeFile } from 'node:fs/promises';
+await writeFile(${JSON.stringify(pidPath)}, String(process.pid));
+process.stdin.setRawMode(true);
+let bytes = 0;
+let writes = Promise.resolve();
+process.stdin.on('data', data => {
+  bytes += data.length;
+  if (bytes > 4096) process.exit(2);
+  writes = writes.then(() => appendFile(${JSON.stringify(inputPath)}, data));
+});
+process.stdout.write('READY');
+setTimeout(() => process.exit(0), 30000);
+`);
+    await writeFile(layout, `layout {
+  pane command=${JSON.stringify(process.execPath)} {
+    args ${JSON.stringify(probe)}
+  }
+}
+`);
+    await run(binary, ["--config", serverConfig, "--layout", layout, "attach", "--create-background", session], {
+      env, cwd: root, timeout: 5_000,
+    });
+    created = true;
+    await waitFor(async () => readFile(pidPath).then(() => true, (error) => {
+      if (error.code === "ENOENT") return false;
+      throw error;
+    }), "pane did not start");
+    const originalPid = await readFile(pidPath, "utf8");
+    const adapter = createZellijAdapter({ binaryPath: binary, cwd: root, env, manageConfig: false });
+    let expected = "";
+    for (let attachment = 0; attachment < 2; attachment += 1) {
+      client = adapter.attachSession(session, { size: { cols: 80, rows: 24 } });
+      // Consume output so the attached PTY cannot block on startup queries.
+      let output = "";
+      const data = client.onData((chunk) => { output = (output + chunk).slice(-65_536); });
+      await waitFor(async () => output.includes("READY"), `${savedMode} attachment did not render the live pane`);
+      // A new Locked session must still pass Ctrl+p to the application, rather
+      // than entering Zellij's native pane mode as a Normal session would.
+      const inputs = ["q", "\x7f", "\x1b[200~paste\x1b[201~", ...(savedMode === "locked" ? ["\x10"] : [])];
+      for (const input of inputs) {
+        // The pane never enables bracketed paste, so Zellij strips its markers.
+        expected += input.startsWith("\x1b[200~") ? "paste" : input;
+        client.write(input);
+        await waitFor(async () => (await readFile(inputPath, "utf8")) === expected,
+          `${savedMode} server lost input on attachment ${attachment + 1}: ${JSON.stringify(input)}`);
+      }
+      client.kill();
+      client = undefined;
+      data.dispose();
+      await delay(150);
+      if (await readFile(pidPath, "utf8") !== originalPid) throw new Error("pane process was replaced");
+    }
+    console.log(`PASS: ${savedMode} server, updated Locked client, typing/paste/reconnect, same pane process`);
+  } finally {
+    client?.kill();
+    if (created) await run(binary, ["kill-session", session], { env, timeout: 5_000 });
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/scripts/smoke-zellij-session-config.ts
+++ b/scripts/smoke-zellij-session-config.ts
@@ -1,17 +1,30 @@
 #!/usr/bin/env -S node --import tsx
-// Exercise the real adapter against a server retaining an earlier configuration.
+// Exercise real Matrix attachments against servers retaining older configuration.
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { createZellijAdapter, type ShellAttachProcess } from "../packages/gateway/src/shell/zellij.js";
+import { createZellijRuntime } from "../packages/gateway/src/zellij-runtime.js";
 
 const run = promisify(execFile);
 const binary = resolve(process.argv[2] ?? "");
 if (!process.argv[2]) throw new Error("usage: smoke-zellij-session-config.ts <zellij-binary>");
 const delay = (ms: number) => new Promise((done) => setTimeout(done, ms));
+const spawnPty = createRequire(import.meta.url)("node-pty").spawn;
+
+function fixtureEnv(root: string) {
+  return {
+    HOME: root, PATH: process.env.PATH ?? "/usr/bin:/bin", TERM: "xterm-256color", LANG: "C.UTF-8",
+    XDG_RUNTIME_DIR: join(root, "runtime"), XDG_CACHE_HOME: join(root, "cache"),
+    XDG_DATA_HOME: join(root, "data"), XDG_CONFIG_HOME: join(root, "config"), TMPDIR: join(root, "tmp"),
+    ZELLIJ_CONFIG_DIR: root, ZELLIJ_CONFIG_FILE: join(root, "client.kdl"), ZELLIJ_SOCKET_DIR: join(root, "s"),
+  };
+}
 
 async function waitFor(check: () => Promise<boolean>, label: string) {
   const deadline = Date.now() + 4_000;
@@ -22,39 +35,73 @@ async function waitFor(check: () => Promise<boolean>, label: string) {
   throw new Error(label);
 }
 
-for (const savedMode of ["normal", "locked"]) {
-  const root = await mkdtemp(join(tmpdir(), "mzc-"));
-  const serverConfig = join(root, "server.kdl");
-  const clientConfig = join(root, "client.kdl");
-  const inputPath = join(root, "input");
-  const pidPath = join(root, "pane-pid");
-  const probe = join(root, "probe.mjs");
-  const layout = join(root, "layout.kdl");
-  const session = `mzc-${randomUUID().slice(0, 8)}`;
-  const env = {
-    HOME: root,
-    PATH: process.env.PATH ?? "/usr/bin:/bin",
-    TERM: "xterm-256color",
-    LANG: "C.UTF-8",
-    XDG_RUNTIME_DIR: join(root, "runtime"),
-    XDG_CACHE_HOME: join(root, "cache"),
-    XDG_DATA_HOME: join(root, "data"),
-    XDG_CONFIG_HOME: join(root, "config"),
-    TMPDIR: join(root, "tmp"),
-    ZELLIJ_CONFIG_DIR: root,
-    ZELLIJ_CONFIG_FILE: clientConfig,
-    ZELLIJ_SOCKET_DIR: join(root, "s"),
-  };
-  let created = false;
-  let client: ShellAttachProcess | undefined;
+// The supervisor owns all fixture roots and daemons. Killing a timed-out worker
+// cannot bypass cleanup, unlike an outer `timeout --signal=KILL` on this script.
+async function supervise() {
+  const root = await mkdtemp(join(process.platform === "darwin" ? "/tmp" : tmpdir(), "mzc-"));
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  process.once("SIGTERM", abort);
+  process.once("SIGINT", abort);
+  let failure: unknown;
   try {
-    await Promise.all([env.XDG_RUNTIME_DIR, env.XDG_CACHE_HOME, env.XDG_DATA_HOME, env.XDG_CONFIG_HOME, env.TMPDIR]
-      .map((path) => mkdir(path, { recursive: true })));
-    const common = "pane_frames false\nshow_startup_tips false\nshow_release_notes false\nsession_serialization false\n";
-    await writeFile(serverConfig, `${common}default_mode "${savedMode}"\n`);
-    await writeFile(clientConfig, `${common}default_mode "locked"\n`);
-    await writeFile(inputPath, "");
-    await writeFile(probe, `
+    const result = await run(process.execPath, ["--import", "tsx", fileURLToPath(import.meta.url), binary, root], {
+      timeout: 35_000, killSignal: "SIGKILL", signal: controller.signal, maxBuffer: 512 * 1024,
+    });
+    process.stdout.write(result.stdout);
+    process.stderr.write(result.stderr);
+  } catch (error) {
+    failure = error;
+  } finally {
+    try {
+      for (const entry of await readdir(root, { withFileTypes: true })) {
+        if (!entry.isDirectory() || !entry.name.startsWith("case-")) continue;
+        const fixture = join(root, entry.name);
+        try {
+          const session = await readFile(join(fixture, "session"), "utf8");
+          if (!/^matrix-sess_[0-9a-f]{8}$/.test(session)) throw new Error("invalid smoke session marker");
+          await run(binary, ["kill-session", session], { env: fixtureEnv(fixture), timeout: 5_000 });
+        } catch (error) {
+          console.error("Zellij smoke cleanup failed:", error);
+          failure ??= error;
+        }
+      }
+    } finally {
+      try {
+        await rm(root, { recursive: true, force: true });
+      } catch (error) {
+        console.error("Zellij smoke directory cleanup failed:", error);
+        failure ??= error;
+      }
+      process.removeListener("SIGTERM", abort);
+      process.removeListener("SIGINT", abort);
+    }
+  }
+  if (failure) throw failure;
+}
+
+async function exercise(parentRoot: string) {
+  for (const savedMode of ["normal", "locked"]) {
+    const root = await mkdtemp(join(parentRoot, "case-"));
+    const env = fixtureEnv(root);
+    const serverConfig = join(root, "server.kdl");
+    const inputPath = join(root, "input");
+    const pidPath = join(root, "pane-pid");
+    const probe = join(root, "probe.mjs");
+    const layout = join(root, "layout.kdl");
+    const sessionId = `sess_${randomUUID().slice(0, 8)}`;
+    const session = `matrix-${sessionId}`;
+    let client: ShellAttachProcess | undefined;
+    try {
+      // Record before launch so the supervisor can recover even a timed-out start.
+      await writeFile(join(root, "session"), session);
+      await Promise.all([env.XDG_RUNTIME_DIR, env.XDG_CACHE_HOME, env.XDG_DATA_HOME, env.XDG_CONFIG_HOME, env.TMPDIR]
+        .map((path) => mkdir(path, { recursive: true })));
+      const common = "pane_frames false\nshow_startup_tips false\nshow_release_notes false\nsession_serialization false\n";
+      await writeFile(serverConfig, `${common}default_mode "${savedMode}"\n`);
+      await writeFile(env.ZELLIJ_CONFIG_FILE, `${common}default_mode "locked"\n`);
+      await writeFile(inputPath, "");
+      await writeFile(probe, `
 import { appendFile, writeFile } from 'node:fs/promises';
 await writeFile(${JSON.stringify(pidPath)}, String(process.pid));
 process.stdin.setRawMode(true);
@@ -68,49 +115,54 @@ process.stdin.on('data', data => {
 process.stdout.write('READY');
 setTimeout(() => process.exit(0), 30000);
 `);
-    await writeFile(layout, `layout {
+      await writeFile(layout, `layout {
   pane command=${JSON.stringify(process.execPath)} {
     args ${JSON.stringify(probe)}
   }
 }
 `);
-    await run(binary, ["--config", serverConfig, "--layout", layout, "attach", "--create-background", session], {
-      env, cwd: root, timeout: 5_000,
-    });
-    created = true;
-    await waitFor(async () => readFile(pidPath).then(() => true, (error) => {
-      if (error.code === "ENOENT") return false;
-      throw error;
-    }), "pane did not start");
-    const originalPid = await readFile(pidPath, "utf8");
-    const adapter = createZellijAdapter({ binaryPath: binary, cwd: root, env, manageConfig: false });
-    let expected = "";
-    for (let attachment = 0; attachment < 2; attachment += 1) {
-      client = adapter.attachSession(session, { size: { cols: 80, rows: 24 } });
-      // Consume output so the attached PTY cannot block on startup queries.
-      let output = "";
-      const data = client.onData((chunk) => { output = (output + chunk).slice(-65_536); });
-      await waitFor(async () => output.includes("READY"), `${savedMode} attachment did not render the live pane`);
-      // A new Locked session must still pass Ctrl+p to the application, rather
-      // than entering Zellij's native pane mode as a Normal session would.
-      const inputs = ["q", "\x7f", "\x1b[200~paste\x1b[201~", ...(savedMode === "locked" ? ["\x10"] : [])];
-      for (const input of inputs) {
-        // The pane never enables bracketed paste, so Zellij strips its markers.
-        expected += input.startsWith("\x1b[200~") ? "paste" : input;
-        client.write(input);
-        await waitFor(async () => (await readFile(inputPath, "utf8")) === expected,
-          `${savedMode} server lost input on attachment ${attachment + 1}: ${JSON.stringify(input)}`);
+      await run(binary, ["--config", serverConfig, "--layout", layout, "attach", "--create-background", session], {
+        env, cwd: root, timeout: 5_000,
+      });
+      await waitFor(async () => readFile(pidPath).then(() => true, (error) => {
+        if (error.code === "ENOENT") return false;
+        throw error;
+      }), "pane did not start");
+      const originalPid = await readFile(pidPath, "utf8");
+      const adapter = createZellijAdapter({ binaryPath: binary, cwd: root, env, manageConfig: false });
+      const runtime = createZellijRuntime({ homePath: root });
+      let expected = "";
+      for (const path of ["direct", "reconnect", "indexed"]) {
+        client = path === "indexed"
+          ? spawnPty(binary, runtime.observeCommand(sessionId).slice(1), {
+              name: "xterm-256color", cols: 80, rows: 24, cwd: root, env,
+            })
+          : adapter.attachSession(session, { size: { cols: 80, rows: 24 } });
+        let output = "";
+        const data = client!.onData((chunk) => { output = (output + chunk).slice(-65_536); });
+        await waitFor(async () => output.includes("READY"), `${savedMode}/${path} did not render the live pane`);
+        // Ctrl+p must reach new Locked sessions, not enter native pane mode.
+        const inputs = ["q", "\x7f", "\x1b[200~paste\x1b[201~", ...(savedMode === "locked" ? ["\x10"] : [])];
+        for (const input of inputs) {
+          // The probe never enables bracketed paste; Zellij strips its markers.
+          expected += input.startsWith("\x1b[200~") ? "paste" : input;
+          client!.write(input);
+          await waitFor(async () => (await readFile(inputPath, "utf8")) === expected,
+            `${savedMode}/${path} lost input: ${JSON.stringify(input)}`);
+        }
+        client!.kill();
+        client = undefined;
+        data.dispose();
+        await delay(150);
+        if (await readFile(pidPath, "utf8") !== originalPid) throw new Error("pane process was replaced");
       }
-      client.kill();
-      client = undefined;
-      data.dispose();
-      await delay(150);
-      if (await readFile(pidPath, "utf8") !== originalPid) throw new Error("pane process was replaced");
+      console.log(`PASS: ${savedMode} server, direct/reconnect/indexed, typing/paste/Ctrl keys, same process`);
+    } finally {
+      client?.kill();
+      // Daemon and directory cleanup belongs to the supervisor, even on timeout.
     }
-    console.log(`PASS: ${savedMode} server, updated Locked client, typing/paste/reconnect, same pane process`);
-  } finally {
-    client?.kill();
-    if (created) await run(binary, ["kill-session", session], { env, timeout: 5_000 });
-    await rm(root, { recursive: true, force: true });
   }
 }
+
+if (process.argv[3]) await exercise(process.argv[3]);
+else await supervise();

--- a/tests/deploy/customer-vps/matrix-terminal-attach.test.ts
+++ b/tests/deploy/customer-vps/matrix-terminal-attach.test.ts
@@ -45,8 +45,8 @@ describe("matrix-terminal-attach", () => {
     await rm(fixtureRoot, { recursive: true, force: true });
   });
 
-  it("executes only the exact generation binary with a validated argv array", async () => {
-    await execFileAsync(process.execPath, [helperPath, RUNTIME_ID, "--index", "0"], {
+  it.each([[], ["--index", "0"]])("executes the pinned binary with compatible input mode (%j)", async (...args) => {
+    await execFileAsync(process.execPath, [helperPath, RUNTIME_ID, ...args], {
       env: {
         ...process.env,
         MATRIX_HOME: homePath,
@@ -57,7 +57,7 @@ describe("matrix-terminal-attach", () => {
     });
 
     await expect(readFile(capturePath, "utf8")).resolves.toBe(
-      `attach\nmatrix-${RUNTIME_ID}\n--index\n0\n`,
+      ["attach", `matrix-${RUNTIME_ID}`, ...args, "options", "--default-mode", "normal", ""].join("\n"),
     );
   });
 

--- a/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
+++ b/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
@@ -133,7 +133,7 @@ describe("customer VPS user-systemd terminal runtime", () => {
     );
 
     expect(attach).toContain("descriptor.generation");
-    expect(attach).toContain('["attach", descriptor.sessionName, ...remainingArgs]');
+    expect(attach).toContain('["attach", descriptor.sessionName, ...remainingArgs, "options", "--default-mode", "normal"]');
     expect(attach).not.toContain("shell: true");
     expect(updater).toContain("/usr/local/bin/matrix-terminal-attach");
   });

--- a/tests/deploy/customer-vps/zellij-smoke-supervisor.test.ts
+++ b/tests/deploy/customer-vps/zellij-smoke-supervisor.test.ts
@@ -1,0 +1,51 @@
+import { spawn } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Zellij smoke supervisor", () => {
+  it.each([false, true])("cleans an interrupted worker and preserves its error (cleanup fails: %s)", async (cleanupFails) => {
+    const root = await mkdtemp(join(tmpdir(), "mzc-supervisor-"));
+    const marker = join(root, "started.json");
+    const cleaned = join(root, "cleaned");
+    const binary = join(root, "fake-zellij");
+    let child: ReturnType<typeof spawn> | undefined;
+    try {
+      await writeFile(binary, `#!${process.execPath}
+const fs = require('node:fs');
+if (process.argv[2] === 'kill-session') {
+  const original = JSON.parse(fs.readFileSync(${JSON.stringify(marker)}, 'utf8'));
+  try { process.kill(original.pid, 'SIGKILL'); }
+  catch (error) { if (error.code !== 'ESRCH') throw error; }
+  fs.writeFileSync(${JSON.stringify(cleaned)}, 'yes');
+  process.exit(${cleanupFails ? 1 : 0});
+}
+fs.writeFileSync(${JSON.stringify(marker)}, JSON.stringify({pid:process.pid, fixture:process.env.HOME}));
+setTimeout(() => process.exit(0), 10000);
+`);
+      await chmod(binary, 0o700);
+      child = spawn(process.execPath, ["--import", "tsx", "scripts/smoke-zellij-session-config.ts", binary], {
+        cwd: process.cwd(), stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stderr = "";
+      child.stderr!.on("data", (data) => { stderr = (stderr + data).slice(-65_536); });
+      child.stdout!.resume();
+      const closed = new Promise<number | null>((done) => child!.once("close", done));
+      await expect.poll(async () => readFile(marker, "utf8").then(() => true, (error) => {
+        if (error.code === "ENOENT") return false;
+        throw error;
+      }), { timeout: 4_000 }).toBe(true);
+      const { fixture } = JSON.parse(await readFile(marker, "utf8"));
+      child.kill("SIGTERM");
+      expect(await closed).not.toBe(0);
+      expect(stderr).toContain("AbortError");
+      if (cleanupFails) expect(stderr).toContain("Zellij smoke cleanup failed");
+      await expect(readFile(cleaned, "utf8")).resolves.toBe("yes");
+      await expect(readFile(join(fixture, "session"))).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      if (child && child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -394,7 +394,7 @@ describe("zellij adapter", () => {
 
     expect(spawnPty).toHaveBeenCalledWith(
       "zellij",
-      ["attach", "main"],
+      ["attach", "main", "options", "--default-mode", "normal"],
       expect.objectContaining({
         cols: 120,
         rows: 40,
@@ -441,7 +441,7 @@ describe("zellij adapter", () => {
 
     expect(spawnPty).toHaveBeenCalledWith(
       "zellij",
-      ["attach", "main"],
+      ["attach", "main", "options", "--default-mode", "normal"],
       expect.objectContaining({
         env: expect.objectContaining({
           HOME: "/srv/matrix/home",
@@ -476,7 +476,7 @@ describe("zellij adapter", () => {
 
     expect(spawnPty).toHaveBeenCalledWith(
       "zellij",
-      ["attach", "setup"],
+      ["attach", "setup", "options", "--default-mode", "normal"],
       expect.objectContaining({ name: "xterm-256color", cols: 120, rows: 40 }),
     );
     expect(pty.writes).toEqual(["claude\r"]);

--- a/tests/gateway/zellij-runtime.test.ts
+++ b/tests/gateway/zellij-runtime.test.ts
@@ -87,8 +87,8 @@ describe("zellij-runtime", () => {
     );
     expect(runCommand).not.toHaveBeenCalledWith("zellij", expect.arrayContaining(["--layout"]), expect.any(Object));
 
-    expect(runtime.attachCommand("sess_abc123")).toEqual(["zellij", "attach", "matrix-sess_abc123"]);
-    expect(runtime.observeCommand("sess_abc123")).toEqual(["zellij", "attach", "matrix-sess_abc123", "--index", "0"]);
+    expect(runtime.attachCommand("sess_abc123")).toEqual(["zellij", "attach", "matrix-sess_abc123", "options", "--default-mode", "normal"]);
+    expect(runtime.observeCommand("sess_abc123")).toEqual(["zellij", "attach", "matrix-sess_abc123", "--index", "0", "options", "--default-mode", "normal"]);
 
     await expect(runtime.kill("sess_abc123")).resolves.toEqual({ ok: true });
     expect(pty.process.kill).toHaveBeenCalledTimes(1);

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -142,7 +142,7 @@ describe('customer VPS host bundle', () => {
       'timeout --signal=KILL 15s node "$ROOT_DIR/scripts/smoke-zellij-host-query.mjs" "$STAGE_DIR/bin/zellij"',
     );
     expect(script).toContain(
-      'timeout --signal=KILL 35s node --import tsx "$ROOT_DIR/scripts/smoke-zellij-session-config.ts" "$STAGE_DIR/bin/zellij"',
+      'node --import tsx "$ROOT_DIR/scripts/smoke-zellij-session-config.ts" "$STAGE_DIR/bin/zellij"',
     );
     expect(script).toContain('chmod 0755 "$STAGE_DIR/bin/zellij"');
     expect(script).toContain(

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -141,6 +141,9 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain(
       'timeout --signal=KILL 15s node "$ROOT_DIR/scripts/smoke-zellij-host-query.mjs" "$STAGE_DIR/bin/zellij"',
     );
+    expect(script).toContain(
+      'timeout --signal=KILL 35s node --import tsx "$ROOT_DIR/scripts/smoke-zellij-session-config.ts" "$STAGE_DIR/bin/zellij"',
+    );
     expect(script).toContain('chmod 0755 "$STAGE_DIR/bin/zellij"');
     expect(script).toContain(
       'tar -C "$STAGE_DIR" -czf "$DIST_DIR/$BUNDLE_NAME" bin app runtime systemd user-systemd terminal-runtime release.json incremental-manifest.json',


### PR DESCRIPTION
## Summary

Terminal sessions created before a configuration update can still render and accept pasted text while silently discarding ordinary typing. Zellij 0.44 initializes an attachment in the server's saved mode, but interprets unbound keys against the fresh client's default. An older Normal-mode server combined with a new Locked default turns ordinary keys into no-ops.

Use `options --default-mode normal` as the attachment fallback in the shared gateway adapter, workspace runtime commands, and validated host helper. Both saved modes accept input; new sessions retain their Locked initial mode and Ctrl-key behavior. Existing processes, identities, and stored content are preserved.

Add a supervised real Zellij regression to host-bundle validation, including direct and indexed attachment, interruption-safe cleanup, and cleanup-failure tests. Document the compatibility contract. Tracks MAT-518. No release or fleet rollout is included.

## Tests

- Real Zellij 0.44.3 regression: ordinary `q` failed before the fix; both saved-mode scenarios pass after it, including typing, backspace, paste, reconnects with the same pane process, and Ctrl+p preservation in Locked sessions.
- 205 focused tests pass across gateway adapter, WebSocket, workspace runtime, host helper, and bundle suites.
- Full typecheck passes; pattern checks pass with zero violations and five existing warnings.
- Full test suite attempted, then interrupted after repeated failures and long waits in other areas, including app storage and runtime-service suites. No full-suite pass is claimed; exact-head CI remains required.

## Surface validation

No renderer UI changes. UI N/A entries request review on that architectural basis. Shared gateway coverage applies to all coordinated renderers; final-branch acceptance in individual renderers remains unverified until deployment.

| Surface | UI | Behavior | State/recovery | Automated tests | Real evidence |
| --- | --- | --- | --- | --- | --- |
| Web Canvas | N/A: no UI diff | shared fix | shared fix | gateway pass | unverified |
| Web Desktop | N/A: no UI diff | shared fix | shared fix | gateway pass | unverified |
| Electron Desktop | N/A: no UI diff | shared fix | shared fix | gateway pass | unverified for final branch |
| Web Mobile | N/A: no UI diff | shared fix | shared fix | gateway pass | unverified |
| Native Mobile | N/A: no UI diff | shared fix | shared fix | gateway pass | unverified |

## Invariants

### Source of truth
Zellij retains live processes and the saved initial mode. The adapter changes only the client fallback for unbound keys. Runtime descriptors still select the pinned executable.

### Lock/transaction scope
No database changes or new critical sections. Existing ownership leases, epoch fencing, and attachment lifecycle remain authoritative.

### Acceptable orphan states
No new production resources. Smoke sessions have unique names, isolated socket/config directories, bounded probes, and explicit teardown. Failed attachment never deletes or recreates an existing session.

### Auth source of truth
Existing gateway authentication and lease checks. The host helper retains exact descriptor/generation validation and its argument allowlist; compatibility options are fixed internal arguments.

### Deferred scope
No clipboard-upload changes, heartbeat redesign, binary upgrade, session recreation, deployment, or fleet rollout. Broader full-suite failures are not claimed resolved. This restores existing behavior without adding a customer workflow, so the internal attachment contract is updated without a separate public-site documentation change.
