### PR TITLE
feat(collaboration): expose scoped Chat realtime APIs

### DIFF
--- a/packages/contracts/src/collaboration.ts
+++ b/packages/contracts/src/collaboration.ts
@@ -81,6 +81,30 @@ export const CollaborationScopeSchema = z.object({
   }
 });
 
+export const CollaborationScopePreflightRequestSchema = z.object({
+  kind: CollaborationScopeKindSchema,
+  resourceId: CollaborationResourceIdSchema,
+}).strict();
+
+export const CollaborationScopePreflightResponseSchema = z.object({
+  eligible: z.boolean(),
+  reason: z.enum(["active_work", "unsupported", "unavailable"]).optional(),
+  resourceRevision: CollaborationRevisionSchema,
+  confirmationToken: z.string().min(64).max(4_096).regex(/^[A-Za-z0-9_.-]+$/).optional(),
+}).strict().superRefine((value, context) => {
+  if (value.eligible !== (value.confirmationToken !== undefined)) {
+    context.addIssue({ code: "custom", message: "Eligible preflights require confirmation" });
+  }
+});
+
+export const CollaborationCreateScopeRequestSchema = z.object({
+  kind: CollaborationScopeKindSchema,
+  resourceId: CollaborationResourceIdSchema,
+  clientRequestId: CollaborationIdSchema,
+  expectedRevision: CollaborationRevisionSchema,
+  confirmationToken: z.string().min(64).max(4_096).regex(/^[A-Za-z0-9_.-]+$/),
+}).strict();
+
 export const CollaborationMemberStatusSchema = z.enum([
   "pending",
   "accepted",
@@ -127,9 +151,12 @@ export const CollaborationMemberPatchRequestSchema = z.object({
   role: CollaborationInviteRoleSchema,
   clientRequestId: CollaborationIdSchema,
   expectedRevision: CollaborationRevisionSchema,
+  expectedMemberRevision: CollaborationRevisionSchema,
 }).strict();
 
-export const CollaborationRevokeRequestSchema = CollaborationConditionalMutationSchema;
+export const CollaborationRevokeRequestSchema = CollaborationConditionalMutationSchema.extend({
+  expectedMemberRevision: CollaborationRevisionSchema,
+}).strict();
 
 export const CollaborationUserStateSchema = z.object({
   readThroughSeq: CollaborationRevisionSchema,
@@ -160,6 +187,16 @@ export const CollaborationHumanMessageSchema = z.object({
   actor: CollaborationParticipantSchema,
   text: boundedText(65_536, COLLABORATION_MESSAGE_BYTE_LIMIT),
   createdAt: z.iso.datetime(),
+}).strict();
+
+export const CollaborationChatSchema = z.object({
+  id: CollaborationResourceIdSchema,
+  scopeId: CollaborationIdSchema,
+  title: boundedDisplayText(200, 1_024),
+  lifecycle: z.enum(["active", "archived"]),
+  revision: CollaborationRevisionSchema,
+  messageCount: CollaborationRevisionSchema,
+  lastMessagePreview: boundedDisplayText(512, 2_048).optional(),
 }).strict();
 
 export const CollaborationPageRequestSchema = z.object({

--- a/packages/contracts/src/collaboration.ts
+++ b/packages/contracts/src/collaboration.ts
@@ -252,6 +252,20 @@ export const CollaborationConnectionTicketResponseSchema = z.object({
   expiresAt: z.iso.datetime(),
 }).strict();
 
+export const CollaborationDirectoryEventSchema = z.object({
+  eventId: CollaborationIdSchema,
+  scopeId: CollaborationIdSchema,
+  runtimeId: CollaborationRuntimeIdSchema,
+  ownerId: CollaborationActorIdSchema,
+  kind: CollaborationScopeKindSchema,
+  authorityGeneration: z.number().int().positive(),
+  metadataRevision: z.number().int().nonnegative(),
+  recipients: z.array(z.object({
+    actorId: CollaborationActorIdSchema,
+    status: z.enum(["invited", "accepted", "revoked"]),
+  }).strict()).max(8),
+}).strict();
+
 const CollaborationEventBaseSchema = z.object({
   version: z.literal(1),
   scopeId: CollaborationIdSchema,

--- a/packages/gateway/src/collaboration/actor-proof.ts
+++ b/packages/gateway/src/collaboration/actor-proof.ts
@@ -99,6 +99,7 @@ export class CollaborationActorProofVerifier {
     signedProof: unknown;
     purpose: "events" | "terminal";
     path: string;
+    query?: string;
   }): Promise<CollaborationActorProof> {
     const parsed = CollaborationSignedActorProofSchema.safeParse(input.signedProof);
     if (!parsed.success) throw invalidProof();
@@ -115,7 +116,7 @@ export class CollaborationActorProofVerifier {
       || proof.purpose !== input.purpose
       || proof.method !== "GET"
       || proof.path !== input.path
-      || proof.query !== ""
+      || proof.query !== (input.query ?? "")
       || proof.bodyDigest !== digestBody(new Uint8Array())
       || !proof.scopeId
       || issuedAt > now + MAX_CLOCK_SKEW_MS

--- a/packages/gateway/src/collaboration/chat-adapter.ts
+++ b/packages/gateway/src/collaboration/chat-adapter.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
   CanonicalChatMessageSchema,
+  CollaborationChatSchema,
   CollaborationCreateDiscussionRequestSchema,
   CollaborationHumanMessageSchema,
   type CanonicalChatMessage,
@@ -205,6 +206,36 @@ export class CollaborationChatAdapter {
         parts: sanitizeParts(message.parts),
         createdAt: message.createdAt,
       };
+    });
+  }
+
+  async getChat(context: AuthorizedCollaborationContext) {
+    const current = await this.options.authority.authorize({
+      scopeId: context.scopeId,
+      actorId: context.actorId,
+      action: "read",
+    });
+    if (current.resourceKind !== "chat" || current.resourceId !== context.resourceId
+      || current.ownerId !== context.ownerId) {
+      throw new CollaborationAuthorizationError("unavailable", "Shared Chat is unavailable");
+    }
+    const chat = await this.options.db.selectFrom("chats")
+      .select(["id", "title", "lifecycle", "revision", "message_count", "last_message_preview", "collaboration"])
+      .where("id", "=", current.resourceId)
+      .where("owner_type", "=", "personal")
+      .where("owner_id", "=", current.ownerId)
+      .executeTakeFirst();
+    if (!chat || !bindingMatches(chat.collaboration, current.scopeId)) {
+      throw new CollaborationAuthorizationError("unavailable", "Shared Chat is unavailable");
+    }
+    return CollaborationChatSchema.parse({
+      id: chat.id,
+      scopeId: current.scopeId,
+      title: chat.title,
+      lifecycle: chat.lifecycle,
+      revision: String(chat.revision),
+      messageCount: String(chat.message_count),
+      ...(chat.last_message_preview ? { lastMessagePreview: chat.last_message_preview } : {}),
     });
   }
 

--- a/packages/gateway/src/collaboration/chat-scope.ts
+++ b/packages/gateway/src/collaboration/chat-scope.ts
@@ -7,6 +7,7 @@ import type { CollaborationScopeRecord } from "./repository.js";
 
 const ACTIVE_RUN_STATES = ["accepted", "running", "waiting_for_approval", "waiting_for_input"] as const;
 const PREFLIGHT_LIFETIME_MS = 60_000;
+const OPERATION_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
 
 const PreflightPayloadSchema = z.object({
   version: z.literal(1),
@@ -88,6 +89,8 @@ export class CollaborationChatScopeService {
   async shareChat(input: {
     ownerId: string;
     chatId: string;
+    clientRequestId: string;
+    payloadHash: string;
     expectedChatRevision: number;
     confirmationToken: string;
   }): Promise<CollaborationScopeRecord> {
@@ -106,7 +109,22 @@ export class CollaborationChatScopeService {
       if (existingBinding) {
         const existing = await selectScope(trx, existingBinding.scopeId);
         if (existing && existing.kind === "chat" && existing.resource_id === input.chatId
-          && existing.lifecycle === "shared") return scopeRecord(existing);
+          && existing.lifecycle === "shared") {
+          const replay = await trx.selectFrom("collaboration_operations")
+            .select(["payload_hash", "status"])
+            .where("scope_id", "=", existing.id)
+            .where("actor_id", "=", input.ownerId)
+            .where("client_request_id", "=", input.clientRequestId)
+            .where("operation_kind", "=", "scope.create")
+            .executeTakeFirst();
+          if (replay && (replay.payload_hash !== input.payloadHash || replay.status !== "completed")) {
+            throw new CollaborationChatScopeError("conflict", "Scope creation request changed");
+          }
+          if (!replay) {
+            await writeCreateOperation(trx, existing, input, now);
+          }
+          return scopeRecord(existing);
+        }
         throw new CollaborationChatScopeError("conflict", "Chat collaboration binding is invalid");
       }
       this.verifyConfirmation(input);
@@ -236,6 +254,7 @@ export class CollaborationChatScopeService {
         delivered_at: null,
         created_at: now,
       }).execute();
+      await writeCreateOperation(trx, activated, input, now);
       return scopeRecord(activated);
     });
   }
@@ -269,6 +288,33 @@ export class CollaborationChatScopeService {
       || payload.data.chatRevision !== input.expectedChatRevision
       || Date.parse(payload.data.expiresAt) <= this.now().getTime()) throw invalidConfirmation();
   }
+}
+
+async function writeCreateOperation(
+  trx: Transaction<OwnerCollaborationDatabase>,
+  scope: Awaited<ReturnType<typeof selectScope>> & {},
+  input: {
+    ownerId: string;
+    clientRequestId: string;
+    payloadHash: string;
+    expectedChatRevision: number;
+  },
+  now: string,
+): Promise<void> {
+  if (!scope) throw new CollaborationChatScopeError("conflict", "Chat scope is unavailable");
+  await trx.insertInto("collaboration_operations").values({
+    scope_id: scope.id,
+    actor_id: input.ownerId,
+    client_request_id: input.clientRequestId,
+    operation_kind: "scope.create",
+    payload_hash: input.payloadHash,
+    status: "completed",
+    result_ref: jsonb({ scopeId: scope.id }),
+    expected_revision: input.expectedChatRevision,
+    accepted_auth_epoch: Number(scope.auth_epoch),
+    created_at: now,
+    expires_at: new Date(new Date(now).getTime() + OPERATION_RETENTION_MS).toISOString(),
+  }).execute();
 }
 
 export function createDiscussionOnlyChatExecutionGuard(db: Kysely<OwnerCollaborationDatabase>): {

--- a/packages/gateway/src/collaboration/chat-scope.ts
+++ b/packages/gateway/src/collaboration/chat-scope.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import { z } from "zod/v4";
 import { sql, type Kysely, type Transaction } from "kysely";
 import type { ChatOwner } from "../chat/records.js";
@@ -50,7 +50,7 @@ export class CollaborationChatScopeService {
       throw new Error("Collaboration preflight secret is unavailable");
     }
     this.now = options.now ?? (() => new Date());
-    this.createScopeId = options.createScopeId ?? (() => crypto.randomUUID());
+    this.createScopeId = options.createScopeId ?? randomUUID;
   }
 
   async preflight(input: { ownerId: string; chatId: string }): Promise<{
@@ -202,6 +202,40 @@ export class CollaborationChatScopeService {
         .returningAll()
         .executeTakeFirst();
       if (!activated) throw new CollaborationChatScopeError("conflict", "Chat scope state changed");
+      const eventId = randomUUID();
+      await trx.insertInto("collaboration_events").values({
+        scope_id: scope.id,
+        scope_seq: 1,
+        event_id: eventId,
+        resource_kind: "chat",
+        resource_id: input.chatId,
+        revision: 1,
+        authority_generation: 1,
+        event_type: "scope.shared",
+        payload: jsonb({}),
+        created_at: now,
+      }).execute();
+      await trx.insertInto("collaboration_audit").values({
+        scope_id: scope.id,
+        actor_id: input.ownerId,
+        action: "scope.shared",
+        outcome: "completed",
+        revision: 1,
+        reason_code: null,
+        created_at: now,
+      }).execute();
+      await trx.insertInto("collaboration_directory_outbox").values({
+        event_id: eventId,
+        scope_id: scope.id,
+        recipient_actor_ids: jsonb([input.ownerId]),
+        authority_runtime_id: this.options.runtimeId,
+        authority_generation: 1,
+        resource_kind: "chat",
+        discovery_state: "accepted",
+        retry_after: now,
+        delivered_at: null,
+        created_at: now,
+      }).execute();
       return scopeRecord(activated);
     });
   }

--- a/packages/gateway/src/collaboration/chat-scope.ts
+++ b/packages/gateway/src/collaboration/chat-scope.ts
@@ -91,7 +91,6 @@ export class CollaborationChatScopeService {
     expectedChatRevision: number;
     confirmationToken: string;
   }): Promise<CollaborationScopeRecord> {
-    this.verifyConfirmation(input);
     const now = this.now().toISOString();
     return this.db.transaction().execute(async (trx) => {
       const chat = await trx.selectFrom("chats")
@@ -110,6 +109,7 @@ export class CollaborationChatScopeService {
           && existing.lifecycle === "shared") return scopeRecord(existing);
         throw new CollaborationChatScopeError("conflict", "Chat collaboration binding is invalid");
       }
+      this.verifyConfirmation(input);
       if (Number(chat.revision) !== input.expectedChatRevision) {
         throw new CollaborationChatScopeError("conflict", "Chat revision changed");
       }

--- a/packages/gateway/src/collaboration/directory-outbox.ts
+++ b/packages/gateway/src/collaboration/directory-outbox.ts
@@ -162,6 +162,22 @@ export class CollaborationDirectoryOutbox {
           .returning("event_id")
           .executeTakeFirst();
         if (!updated) continue;
+        let recipientActorIds: string[];
+        try {
+          recipientActorIds = parseActorIds(row.recipient_actor_ids);
+        } catch (error: unknown) {
+          console.warn(
+            "[collaboration-directory] quarantined malformed outbox event",
+            error instanceof Error ? error.name : "UnknownError",
+          );
+          await trx.updateTable("collaboration_directory_outbox").set({
+            attempts: MAX_ATTEMPTS,
+          }).where("event_id", "=", row.event_id)
+            .where("attempts", "=", attempt)
+            .where("delivered_at", "is", null)
+            .execute();
+          continue;
+        }
         claimed.push({
           eventId: row.event_id,
           scopeId: row.scope_id,
@@ -169,7 +185,7 @@ export class CollaborationDirectoryOutbox {
           kind: row.resource_kind,
           authorityGeneration: Number(row.authority_generation),
           metadataRevision: Number(row.revision),
-          recipientActorIds: parseActorIds(row.recipient_actor_ids),
+          recipientActorIds,
           discoveryState: row.discovery_state,
           attempt,
         });

--- a/packages/gateway/src/collaboration/directory-outbox.ts
+++ b/packages/gateway/src/collaboration/directory-outbox.ts
@@ -1,6 +1,7 @@
 import { CollaborationDirectoryEventSchema } from "@matrix-os/contracts";
 import type { Kysely } from "kysely";
 import type { OwnerCollaborationDatabase } from "./database.js";
+import { requireSecureCollaborationPlatformBaseUrl } from "./platform-base-url.js";
 
 const BATCH_SIZE = 25;
 const MAX_ATTEMPTS = 20;
@@ -37,7 +38,7 @@ export class CollaborationDirectoryOutbox {
     now?: () => Date;
     startTimer?: boolean;
   }) {
-    const baseUrl = requireBaseUrl(options.platformBaseUrl);
+    const baseUrl = requireSecureCollaborationPlatformBaseUrl(options.platformBaseUrl);
     if (Buffer.byteLength(options.serviceToken) < 32) {
       throw new Error("Collaboration directory service token is unavailable");
     }
@@ -204,20 +205,4 @@ function parseActorIds(value: unknown): string[] {
 
 function backoffMs(attempt: number): number {
   return Math.min(MAX_BACKOFF_MS, 1_000 * (2 ** Math.min(attempt - 1, 6)));
-}
-
-function requireBaseUrl(value: string): URL {
-  try {
-    const url = new URL(value);
-    if (!url.hostname || !["https:", "http:"].includes(url.protocol)
-      || url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
-      throw new Error("invalid base URL");
-    }
-    return url;
-  } catch (error: unknown) {
-    if (!(error instanceof TypeError || error instanceof Error)) {
-      console.warn("[collaboration-directory] URL parse failed", "UnknownError");
-    }
-    throw new Error("Collaboration platform URL is unavailable");
-  }
 }

--- a/packages/gateway/src/collaboration/directory-outbox.ts
+++ b/packages/gateway/src/collaboration/directory-outbox.ts
@@ -1,0 +1,207 @@
+import { CollaborationDirectoryEventSchema } from "@matrix-os/contracts";
+import type { Kysely } from "kysely";
+import type { OwnerCollaborationDatabase } from "./database.js";
+
+const BATCH_SIZE = 25;
+const MAX_ATTEMPTS = 20;
+const POLL_INTERVAL_MS = 1_000;
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_BACKOFF_MS = 60_000;
+
+interface ClaimedDirectoryEvent {
+  eventId: string;
+  scopeId: string;
+  ownerId: string;
+  kind: "chat" | "terminal" | "project";
+  authorityGeneration: number;
+  metadataRevision: number;
+  recipientActorIds: string[];
+  discoveryState: "invited" | "accepted" | "revoked" | "deleted";
+  attempt: number;
+}
+
+export class CollaborationDirectoryOutbox {
+  private readonly now: () => Date;
+  private readonly fetchImpl: typeof fetch;
+  private readonly endpoint: string;
+  private timer?: ReturnType<typeof setInterval>;
+  private active?: Promise<number>;
+  private closing = false;
+
+  constructor(private readonly options: {
+    db: Kysely<OwnerCollaborationDatabase>;
+    platformBaseUrl: string;
+    runtimeId: string;
+    serviceToken: string;
+    fetchImpl?: typeof fetch;
+    now?: () => Date;
+    startTimer?: boolean;
+  }) {
+    const baseUrl = requireBaseUrl(options.platformBaseUrl);
+    if (Buffer.byteLength(options.serviceToken) < 32) {
+      throw new Error("Collaboration directory service token is unavailable");
+    }
+    this.endpoint = `${baseUrl.origin}/internal/collaboration/directory`;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.now = options.now ?? (() => new Date());
+    if (options.startTimer !== false) {
+      this.timer = setInterval(() => {
+        void this.runOnce().catch((error: unknown) => {
+          console.warn("[collaboration-directory] delivery cycle failed", error instanceof Error ? error.name : "UnknownError");
+        });
+      }, POLL_INTERVAL_MS);
+      this.timer.unref?.();
+    }
+  }
+
+  async runOnce(): Promise<number> {
+    if (this.closing) return 0;
+    if (this.active) return this.active;
+    const active = this.deliverBatch();
+    this.active = active;
+    try {
+      return await active;
+    } finally {
+      if (this.active === active) this.active = undefined;
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.closing) return;
+    this.closing = true;
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+    if (this.active) await this.active;
+  }
+
+  private async deliverBatch(): Promise<number> {
+    const claimed = await this.claimBatch();
+    let delivered = 0;
+    for (const event of claimed) {
+      const payload = CollaborationDirectoryEventSchema.parse({
+        eventId: event.eventId,
+        scopeId: event.scopeId,
+        runtimeId: this.options.runtimeId,
+        ownerId: event.ownerId,
+        kind: event.kind,
+        authorityGeneration: event.authorityGeneration,
+        metadataRevision: event.metadataRevision,
+        recipients: event.recipientActorIds.map((actorId) => ({
+          actorId,
+          status: event.discoveryState === "deleted" ? "revoked" : event.discoveryState,
+        })),
+      });
+      try {
+        const response = await this.fetchImpl(this.endpoint, {
+          method: "PUT",
+          redirect: "error",
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          headers: {
+            accept: "application/json",
+            authorization: `Bearer ${this.options.serviceToken}`,
+            "content-type": "application/json",
+            "x-matrix-runtime-id": this.options.runtimeId,
+          },
+          body: JSON.stringify(payload),
+        });
+        await response.body?.cancel();
+        if (!response.ok) {
+          console.warn("[collaboration-directory] platform rejected event", response.status);
+          continue;
+        }
+        const result = await this.options.db.updateTable("collaboration_directory_outbox").set({
+          delivered_at: this.now().toISOString(),
+        }).where("event_id", "=", event.eventId)
+          .where("attempts", "=", event.attempt)
+          .where("delivered_at", "is", null)
+          .returning("event_id")
+          .executeTakeFirst();
+        if (result) delivered += 1;
+      } catch (error: unknown) {
+        console.warn("[collaboration-directory] platform unavailable", error instanceof Error ? error.name : "UnknownError");
+      }
+    }
+    return delivered;
+  }
+
+  private async claimBatch(): Promise<ClaimedDirectoryEvent[]> {
+    const now = this.now();
+    return this.options.db.transaction().execute(async (trx) => {
+      const rows = await trx.selectFrom("collaboration_directory_outbox as outbox")
+        .innerJoin("collaboration_scopes as scope", "scope.id", "outbox.scope_id")
+        .innerJoin("collaboration_events as event", "event.event_id", "outbox.event_id")
+        .select([
+          "outbox.event_id",
+          "outbox.scope_id",
+          "outbox.recipient_actor_ids",
+          "outbox.authority_generation",
+          "outbox.resource_kind",
+          "outbox.discovery_state",
+          "outbox.attempts",
+          "scope.owner_id",
+          "event.revision",
+        ])
+        .where("outbox.authority_runtime_id", "=", this.options.runtimeId)
+        .where("outbox.delivered_at", "is", null)
+        .where("outbox.retry_after", "<=", now.toISOString())
+        .where("outbox.attempts", "<", MAX_ATTEMPTS)
+        .orderBy("outbox.created_at", "asc")
+        .limit(BATCH_SIZE)
+        .forUpdate("outbox")
+        .skipLocked()
+        .execute();
+      const claimed: ClaimedDirectoryEvent[] = [];
+      for (const row of rows) {
+        const attempt = Number(row.attempts) + 1;
+        const updated = await trx.updateTable("collaboration_directory_outbox").set({
+          attempts: attempt,
+          retry_after: new Date(now.getTime() + backoffMs(attempt)).toISOString(),
+        }).where("event_id", "=", row.event_id)
+          .where("attempts", "=", Number(row.attempts))
+          .where("delivered_at", "is", null)
+          .returning("event_id")
+          .executeTakeFirst();
+        if (!updated) continue;
+        claimed.push({
+          eventId: row.event_id,
+          scopeId: row.scope_id,
+          ownerId: row.owner_id,
+          kind: row.resource_kind,
+          authorityGeneration: Number(row.authority_generation),
+          metadataRevision: Number(row.revision),
+          recipientActorIds: parseActorIds(row.recipient_actor_ids),
+          discoveryState: row.discovery_state,
+          attempt,
+        });
+      }
+      return claimed;
+    });
+  }
+}
+
+function parseActorIds(value: unknown): string[] {
+  const parsed = typeof value === "string" ? JSON.parse(value) as unknown : value;
+  return CollaborationDirectoryEventSchema.shape.recipients
+    .parse((Array.isArray(parsed) ? parsed : []).map((actorId) => ({ actorId, status: "accepted" })))
+    .map(({ actorId }) => actorId);
+}
+
+function backoffMs(attempt: number): number {
+  return Math.min(MAX_BACKOFF_MS, 1_000 * (2 ** Math.min(attempt - 1, 6)));
+}
+
+function requireBaseUrl(value: string): URL {
+  try {
+    const url = new URL(value);
+    if (!url.hostname || !["https:", "http:"].includes(url.protocol)
+      || url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
+      throw new Error("invalid base URL");
+    }
+    return url;
+  } catch (error: unknown) {
+    if (!(error instanceof TypeError || error instanceof Error)) {
+      console.warn("[collaboration-directory] URL parse failed", "UnknownError");
+    }
+    throw new Error("Collaboration platform URL is unavailable");
+  }
+}

--- a/packages/gateway/src/collaboration/event-websocket-route.ts
+++ b/packages/gateway/src/collaboration/event-websocket-route.ts
@@ -1,0 +1,168 @@
+import {
+  CollaborationClientFrameSchema,
+  CollaborationIdSchema,
+  CollaborationRevisionSchema,
+} from "@matrix-os/contracts";
+import { randomUUID } from "node:crypto";
+import type { Context, Hono } from "hono";
+import type { UpgradeWebSocket } from "hono/ws";
+import { z } from "zod/v4";
+import type { CollaborationActorProofVerifier } from "./actor-proof.js";
+import type { CollaborationAuthority } from "./authority.js";
+import type { CollaborationEventRegistry } from "./events.js";
+
+const PROOF_HEADER = "x-matrix-collaboration-proof";
+const MAX_FRAME_BYTES = 64 * 1024;
+const MAX_PENDING_FRAMES = 8;
+const EventQuerySchema = z.object({ after: CollaborationRevisionSchema.default("0") }).strict();
+
+type EventSession = Awaited<ReturnType<CollaborationEventRegistry["open"]>>;
+
+export function registerCollaborationEventWebSocketRoute(options: {
+  app: Hono;
+  upgradeWebSocket: UpgradeWebSocket;
+  verifier: CollaborationActorProofVerifier;
+  authority: CollaborationAuthority;
+  registry: CollaborationEventRegistry;
+  createConnectionId?: () => string;
+}): void {
+  const createConnectionId = options.createConnectionId ?? randomUUID;
+  options.app.get(
+    "/ws/collaboration/scopes/:scopeId/events",
+    options.upgradeWebSocket((context) => {
+      const scopeId = CollaborationIdSchema.parse(context.req.param("scopeId"));
+      const query = parseQuery(context);
+      let session: EventSession | null = null;
+      let socketClosed = false;
+      let processing = Promise.resolve();
+      const pendingFrames: string[] = [];
+
+      const processFrame = (raw: string, ws: { send(value: string): void; close(code?: number, reason?: string): void }) => {
+        processing = processing.then(async () => {
+          const frame = CollaborationClientFrameSchema.parse(JSON.parse(raw) as unknown);
+          if (!session) return;
+          if (frame.type === "heartbeat") {
+            session.touch();
+            return;
+          }
+          if (frame.scopeId !== scopeId) throw new Error("scope mismatch");
+          await session.resume(Number(frame.sequence), Number(frame.authorityGeneration));
+        }).catch((error: unknown) => {
+          console.warn("[collaboration-events] client frame rejected", error instanceof Error ? error.name : "UnknownError");
+          sendSetupError(ws);
+          ws.close(1008, "Invalid frame");
+        });
+      };
+
+      return {
+        onOpen(_event, ws) {
+          void (async () => {
+            const signedProof = decodeProof(context);
+            const proof = await options.verifier.verifySocket({
+              signedProof,
+              purpose: "events",
+              path: context.req.path,
+              query: rawQuery(context),
+            });
+            if (proof.scopeId !== scopeId) throw new Error("scope mismatch");
+            const authorized = await options.authority.authorize({
+              scopeId,
+              actorId: proof.actorId,
+              action: "read",
+            });
+            if (authorized.ownerId !== proof.ownerId
+              || authorized.authorityRuntimeId !== proof.runtimeId) throw new Error("authority mismatch");
+            const opened = await options.registry.open({
+              connectionId: createConnectionId(),
+              scopeId,
+              actorId: proof.actorId,
+              authorityGeneration: authorized.authorityGeneration,
+              afterSequence: Number(query.after),
+              socket: ws,
+            });
+            if (socketClosed) {
+              opened.close();
+              return;
+            }
+            session = opened;
+            for (const frame of pendingFrames.splice(0)) processFrame(frame, ws);
+          })().catch((error: unknown) => {
+            console.warn("[collaboration-events] socket setup failed", error instanceof Error ? error.name : "UnknownError");
+            pendingFrames.splice(0);
+            if (socketClosed) return;
+            sendSetupError(ws);
+            ws.close(1008, "Unavailable");
+          });
+        },
+        onMessage(event, ws) {
+          const raw = frameText(event.data);
+          if (raw === null) {
+            sendSetupError(ws);
+            ws.close(1008, "Invalid frame");
+            return;
+          }
+          if (session) {
+            processFrame(raw, ws);
+            return;
+          }
+          if (pendingFrames.length >= MAX_PENDING_FRAMES) {
+            sendSetupError(ws);
+            ws.close(1008, "Invalid frame");
+            return;
+          }
+          pendingFrames.push(raw);
+        },
+        onClose() {
+          socketClosed = true;
+          pendingFrames.splice(0);
+          session?.close();
+          session = null;
+        },
+      };
+    }),
+  );
+}
+
+function parseQuery(context: Context): z.infer<typeof EventQuerySchema> {
+  const params = new URL(context.req.url).searchParams;
+  const keys = [...params.keys()];
+  if (keys.some((key) => key !== "after") || keys.filter((key) => key === "after").length > 1) {
+    throw new SyntaxError("Invalid event cursor");
+  }
+  return EventQuerySchema.parse(Object.fromEntries(params.entries()));
+}
+
+function rawQuery(context: Context): string {
+  return new URL(context.req.url).search.slice(1);
+}
+
+function decodeProof(context: Context): unknown {
+  const value = context.req.header(PROOF_HEADER);
+  if (!value || value.length > 8_192 || !/^[A-Za-z0-9_-]+$/.test(value)) {
+    throw new Error("invalid proof");
+  }
+  return JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as unknown;
+}
+
+function frameText(value: unknown): string | null {
+  if (typeof value === "string") {
+    return Buffer.byteLength(value) <= MAX_FRAME_BYTES ? value : null;
+  }
+  if (value instanceof ArrayBuffer) {
+    return value.byteLength <= MAX_FRAME_BYTES ? new TextDecoder().decode(value) : null;
+  }
+  if (ArrayBuffer.isView(value)) {
+    return value.byteLength <= MAX_FRAME_BYTES
+      ? new TextDecoder().decode(new Uint8Array(value.buffer, value.byteOffset, value.byteLength))
+      : null;
+  }
+  return null;
+}
+
+function sendSetupError(ws: { send(value: string): void }): void {
+  try {
+    ws.send(JSON.stringify({ version: 1, type: "collaboration.error", code: "unavailable" }));
+  } catch (error: unknown) {
+    console.warn("[collaboration-events] socket error send failed", error instanceof Error ? error.name : "UnknownError");
+  }
+}

--- a/packages/gateway/src/collaboration/events.ts
+++ b/packages/gateway/src/collaboration/events.ts
@@ -33,6 +33,7 @@ interface Connection {
   lastSequence: number;
   lastTouchedAt: number;
   socket: CollaborationEventSocket;
+  delivery: Promise<void>;
 }
 
 export class CollaborationEventRegistry {
@@ -68,12 +69,13 @@ export class CollaborationEventRegistry {
     authorityGeneration: number;
     afterSequence?: number;
     socket: CollaborationEventSocket;
-  }): Promise<{ sequence: number; close(): void; touch(): void }> {
+  }): Promise<{ sequence: number; close(): void; touch(): void; resume(sequence: number, authorityGeneration: number): Promise<void> }> {
     if (this.closing) throw new CollaborationEventRegistryError("unavailable", "Event delivery is shutting down");
     const context = await this.options.authorize(input.scopeId, input.actorId);
     if (context.authorityGeneration !== input.authorityGeneration) {
       throw new CollaborationEventRegistryError("unavailable", "Event authority changed");
     }
+    await this.requireValidCursor(input.scopeId, input.afterSequence ?? 0);
     this.requireCapacity(input.scopeId, input.actorId, input.connectionId);
     const existing = this.connections.get(input.connectionId);
     if (existing) this.remove(existing.connectionId, 1000, "Replaced");
@@ -87,17 +89,20 @@ export class CollaborationEventRegistry {
       lastSequence: input.afterSequence ?? 0,
       lastTouchedAt: this.now().getTime(),
       socket: input.socket,
+      delivery: Promise.resolve(),
     };
     this.connections.set(connection.connectionId, connection);
     try {
-      await this.sendReplay(connection);
-      this.send(connection, {
-        version: 1,
-        type: "ready",
-        scopeId: connection.scopeId,
-        resourceId: connection.resourceId,
-        authorityGeneration: String(connection.authorityGeneration),
-        sequence: String(connection.lastSequence),
+      await this.enqueueDelivery(connection, async () => {
+        await this.sendReplay(connection);
+        this.send(connection, {
+          version: 1,
+          type: "ready",
+          scopeId: connection.scopeId,
+          resourceId: connection.resourceId,
+          authorityGeneration: String(connection.authorityGeneration),
+          sequence: String(connection.lastSequence),
+        });
       });
     } catch (error: unknown) {
       this.remove(connection.connectionId, 1011, "Unavailable");
@@ -110,6 +115,22 @@ export class CollaborationEventRegistry {
         const current = this.connections.get(connection.connectionId);
         if (current) current.lastTouchedAt = this.now().getTime();
       },
+      resume: async (sequence, authorityGeneration) => {
+        const current = this.connections.get(connection.connectionId);
+        if (!current || authorityGeneration !== current.authorityGeneration) {
+          throw new CollaborationEventRegistryError("unavailable", "Event cursor is unavailable");
+        }
+        await this.enqueueDelivery(current, async () => {
+          const authorized = await this.options.authorize(current.scopeId, current.actorId);
+          if (authorized.authorityGeneration !== current.authorityGeneration) {
+            throw new CollaborationEventRegistryError("unavailable", "Event authority changed");
+          }
+          await this.requireValidCursor(current.scopeId, sequence);
+          current.lastSequence = Math.max(current.lastSequence, sequence);
+          current.lastTouchedAt = this.now().getTime();
+          await this.sendReplay(current);
+        });
+      },
     };
   }
 
@@ -118,9 +139,11 @@ export class CollaborationEventRegistry {
     const remove: string[] = [];
     for (const connection of targets) {
       try {
-        const context = await this.options.authorize(connection.scopeId, connection.actorId);
-        if (context.authorityGeneration !== connection.authorityGeneration) throw new Error("authority changed");
-        await this.sendReplay(connection);
+        await this.enqueueDelivery(connection, async () => {
+          const context = await this.options.authorize(connection.scopeId, connection.actorId);
+          if (context.authorityGeneration !== connection.authorityGeneration) throw new Error("authority changed");
+          await this.sendReplay(connection);
+        });
       } catch (error: unknown) {
         console.warn("[collaboration-events] subscriber unavailable", error instanceof Error ? error.name : "UnknownError");
         this.sendBestEffort(connection, {
@@ -220,6 +243,30 @@ export class CollaborationEventRegistry {
         revision: String(row.revision),
       });
       connection.lastSequence = Number(row.scope_seq);
+    }
+  }
+
+  private enqueueDelivery(connection: Connection, operation: () => Promise<void>): Promise<void> {
+    const active = connection.delivery.then(operation);
+    connection.delivery = active.catch((error: unknown) => {
+      console.warn(
+        "[collaboration-events] serialized delivery failed",
+        error instanceof Error ? error.name : "UnknownError",
+      );
+    });
+    return active;
+  }
+
+  private async requireValidCursor(scopeId: string, sequence: number): Promise<void> {
+    if (!Number.isSafeInteger(sequence) || sequence < 0) {
+      throw new CollaborationEventRegistryError("unavailable", "Event cursor is unavailable");
+    }
+    const row = await this.options.db.selectFrom("collaboration_events")
+      .select(({ fn }) => fn.max("scope_seq").as("sequence"))
+      .where("scope_id", "=", scopeId)
+      .executeTakeFirst();
+    if (sequence > Number(row?.sequence ?? 0)) {
+      throw new CollaborationEventRegistryError("unavailable", "Event cursor is unavailable");
     }
   }
 

--- a/packages/gateway/src/collaboration/participant-resolver.ts
+++ b/packages/gateway/src/collaboration/participant-resolver.ts
@@ -1,0 +1,153 @@
+import {
+  CollaborationActorIdSchema,
+  CollaborationParticipantSchema,
+  CollaborationRuntimeIdSchema,
+} from "@matrix-os/contracts";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 8 * 1024;
+const MAX_CACHE_ENTRIES = 512;
+const CACHE_TTL_MS = 5 * 60_000;
+
+interface CacheEntry {
+  participant: { actorId: string; displayName: string };
+  expiresAt: number;
+}
+
+export class CollaborationParticipantResolverError extends Error {
+  constructor() {
+    super("Participant identity is unavailable");
+    this.name = "CollaborationParticipantResolverError";
+  }
+}
+
+export class CollaborationParticipantResolver {
+  private readonly endpoint: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => Date;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(private readonly options: {
+    platformBaseUrl: string;
+    runtimeId: string;
+    serviceToken: string;
+    fetchImpl?: typeof fetch;
+    now?: () => Date;
+  }) {
+    const baseUrl = requireBaseUrl(options.platformBaseUrl);
+    CollaborationRuntimeIdSchema.parse(options.runtimeId);
+    if (Buffer.byteLength(options.serviceToken) < 32) {
+      throw new Error("Collaboration participant service token is unavailable");
+    }
+    this.endpoint = `${baseUrl.origin}/internal/collaboration/participants`;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async resolve(actorIdInput: string): Promise<{ actorId: string; displayName: string }> {
+    const actorId = CollaborationActorIdSchema.parse(actorIdInput);
+    const now = this.now().getTime();
+    const cached = this.cache.get(actorId);
+    if (cached && cached.expiresAt > now) {
+      this.cache.delete(actorId);
+      this.cache.set(actorId, cached);
+      return cached.participant;
+    }
+    if (cached) this.cache.delete(actorId);
+
+    try {
+      const response = await this.fetchImpl(`${this.endpoint}/${encodeURIComponent(actorId)}`, {
+        method: "GET",
+        redirect: "error",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${this.options.serviceToken}`,
+          "x-matrix-runtime-id": this.options.runtimeId,
+        },
+      });
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new CollaborationParticipantResolverError();
+      }
+      const bytes = await readBounded(response, MAX_RESPONSE_BYTES);
+      if (!bytes) throw new CollaborationParticipantResolverError();
+      let value: unknown;
+      try {
+        value = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+      } catch (error: unknown) {
+        if (!(error instanceof SyntaxError)) throw error;
+        throw new CollaborationParticipantResolverError();
+      }
+      const participant = CollaborationParticipantSchema.safeParse(value);
+      if (!participant.success || participant.data.actorId !== actorId) {
+        throw new CollaborationParticipantResolverError();
+      }
+      while (this.cache.size >= MAX_CACHE_ENTRIES) {
+        const oldest = this.cache.keys().next().value as string | undefined;
+        if (!oldest) break;
+        this.cache.delete(oldest);
+      }
+      const result = { actorId: participant.data.actorId, displayName: participant.data.displayName };
+      this.cache.set(actorId, { participant: result, expiresAt: now + CACHE_TTL_MS });
+      return result;
+    } catch (error: unknown) {
+      console.warn("[collaboration-participant] identity lookup failed", error instanceof Error ? error.name : "UnknownError");
+      if (error instanceof CollaborationParticipantResolverError) throw error;
+      throw new CollaborationParticipantResolverError();
+    }
+  }
+
+  shutdown(): void {
+    this.cache.clear();
+  }
+}
+
+async function readBounded(response: Response, maxBytes: number): Promise<Uint8Array | null> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    await response.body?.cancel();
+    return null;
+  }
+  if (!response.body) return new Uint8Array();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > maxBytes) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+    const output = new Uint8Array(size);
+    let offset = 0;
+    for (const chunk of chunks) {
+      output.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return output;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function requireBaseUrl(value: string): URL {
+  try {
+    const url = new URL(value);
+    if (!url.hostname || !["https:", "http:"].includes(url.protocol)
+      || url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
+      throw new Error("invalid base URL");
+    }
+    return url;
+  } catch (error: unknown) {
+    if (!(error instanceof TypeError || error instanceof Error)) {
+      console.warn("[collaboration-participant] URL parse failed", "UnknownError");
+    }
+    throw new Error("Collaboration platform URL is unavailable");
+  }
+}

--- a/packages/gateway/src/collaboration/participant-resolver.ts
+++ b/packages/gateway/src/collaboration/participant-resolver.ts
@@ -3,6 +3,7 @@ import {
   CollaborationParticipantSchema,
   CollaborationRuntimeIdSchema,
 } from "@matrix-os/contracts";
+import { requireSecureCollaborationPlatformBaseUrl } from "./platform-base-url.js";
 
 const REQUEST_TIMEOUT_MS = 10_000;
 const MAX_RESPONSE_BYTES = 8 * 1024;
@@ -34,7 +35,7 @@ export class CollaborationParticipantResolver {
     fetchImpl?: typeof fetch;
     now?: () => Date;
   }) {
-    const baseUrl = requireBaseUrl(options.platformBaseUrl);
+    const baseUrl = requireSecureCollaborationPlatformBaseUrl(options.platformBaseUrl);
     CollaborationRuntimeIdSchema.parse(options.runtimeId);
     if (Buffer.byteLength(options.serviceToken) < 32) {
       throw new Error("Collaboration participant service token is unavailable");
@@ -133,21 +134,5 @@ async function readBounded(response: Response, maxBytes: number): Promise<Uint8A
     return output;
   } finally {
     reader.releaseLock();
-  }
-}
-
-function requireBaseUrl(value: string): URL {
-  try {
-    const url = new URL(value);
-    if (!url.hostname || !["https:", "http:"].includes(url.protocol)
-      || url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
-      throw new Error("invalid base URL");
-    }
-    return url;
-  } catch (error: unknown) {
-    if (!(error instanceof TypeError || error instanceof Error)) {
-      console.warn("[collaboration-participant] URL parse failed", "UnknownError");
-    }
-    throw new Error("Collaboration platform URL is unavailable");
   }
 }

--- a/packages/gateway/src/collaboration/platform-base-url.ts
+++ b/packages/gateway/src/collaboration/platform-base-url.ts
@@ -1,0 +1,20 @@
+const LOOPBACK_HOSTNAMES = ["127.0.0.1", "localhost", "[::1]"];
+
+export function requireSecureCollaborationPlatformBaseUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (error: unknown) {
+    if (!(error instanceof TypeError)) {
+      console.warn("[collaboration-platform] URL parse failed", "UnknownError");
+    }
+    throw new Error("Collaboration platform URL is unavailable");
+  }
+  const transportIsSecure = url.protocol === "https:"
+    || (url.protocol === "http:" && LOOPBACK_HOSTNAMES.includes(url.hostname));
+  if (!url.hostname || !transportIsSecure || url.username || url.password
+    || url.pathname !== "/" || url.search || url.hash) {
+    throw new Error("Collaboration platform URL is unavailable");
+  }
+  return url;
+}

--- a/packages/gateway/src/collaboration/repository.ts
+++ b/packages/gateway/src/collaboration/repository.ts
@@ -100,6 +100,16 @@ export interface ChangeMemberRoleInput extends MemberMutationInput {
   role: "editor" | "viewer";
 }
 
+export interface RevokeInvitationInput {
+  scopeId: string;
+  invitationId: string;
+  actorId: string;
+  clientRequestId: string;
+  expectedRevision: number;
+  expectedMemberRevision: number;
+  payloadHash: string;
+}
+
 export interface InvitationMutationResult {
   invitationId: string;
   scopeId: string;
@@ -211,6 +221,14 @@ export class CollaborationRepository {
       .selectAll()
       .where("scope_id", "=", scopeId)
       .where("actor_id", "=", actorId)
+      .executeTakeFirst();
+    return row ? toMember(row) : null;
+  }
+
+  async getInvitation(invitationId: string): Promise<CollaborationMemberRecord | null> {
+    const row = await this.db.selectFrom("collaboration_members")
+      .selectAll()
+      .where("invitation_id", "=", invitationId)
       .executeTakeFirst();
     return row ? toMember(row) : null;
   }
@@ -425,6 +443,111 @@ export class CollaborationRepository {
       throw new CollaborationRepositoryError("expired", "Invitation expired");
     }
     return result.value;
+  }
+
+  async revokeInvitation(input: RevokeInvitationInput): Promise<MemberMutationResult> {
+    const nowDate = this.now();
+    const now = nowDate.toISOString();
+    const operationExpiresAt = new Date(nowDate.getTime() + OPERATION_RETENTION_MS).toISOString();
+    return this.db.transaction().execute(async (trx) => {
+      const scope = await lockDirectScope(trx, input.scopeId);
+      await requireAcceptedOwner(trx, input.scopeId, input.actorId);
+      const replay = await readOperationReplay<MemberMutationResult>(trx, input, "invitation.revoked");
+      if (replay) return replay;
+      if (Number(scope.revision) !== input.expectedRevision) {
+        throw new CollaborationRepositoryError("conflict", "Scope revision changed");
+      }
+      const member = await trx.selectFrom("collaboration_members")
+        .selectAll()
+        .where("scope_id", "=", input.scopeId)
+        .where("invitation_id", "=", input.invitationId)
+        .forUpdate()
+        .executeTakeFirst();
+      if (!member) throw new CollaborationRepositoryError("not_found", "Invitation not found");
+      if (member.status !== "pending" || Number(member.revision) !== input.expectedMemberRevision) {
+        throw new CollaborationRepositoryError("conflict", "Invitation state changed");
+      }
+      const memberRevision = input.expectedMemberRevision + 1;
+      const updated = await trx.updateTable("collaboration_members").set({
+        status: "revoked",
+        revision: memberRevision,
+        updated_at: now,
+      }).where("scope_id", "=", input.scopeId)
+        .where("actor_id", "=", member.actor_id)
+        .where("status", "=", "pending")
+        .where("revision", "=", input.expectedMemberRevision)
+        .returning("actor_id")
+        .executeTakeFirst();
+      if (!updated) throw new CollaborationRepositoryError("conflict", "Invitation state changed");
+      const nextRevision = input.expectedRevision + 1;
+      await updateScopeRevision(trx, input.scopeId, input.expectedRevision, nextRevision, now);
+      const result: MemberMutationResult = {
+        scopeId: input.scopeId,
+        actorId: member.actor_id,
+        role: member.role as "editor" | "viewer",
+        status: "revoked",
+        scopeRevision: nextRevision,
+        memberRevision,
+      };
+      await writeOperation(trx, input, "invitation.revoked", scope, result, now, operationExpiresAt);
+      await appendMutationRecords(trx, {
+        scope: { ...scope, revision: nextRevision, auth_epoch: Number(scope.auth_epoch) + 1 },
+        actorId: input.actorId,
+        action: "invitation.revoked",
+        recipients: [member.actor_id],
+        discoveryState: "revoked",
+        now,
+      });
+      return result;
+    });
+  }
+
+  async getChatUserState(chatId: string, actorId: string): Promise<{
+    readThroughSeq: number;
+    pinned: boolean;
+    muted: boolean;
+    lastOpenedAt?: string;
+  }> {
+    const row = await this.db.selectFrom("chat_user_state")
+      .select(["read_through_seq", "pinned", "muted", "last_opened_at"])
+      .where("chat_id", "=", chatId)
+      .where("principal_id", "=", actorId)
+      .executeTakeFirst();
+    return row ? {
+      readThroughSeq: Number(row.read_through_seq),
+      pinned: row.pinned,
+      muted: row.muted,
+      ...(row.last_opened_at === null ? {} : { lastOpenedAt: toIso(row.last_opened_at) }),
+    } : { readThroughSeq: 0, pinned: false, muted: false };
+  }
+
+  async updateChatUserState(input: {
+    chatId: string;
+    actorId: string;
+    readThroughSeq?: number;
+    pinned?: boolean;
+    muted?: boolean;
+    openedAt?: string;
+  }): Promise<void> {
+    const now = this.now().toISOString();
+    await this.db.insertInto("chat_user_state").values({
+      chat_id: input.chatId,
+      principal_id: input.actorId,
+      read_through_seq: input.readThroughSeq ?? 0,
+      pinned: input.pinned ?? false,
+      muted: input.muted ?? false,
+      attention_acknowledged_at: null,
+      last_opened_at: input.openedAt ?? null,
+      updated_at: now,
+    }).onConflict((conflict) => conflict.columns(["chat_id", "principal_id"]).doUpdateSet({
+      ...(input.readThroughSeq === undefined ? {} : {
+        read_through_seq: sql<number>`GREATEST(chat_user_state.read_through_seq, ${input.readThroughSeq})`,
+      }),
+      ...(input.pinned === undefined ? {} : { pinned: input.pinned }),
+      ...(input.muted === undefined ? {} : { muted: input.muted }),
+      ...(input.openedAt === undefined ? {} : { last_opened_at: input.openedAt }),
+      updated_at: now,
+    })).execute();
   }
 
   async changeMemberRole(input: ChangeMemberRoleInput): Promise<MemberMutationResult> {

--- a/packages/gateway/src/collaboration/routes.ts
+++ b/packages/gateway/src/collaboration/routes.ts
@@ -1,0 +1,517 @@
+import { createHash } from "node:crypto";
+import {
+  COLLABORATION_HTTP_BODY_LIMIT,
+  CollaborationAcceptInvitationRequestSchema,
+  CollaborationActorIdSchema,
+  CollaborationCreateDiscussionRequestSchema,
+  CollaborationCreateInvitationRequestSchema,
+  CollaborationCreateScopeRequestSchema,
+  CollaborationIdSchema,
+  CollaborationInvitationSchema,
+  CollaborationMemberPatchRequestSchema,
+  CollaborationMemberSchema,
+  CollaborationRevisionSchema,
+  CollaborationRevokeRequestSchema,
+  CollaborationRuntimeIdSchema,
+  CollaborationScopePreflightRequestSchema,
+  CollaborationScopePreflightResponseSchema,
+  CollaborationScopeSchema,
+  CollaborationUserStatePatchSchema,
+  CollaborationUserStateSchema,
+} from "@matrix-os/contracts";
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import { CollaborationActorProofError, type CollaborationActorProofVerifier } from "./actor-proof.js";
+import {
+  CollaborationAuthorizationError,
+  type AuthorizedCollaborationContext,
+  type CollaborationAction,
+  type CollaborationAuthority,
+} from "./authority.js";
+import type { CollaborationChatAdapter } from "./chat-adapter.js";
+import { CollaborationChatScopeError, type CollaborationChatScopeService } from "./chat-scope.js";
+import {
+  CollaborationRepositoryError,
+  type CollaborationMemberRecord,
+  type CollaborationRepository,
+  type CollaborationScopeRecord,
+} from "./repository.js";
+
+const PROOF_HEADER = "x-matrix-collaboration-proof";
+const INVITATION_LIFETIME_MS = 7 * 24 * 60 * 60 * 1_000;
+const MessageQuerySchema = z.object({
+  after: CollaborationRevisionSchema.default("0"),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+}).strict();
+
+type Participant = { actorId: string; displayName: string };
+
+export function createCollaborationRoutes(options: {
+  runtimeId: string;
+  verifier: CollaborationActorProofVerifier;
+  authority: CollaborationAuthority;
+  repository: CollaborationRepository;
+  chatScope: CollaborationChatScopeService;
+  chatAdapter: CollaborationChatAdapter;
+  resolveParticipant(actorId: string): Promise<Participant>;
+  onScopeCommitted?(scopeId: string): Promise<void>;
+  onRevoked?(scopeId: string, actorId: string): void;
+  now?: () => Date;
+}): Hono {
+  const routes = new Hono();
+  const now = options.now ?? (() => new Date());
+  const mutationLimit = bodyLimit({
+    maxSize: COLLABORATION_HTTP_BODY_LIMIT,
+    onError: (c) => c.json({ error: "Collaboration request too large", code: "invalid_request" }, 413),
+  });
+  routes.use("/api/collaboration/*", async (c, next) => {
+    c.header("Cache-Control", "private, no-store");
+    await next();
+  });
+  routes.on(["POST", "PATCH", "DELETE"], "/api/collaboration/*", mutationLimit);
+
+  routes.post("/api/collaboration/runtimes/:runtimeId/scopes/preflight", async (c) => handle(c, async () => {
+    const { value, bytes } = await readJson(c);
+    const proof = await verifyHttp(options.verifier, c, bytes);
+    requireOwnerCreationProof(proof, CollaborationRuntimeIdSchema.parse(c.req.param("runtimeId")), options.runtimeId);
+    const input = CollaborationScopePreflightRequestSchema.parse(value);
+    if (input.kind !== "chat") return c.json(CollaborationScopePreflightResponseSchema.parse({
+      eligible: false,
+      reason: "unsupported",
+      resourceRevision: "0",
+    }));
+    const result = await options.chatScope.preflight({ ownerId: proof.ownerId, chatId: input.resourceId });
+    return c.json(CollaborationScopePreflightResponseSchema.parse({
+      eligible: result.eligible,
+      ...(result.reason ? { reason: result.reason } : {}),
+      resourceRevision: String(result.chatRevision),
+      ...(result.confirmationToken ? { confirmationToken: result.confirmationToken } : {}),
+    }));
+  }));
+
+  routes.post("/api/collaboration/runtimes/:runtimeId/scopes", async (c) => handle(c, async () => {
+    const { value, bytes } = await readJson(c);
+    const proof = await verifyHttp(options.verifier, c, bytes);
+    requireOwnerCreationProof(proof, CollaborationRuntimeIdSchema.parse(c.req.param("runtimeId")), options.runtimeId);
+    const input = CollaborationCreateScopeRequestSchema.parse(value);
+    if (input.kind !== "chat") throw new CollaborationAuthorizationError("unavailable", "Scope kind is unavailable");
+    const scope = await options.chatScope.shareChat({
+      ownerId: proof.ownerId,
+      chatId: input.resourceId,
+      expectedChatRevision: Number(input.expectedRevision),
+      confirmationToken: input.confirmationToken,
+    });
+    const context = await options.authority.authorize({
+      scopeId: scope.id,
+      actorId: proof.actorId,
+      action: "read",
+    });
+    await notifyScope(options, scope.id);
+    return c.json(scopeProjection(scope, context), 201);
+  }));
+
+  routes.get("/api/collaboration/scopes/:scopeId", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const context = await authorize(options, c, new Uint8Array(), "read", scopeId);
+    const scope = await requireScope(options.repository, scopeId);
+    return c.json(scopeProjection(scope, context));
+  }));
+
+  routes.get("/api/collaboration/scopes/:scopeId/members", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const context = await authorize(options, c, new Uint8Array(), "read", scopeId);
+    const members = await options.repository.listMembers(context.membershipScopeId, {
+      includePending: context.role === "owner",
+    });
+    return c.json({ members: await Promise.all(members.map((member) => memberProjection(options, member))) });
+  }));
+
+  routes.post("/api/collaboration/scopes/:scopeId/invitations", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const { value, bytes } = await readJson(c);
+    const context = await authorize(options, c, bytes, "manage_members", scopeId);
+    const input = CollaborationCreateInvitationRequestSchema.parse(value);
+    await options.resolveParticipant(input.targetActorId);
+    const result = await options.repository.createInvitation({
+      scopeId,
+      actorId: context.actorId,
+      targetActorId: input.targetActorId,
+      role: input.role,
+      clientRequestId: input.clientRequestId,
+      expectedRevision: Number(input.expectedRevision),
+      payloadHash: digest(bytes),
+      expiresAt: new Date(now().getTime() + INVITATION_LIFETIME_MS).toISOString(),
+    });
+    const member = await requireInvitation(options.repository, result.invitationId);
+    await notifyScope(options, scopeId);
+    return c.json(await invitationProjection(options, member), 201);
+  }));
+
+  routes.get("/api/collaboration/invitations/:invitationId", async (c) => handle(c, async () => {
+    const invitationId = CollaborationIdSchema.parse(c.req.param("invitationId"));
+    const proof = await verifyHttp(options.verifier, c, new Uint8Array());
+    const member = await requireInvitation(options.repository, invitationId);
+    const scope = await requireScope(options.repository, member.scopeId);
+    if (proof.scopeId !== scope.id || proof.ownerId !== scope.ownerId
+      || ![member.actorId, member.invitedBy].includes(proof.actorId)) {
+      throw new CollaborationAuthorizationError("forbidden", "Invitation access is required");
+    }
+    return c.json(await invitationProjection(options, member));
+  }));
+
+  routes.post("/api/collaboration/invitations/:invitationId/accept", async (c) => handle(c, async () => {
+    const invitationId = CollaborationIdSchema.parse(c.req.param("invitationId"));
+    const { value, bytes } = await readJson(c);
+    const proof = await verifyHttp(options.verifier, c, bytes);
+    const input = CollaborationAcceptInvitationRequestSchema.parse(value);
+    const member = await requireInvitation(options.repository, invitationId);
+    if (proof.scopeId !== member.scopeId || proof.actorId !== member.actorId) {
+      throw new CollaborationAuthorizationError("forbidden", "Invitation access is required");
+    }
+    const result = await options.repository.acceptInvitation({
+      invitationId,
+      actorId: proof.actorId,
+      clientRequestId: input.clientRequestId,
+      expectedRevision: Number(input.expectedRevision),
+      payloadHash: digest(bytes),
+    });
+    await notifyScope(options, result.scopeId);
+    return c.json(result);
+  }));
+
+  routes.delete("/api/collaboration/scopes/:scopeId/invitations/:invitationId", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const invitationId = CollaborationIdSchema.parse(c.req.param("invitationId"));
+    const { value, bytes } = await readJson(c);
+    const context = await authorize(options, c, bytes, "manage_members", scopeId);
+    const input = CollaborationRevokeRequestSchema.parse(value);
+    const result = await options.repository.revokeInvitation({
+      scopeId,
+      invitationId,
+      actorId: context.actorId,
+      clientRequestId: input.clientRequestId,
+      expectedRevision: Number(input.expectedRevision),
+      expectedMemberRevision: Number(input.expectedMemberRevision),
+      payloadHash: digest(bytes),
+    });
+    options.onRevoked?.(scopeId, result.actorId);
+    await notifyScope(options, scopeId);
+    return c.json(result);
+  }));
+
+  routes.patch("/api/collaboration/scopes/:scopeId/members/:actorId", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const targetActorId = CollaborationActorIdSchema.parse(c.req.param("actorId"));
+    const { value, bytes } = await readJson(c);
+    const context = await authorize(options, c, bytes, "manage_members", scopeId);
+    const input = CollaborationMemberPatchRequestSchema.parse(value);
+    const result = await options.repository.changeMemberRole({
+      scopeId,
+      actorId: context.actorId,
+      targetActorId,
+      role: input.role,
+      clientRequestId: input.clientRequestId,
+      expectedRevision: Number(input.expectedRevision),
+      expectedMemberRevision: Number(input.expectedMemberRevision),
+      payloadHash: digest(bytes),
+    });
+    await notifyScope(options, scopeId);
+    return c.json(result);
+  }));
+
+  routes.delete("/api/collaboration/scopes/:scopeId/members/:actorId", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const targetActorId = CollaborationActorIdSchema.parse(c.req.param("actorId"));
+    const { value, bytes } = await readJson(c);
+    const input = CollaborationRevokeRequestSchema.parse(value);
+    const proof = await verifyHttp(options.verifier, c, bytes);
+    if (proof.scopeId !== scopeId) throw new CollaborationAuthorizationError("forbidden", "Member access is required");
+    const context = proof.actorId === targetActorId
+      ? await options.authority.authorize({ scopeId, actorId: proof.actorId, action: "read" })
+      : await options.authority.authorize({ scopeId, actorId: proof.actorId, action: "manage_members" });
+    const result = await options.repository.revokeMember({
+      scopeId,
+      actorId: context.actorId,
+      targetActorId,
+      clientRequestId: input.clientRequestId,
+      expectedRevision: Number(input.expectedRevision),
+      expectedMemberRevision: Number(input.expectedMemberRevision),
+      payloadHash: digest(bytes),
+    });
+    options.onRevoked?.(scopeId, result.actorId);
+    await notifyScope(options, scopeId);
+    return c.json(result);
+  }));
+
+  routes.get("/api/collaboration/scopes/:scopeId/user-state", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const context = await authorize(options, c, new Uint8Array(), "read", scopeId);
+    requireChatContext(context);
+    const state = await options.repository.getChatUserState(context.resourceId, context.actorId);
+    return c.json(CollaborationUserStateSchema.parse({
+      readThroughSeq: String(state.readThroughSeq),
+      pinned: state.pinned,
+      muted: state.muted,
+      ...(state.lastOpenedAt ? { lastOpenedAt: state.lastOpenedAt } : {}),
+    }));
+  }));
+
+  routes.patch("/api/collaboration/scopes/:scopeId/user-state", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const { value, bytes } = await readJson(c);
+    const context = await authorize(options, c, bytes, "read", scopeId);
+    requireChatContext(context);
+    const input = CollaborationUserStatePatchSchema.parse(value);
+    await options.repository.updateChatUserState({
+      chatId: context.resourceId,
+      actorId: context.actorId,
+      ...(input.readThroughSeq === undefined ? {} : { readThroughSeq: Number(input.readThroughSeq) }),
+      ...(input.pinned === undefined ? {} : { pinned: input.pinned }),
+      ...(input.muted === undefined ? {} : { muted: input.muted }),
+      openedAt: now().toISOString(),
+    });
+    const state = await options.repository.getChatUserState(context.resourceId, context.actorId);
+    return c.json(CollaborationUserStateSchema.parse({
+      readThroughSeq: String(state.readThroughSeq),
+      pinned: state.pinned,
+      muted: state.muted,
+      ...(state.lastOpenedAt ? { lastOpenedAt: state.lastOpenedAt } : {}),
+    }));
+  }));
+
+  routes.get("/api/collaboration/scopes/:scopeId/chat", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const context = await authorize(options, c, new Uint8Array(), "read", scopeId);
+    return c.json(await options.chatAdapter.getChat(context));
+  }));
+
+  routes.get("/api/collaboration/scopes/:scopeId/chat/messages", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const context = await authorize(options, c, new Uint8Array(), "read", scopeId);
+    const query = MessageQuerySchema.parse(exactQuery(c, ["after", "limit"]));
+    return c.json({
+      messages: await options.chatAdapter.listMessages(context, {
+        afterSequence: query.after,
+        limit: query.limit,
+      }),
+    });
+  }));
+
+  routes.post("/api/collaboration/scopes/:scopeId/chat/messages", async (c) => handle(c, async () => {
+    const scopeId = CollaborationIdSchema.parse(c.req.param("scopeId"));
+    const { value, bytes } = await readJson(c);
+    const context = await authorize(options, c, bytes, "discuss", scopeId);
+    const input = CollaborationCreateDiscussionRequestSchema.parse(value);
+    return c.json(await options.chatAdapter.appendDiscussion(context, input), 201);
+  }));
+
+  return routes;
+}
+
+async function authorize(
+  options: { verifier: CollaborationActorProofVerifier },
+  c: Context,
+  body: Uint8Array,
+  action: CollaborationAction,
+  scopeId: string,
+): Promise<AuthorizedCollaborationContext> {
+  const context = await options.verifier.verifyAndAuthorize({
+    signedProof: decodeProof(c),
+    method: method(c),
+    path: c.req.path,
+    query: rawQuery(c),
+    body,
+    action,
+  });
+  if (context.scopeId !== scopeId) throw new CollaborationAuthorizationError("forbidden", "Scope access is required");
+  return context;
+}
+
+async function verifyHttp(verifier: CollaborationActorProofVerifier, c: Context, body: Uint8Array) {
+  return verifier.verifyHttp({
+    signedProof: decodeProof(c),
+    method: method(c),
+    path: c.req.path,
+    query: rawQuery(c),
+    body,
+  });
+}
+
+function decodeProof(c: Context): unknown {
+  const encoded = c.req.header(PROOF_HEADER);
+  if (!encoded || encoded.length > 8_192 || !/^[A-Za-z0-9_-]+$/.test(encoded)) {
+    throw new CollaborationActorProofError("invalid_proof", "Collaboration proof is invalid");
+  }
+  try {
+    return JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  } catch (error: unknown) {
+    if (!(error instanceof SyntaxError)) {
+      console.warn("[collaboration-routes] proof decode failed", error instanceof Error ? error.name : "UnknownError");
+    }
+    throw new CollaborationActorProofError("invalid_proof", "Collaboration proof is invalid");
+  }
+}
+
+async function readJson(c: Context): Promise<{ value: unknown; bytes: Uint8Array }> {
+  const bytes = new Uint8Array(await c.req.arrayBuffer());
+  return { value: JSON.parse(new TextDecoder().decode(bytes)) as unknown, bytes };
+}
+
+function requireOwnerCreationProof(
+  proof: { actorId: string; ownerId: string; runtimeId: string; scopeId?: string },
+  requestedRuntimeId: string,
+  runtimeId: string,
+): void {
+  if (proof.actorId !== proof.ownerId || proof.runtimeId !== requestedRuntimeId
+    || requestedRuntimeId !== runtimeId || proof.scopeId !== undefined) {
+    throw new CollaborationAuthorizationError("forbidden", "Owner runtime access is required");
+  }
+}
+
+function scopeProjection(scope: CollaborationScopeRecord, context: AuthorizedCollaborationContext) {
+  return CollaborationScopeSchema.parse({
+    id: scope.id,
+    ownerId: scope.ownerId,
+    kind: scope.kind,
+    resourceId: scope.resourceId,
+    ...(scope.parentScopeId ? { parentScopeId: scope.parentScopeId } : {}),
+    membershipMode: scope.membershipMode,
+    lifecycle: scope.lifecycle,
+    revision: String(scope.revision),
+    authEpoch: String(context.authEpoch),
+    authorityGeneration: String(scope.authorityGeneration),
+    role: context.role,
+    capabilities: {
+      read: true,
+      discuss: context.role !== "viewer" && scope.lifecycle === "shared",
+      manageMembers: context.role === "owner" && scope.membershipMode === "direct",
+      requestAi: false,
+    },
+  });
+}
+
+async function memberProjection(
+  options: { resolveParticipant(actorId: string): Promise<Participant> },
+  member: CollaborationMemberRecord,
+) {
+  return CollaborationMemberSchema.parse({
+    actor: await options.resolveParticipant(member.actorId),
+    role: member.role,
+    status: member.status,
+    revision: String(member.revision),
+    ...(member.joinedAt ? { joinedAt: member.joinedAt } : {}),
+    updatedAt: member.updatedAt,
+  });
+}
+
+async function invitationProjection(
+  options: {
+    repository: CollaborationRepository;
+    resolveParticipant(actorId: string): Promise<Participant>;
+  },
+  member: CollaborationMemberRecord,
+) {
+  const scope = await requireScope(options.repository, member.scopeId);
+  if (!member.invitationId || !member.expiresAt || member.role === "owner") {
+    throw new CollaborationRepositoryError("not_found", "Invitation not found");
+  }
+  return CollaborationInvitationSchema.parse({
+    id: member.invitationId,
+    scopeId: member.scopeId,
+    owner: await options.resolveParticipant(scope.ownerId),
+    target: await options.resolveParticipant(member.actorId),
+    scopeKind: scope.kind,
+    role: member.role,
+    status: member.status,
+    expiresAt: member.expiresAt,
+    revision: String(member.revision),
+  });
+}
+
+async function requireScope(repository: CollaborationRepository, scopeId: string): Promise<CollaborationScopeRecord> {
+  const scope = await repository.getScope(scopeId);
+  if (!scope) throw new CollaborationRepositoryError("not_found", "Scope not found");
+  return scope;
+}
+
+async function requireInvitation(
+  repository: CollaborationRepository,
+  invitationId: string,
+): Promise<CollaborationMemberRecord> {
+  const invitation = await repository.getInvitation(invitationId);
+  if (!invitation) throw new CollaborationRepositoryError("not_found", "Invitation not found");
+  return invitation;
+}
+
+function requireChatContext(context: AuthorizedCollaborationContext): void {
+  if (context.resourceKind !== "chat") {
+    throw new CollaborationAuthorizationError("unavailable", "Chat scope is unavailable");
+  }
+}
+
+async function notifyScope(
+  options: { onScopeCommitted?(scopeId: string): Promise<void> },
+  scopeId: string,
+): Promise<void> {
+  if (!options.onScopeCommitted) return;
+  try {
+    await options.onScopeCommitted(scopeId);
+  } catch (error: unknown) {
+    console.warn("[collaboration-routes] committed event delivery failed", error instanceof Error ? error.name : "UnknownError");
+  }
+}
+
+function exactQuery(c: Context, allowed: readonly string[]): Record<string, string> {
+  const parameters = new URL(c.req.url).searchParams;
+  const output: Record<string, string> = {};
+  for (const key of parameters.keys()) {
+    if (!allowed.includes(key) || key in output) throw new SyntaxError("Invalid query");
+    output[key] = parameters.get(key)!;
+  }
+  return output;
+}
+
+function rawQuery(c: Context): string {
+  return new URL(c.req.url).search.slice(1);
+}
+
+function method(c: Context): "GET" | "POST" | "PUT" | "PATCH" | "DELETE" {
+  return c.req.method as "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+}
+
+function digest(value: Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function handle(c: Context, operation: () => Promise<Response>): Promise<Response> {
+  try {
+    return await operation();
+  } catch (error: unknown) {
+    if (error instanceof CollaborationActorProofError) {
+      return c.json({ error: "Collaboration authentication failed", code: "unauthorized" }, 401);
+    }
+    if (error instanceof z.ZodError || error instanceof SyntaxError) {
+      return c.json({ error: "Invalid collaboration request", code: "invalid_request" }, 400);
+    }
+    if (error instanceof CollaborationAuthorizationError) {
+      const status = error.code === "not_found" ? 404 : error.code === "forbidden" ? 403 : 503;
+      return c.json({ error: "Collaboration unavailable", code: error.code }, status);
+    }
+    if (error instanceof CollaborationChatScopeError) {
+      const status = error.code === "not_found" ? 404
+        : error.code === "active_work" || error.code === "conflict" || error.code === "invalid_confirmation" ? 409
+          : 503;
+      return c.json({ error: "Collaboration state changed", code: error.code }, status);
+    }
+    if (error instanceof CollaborationRepositoryError) {
+      const status = error.code === "not_found" ? 404
+        : error.code === "forbidden" ? 403
+          : error.code === "capacity" ? 429
+            : error.code === "expired" ? 410 : 409;
+      return c.json({ error: "Collaboration state changed", code: error.code }, status);
+    }
+    console.warn("[collaboration-routes] request failed", error instanceof Error ? error.name : "UnknownError");
+    return c.json({ error: "Collaboration unavailable", code: "unavailable" }, 503);
+  }
+}

--- a/packages/gateway/src/collaboration/routes.ts
+++ b/packages/gateway/src/collaboration/routes.ts
@@ -99,6 +99,8 @@ export function createCollaborationRoutes(options: {
     const scope = await options.chatScope.shareChat({
       ownerId: proof.ownerId,
       chatId: input.resourceId,
+      clientRequestId: input.clientRequestId,
+      payloadHash: digest(bytes),
       expectedChatRevision: Number(input.expectedRevision),
       confirmationToken: input.confirmationToken,
     });
@@ -263,10 +265,18 @@ export function createCollaborationRoutes(options: {
     const context = await authorize(options, c, bytes, "read", scopeId);
     requireChatContext(context);
     const input = CollaborationUserStatePatchSchema.parse(value);
+    const readThroughSeq = input.readThroughSeq === undefined ? undefined : Number(input.readThroughSeq);
+    if (readThroughSeq !== undefined) {
+      const latest = await options.repository.db.selectFrom("chat_messages")
+        .select(({ fn }) => fn.max("seq").as("sequence"))
+        .where("chat_id", "=", context.resourceId)
+        .executeTakeFirst();
+      z.number().int().safe().min(0).max(Number(latest?.sequence ?? 0)).parse(readThroughSeq);
+    }
     await options.repository.updateChatUserState({
       chatId: context.resourceId,
       actorId: context.actorId,
-      ...(input.readThroughSeq === undefined ? {} : { readThroughSeq: Number(input.readThroughSeq) }),
+      ...(readThroughSeq === undefined ? {} : { readThroughSeq }),
       ...(input.pinned === undefined ? {} : { pinned: input.pinned }),
       ...(input.muted === undefined ? {} : { muted: input.muted }),
       openedAt: now().toISOString(),

--- a/packages/gateway/src/collaboration/wiring.ts
+++ b/packages/gateway/src/collaboration/wiring.ts
@@ -1,0 +1,150 @@
+import type { Kysely } from "kysely";
+import type { Hono } from "hono";
+import type { UpgradeWebSocket } from "hono/ws";
+import { CollaborationActorProofVerifier } from "./actor-proof.js";
+import { CollaborationAuthority } from "./authority.js";
+import { CollaborationChatAdapter } from "./chat-adapter.js";
+import { CollaborationChatScopeService } from "./chat-scope.js";
+import { bootstrapCollaborationDatabase, type OwnerCollaborationDatabase } from "./database.js";
+import { CollaborationDirectoryOutbox } from "./directory-outbox.js";
+import { registerCollaborationEventWebSocketRoute } from "./event-websocket-route.js";
+import { CollaborationEventRegistry } from "./events.js";
+import { CollaborationParticipantResolver } from "./participant-resolver.js";
+import { CollaborationRepository } from "./repository.js";
+import { createCollaborationRoutes } from "./routes.js";
+
+const MAX_PROOF_KEYS = 8;
+
+export interface GatewayCollaborationConfig {
+  runtimeId: string;
+  activeKeyId: string;
+  proofKeys: Readonly<Record<string, string>>;
+  preflightSecret: string;
+  platformBaseUrl: string;
+  serviceToken: string;
+}
+
+export function loadGatewayCollaborationConfig(env: NodeJS.ProcessEnv): GatewayCollaborationConfig | null {
+  if (env.MATRIX_COLLABORATION_ENABLED !== "true") return null;
+  const runtimeId = env.MATRIX_RUNTIME_ID?.trim();
+  const activeKeyId = env.MATRIX_COLLABORATION_ACTIVE_KEY_ID?.trim();
+  const preflightSecret = env.MATRIX_COLLABORATION_PREFLIGHT_SECRET;
+  const platformBaseUrl = env.PLATFORM_INTERNAL_URL?.trim();
+  const serviceToken = env.UPGRADE_TOKEN;
+  if (!runtimeId || !activeKeyId || !preflightSecret || !platformBaseUrl || !serviceToken) return null;
+  let proofKeys: Record<string, string>;
+  try {
+    const parsed = JSON.parse(env.MATRIX_COLLABORATION_PROOF_KEYS ?? "null") as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    proofKeys = Object.fromEntries(Object.entries(parsed).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ));
+  } catch (error: unknown) {
+    if (!(error instanceof SyntaxError)) {
+      console.warn("[collaboration] proof key configuration parse failed", error instanceof Error ? error.name : "UnknownError");
+    }
+    return null;
+  }
+  const entries = Object.entries(proofKeys);
+  if (entries.length < 1 || entries.length > MAX_PROOF_KEYS
+    || entries.some(([keyId, key]) => !/^[A-Za-z0-9_.-]{1,80}$/.test(keyId) || Buffer.byteLength(key) < 32)
+    || !proofKeys[activeKeyId] || Buffer.byteLength(preflightSecret) < 32 || Buffer.byteLength(serviceToken) < 32) {
+    return null;
+  }
+  return { runtimeId, activeKeyId, proofKeys, preflightSecret, platformBaseUrl, serviceToken };
+}
+
+export async function createGatewayCollaboration(options: {
+  db: Kysely<OwnerCollaborationDatabase>;
+  config: GatewayCollaborationConfig;
+  resolveParticipant?(actorId: string): Promise<{ actorId: string; displayName: string }>;
+  outboxFetch?: typeof fetch;
+  startTimers?: boolean;
+}) {
+  await bootstrapCollaborationDatabase(options.db);
+  await options.db.deleteFrom("collaboration_operations")
+    .where("expires_at", "<=", new Date().toISOString())
+    .execute();
+  const repository = new CollaborationRepository(options.db);
+  const participantResolver = options.resolveParticipant ? undefined : new CollaborationParticipantResolver({
+    platformBaseUrl: options.config.platformBaseUrl,
+    runtimeId: options.config.runtimeId,
+    serviceToken: options.config.serviceToken,
+  });
+  const resolveParticipant = options.resolveParticipant
+    ?? ((actorId: string) => participantResolver!.resolve(actorId));
+  const authority = new CollaborationAuthority(repository);
+  const verifier = new CollaborationActorProofVerifier({
+    runtimeId: options.config.runtimeId,
+    keys: options.config.proofKeys,
+    authority,
+  });
+  const chatScope = new CollaborationChatScopeService(options.db, {
+    runtimeId: options.config.runtimeId,
+    preflightSecret: options.config.preflightSecret,
+  });
+  const outbox = new CollaborationDirectoryOutbox({
+    db: options.db,
+    platformBaseUrl: options.config.platformBaseUrl,
+    runtimeId: options.config.runtimeId,
+    serviceToken: options.config.serviceToken,
+    ...(options.outboxFetch ? { fetchImpl: options.outboxFetch } : {}),
+    startTimer: options.startTimers,
+  });
+  const eventRegistry = new CollaborationEventRegistry({
+    db: options.db,
+    authorize: (scopeId, actorId) => authority.authorize({ scopeId, actorId, action: "read" }),
+    startTimers: options.startTimers,
+  });
+  const chatAdapter = new CollaborationChatAdapter({
+    db: options.db,
+    authority,
+    resolveParticipant,
+    onCommitted: (scopeId) => eventRegistry.broadcastScope(scopeId),
+  });
+  let registered = false;
+  let closing = false;
+
+  return {
+    repository,
+    authority,
+    verifier,
+    eventRegistry,
+    chatScope,
+    chatAdapter,
+    outbox,
+    collaborationGuard: chatScope,
+    register(input: { app: Hono; upgradeWebSocket: UpgradeWebSocket }): void {
+      if (registered || closing) throw new Error("Collaboration routes are already registered or shutting down");
+      registered = true;
+      input.app.route("/", createCollaborationRoutes({
+        runtimeId: options.config.runtimeId,
+        verifier,
+        authority,
+        repository,
+        chatScope,
+        chatAdapter,
+        resolveParticipant,
+        onScopeCommitted: (scopeId) => eventRegistry.broadcastScope(scopeId),
+        onRevoked: (scopeId, actorId) => eventRegistry.notifyRevoked(scopeId, actorId),
+      }));
+      registerCollaborationEventWebSocketRoute({
+        app: input.app,
+        upgradeWebSocket: input.upgradeWebSocket,
+        verifier,
+        authority,
+        registry: eventRegistry,
+      });
+    },
+    async shutdown(): Promise<void> {
+      if (closing) return;
+      closing = true;
+      eventRegistry.shutdown();
+      await outbox.shutdown();
+      participantResolver?.shutdown();
+      verifier.shutdown();
+    },
+  };
+}
+
+export type GatewayCollaborationRuntime = Awaited<ReturnType<typeof createGatewayCollaboration>>;

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -175,6 +175,11 @@ import {
   createUnavailableCanonicalChatService,
 } from "./chat/service.js";
 import { createDiscussionOnlyChatExecutionGuard } from "./collaboration/chat-scope.js";
+import {
+  createGatewayCollaboration,
+  loadGatewayCollaborationConfig,
+  type GatewayCollaborationRuntime,
+} from "./collaboration/wiring.js";
 import { createCodingAgentFileStore } from "./coding-agents/file-read.js";
 import { createCodingAgentSourceControlStore } from "./coding-agents/source-control.js";
 import { registerCodingAgentAttentionNotifications } from "./coding-agents/attention-notifications.js";
@@ -1013,7 +1018,15 @@ export async function createGateway(config: GatewayConfig) {
   let canonicalChatOrchestrator: CanonicalChatOrchestrator | null = null;
   let canonicalChatExecutionRoots: ChatExecutionRootResolver | null = null;
   let canonicalChatCollaborationGuard: ReturnType<typeof createDiscussionOnlyChatExecutionGuard> | null = null;
+  let gatewayCollaboration: GatewayCollaborationRuntime | null = null;
   let messagingRepository: MessagingKyselyRepository | null = null;
+  const collaborationConfig = loadGatewayCollaborationConfig(process.env);
+  if (process.env.MATRIX_COLLABORATION_ENABLED === "true" && !collaborationConfig) {
+    throw new Error("[collaboration] enabled with incomplete configuration");
+  }
+  if (collaborationConfig && !databaseUrl) {
+    throw new Error("[collaboration] enabled without owner Postgres");
+  }
   if (databaseUrl) {
     try {
       const { db, kysely } = createAppDb(databaseUrl);
@@ -1034,6 +1047,12 @@ export async function createGateway(config: GatewayConfig) {
       await chatRepository.bootstrap();
       canonicalChatCollaborationGuard = createDiscussionOnlyChatExecutionGuard(chatRepository.kysely as Kysely<any>);
       await bootstrapChatSharing(chatRepository.kysely);
+      if (collaborationConfig) {
+        gatewayCollaboration = await createGatewayCollaboration({
+          db: chatRepository.kysely as Kysely<any>,
+          config: collaborationConfig,
+        });
+      }
       canonicalChatEventStream = createCanonicalChatEventStream({
         repository: chatRepository,
         reconcileOwner: (owner) => canonicalChatOrchestrator?.reconcileActiveRuns(owner) ?? Promise.resolve(),
@@ -1143,7 +1162,10 @@ export async function createGateway(config: GatewayConfig) {
         console.error("[app-db] App registration error:", (regErr as Error).message);
       }
     } catch (err) {
+      await gatewayCollaboration?.shutdown();
+      gatewayCollaboration = null;
       console.error("[app-db] Failed to connect to Postgres:", (err as Error).message);
+      if (collaborationConfig) throw err;
       console.log("[app-db] Falling back to file-based storage");
       appDb = null;
       queryEngine = null;
@@ -4433,6 +4455,7 @@ export async function createGateway(config: GatewayConfig) {
     });
   }
   app.route("/", createChatSharingRoutes(chatRepository ? new ChatSharing(chatRepository.kysely) : null));
+  gatewayCollaboration?.register({ app, upgradeWebSocket });
   app.route("/", createCanonicalChatRoutes({
     service: chatRepository
         ? createCanonicalChatService(chatRepository, {
@@ -4776,6 +4799,8 @@ export async function createGateway(config: GatewayConfig) {
       watchdog.stop();
       proactiveHeartbeat.stop();
       cronService.stop();
+      await gatewayCollaboration?.shutdown();
+      gatewayCollaboration = null;
       await canonicalChatOrchestrator?.close();
       canonicalChatOrchestrator = null;
       await codingAgentWorkspaceRuntime?.close();

--- a/packages/platform/src/collaboration/internal-routes.ts
+++ b/packages/platform/src/collaboration/internal-routes.ts
@@ -1,0 +1,111 @@
+import {
+  COLLABORATION_HTTP_BODY_LIMIT,
+  CollaborationActorIdSchema,
+  CollaborationDirectoryEventSchema,
+} from "@matrix-os/contracts";
+import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import {
+  PlatformCollaborationRepositoryError,
+  type PlatformCollaborationRepository,
+} from "./repository.js";
+
+const RuntimeIdSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9:_-]+$/);
+const BearerTokenSchema = z.string().min(32).max(4_096).regex(/^[A-Za-z0-9._~-]+$/);
+
+export function createInternalCollaborationRoutes(options: {
+  repository: PlatformCollaborationRepository;
+  authenticateRuntime(input: {
+    runtimeId: string;
+    bearerToken: string;
+  }): Promise<{ runtimeId: string; ownerId: string } | null>;
+  resolveParticipant(actorId: string): Promise<{ actorId: string; displayName: string } | null>;
+}): Hono {
+  const app = new Hono();
+  const mutationLimit = bodyLimit({
+    maxSize: COLLABORATION_HTTP_BODY_LIMIT,
+    onError: (c) => safeJson(c, "Request too large", 413),
+  });
+
+  app.put("/internal/collaboration/directory", mutationLimit, async (c) => {
+    const runtime = await requireRuntime(c.req.header(), options.authenticateRuntime);
+    if (!runtime) return safeJson(c, "Unauthorized", 401);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (error: unknown) {
+      if (!(error instanceof SyntaxError)) {
+        console.warn("[platform-collaboration] directory parse failed", error instanceof Error ? error.name : "UnknownError");
+      }
+      return safeJson(c, "Invalid request", 422);
+    }
+    const event = CollaborationDirectoryEventSchema.safeParse(body);
+    if (!event.success) return safeJson(c, "Invalid request", 422);
+    if (event.data.runtimeId !== runtime.runtimeId || event.data.ownerId !== runtime.ownerId) {
+      return safeJson(c, "Forbidden", 403);
+    }
+    try {
+      await options.repository.applyDirectoryEvent(event.data);
+      c.header("Cache-Control", "no-store");
+      return c.body(null, 204);
+    } catch (error: unknown) {
+      if (error instanceof PlatformCollaborationRepositoryError && error.code === "conflict") {
+        return safeJson(c, "Collaboration state changed", 409);
+      }
+      console.warn("[platform-collaboration] directory update failed", error instanceof Error ? error.name : "UnknownError");
+      return safeJson(c, "Collaboration unavailable", 503);
+    }
+  });
+
+  app.get("/internal/collaboration/participants/:actorId", async (c) => {
+    const runtime = await requireRuntime(c.req.header(), options.authenticateRuntime);
+    if (!runtime) return safeJson(c, "Unauthorized", 401);
+    const actorId = CollaborationActorIdSchema.safeParse(c.req.param("actorId"));
+    if (!actorId.success) return safeJson(c, "Invalid request", 422);
+    try {
+      const participant = await options.resolveParticipant(actorId.data);
+      const parsed = z.object({
+        actorId: CollaborationActorIdSchema,
+        displayName: z.string().trim().min(1).max(120),
+      }).strict().safeParse(participant);
+      if (!parsed.success || parsed.data.actorId !== actorId.data) {
+        return safeJson(c, "Participant not found", 404);
+      }
+      c.header("Cache-Control", "private, no-store");
+      return c.json(parsed.data);
+    } catch (error: unknown) {
+      console.warn("[platform-collaboration] participant lookup failed", error instanceof Error ? error.name : "UnknownError");
+      return safeJson(c, "Collaboration unavailable", 503);
+    }
+  });
+
+  return app;
+}
+
+async function requireRuntime(
+  headers: Record<string, string>,
+  authenticate: Parameters<typeof createInternalCollaborationRoutes>[0]["authenticateRuntime"],
+) {
+  const runtimeId = RuntimeIdSchema.safeParse(headers["x-matrix-runtime-id"]);
+  const authorization = headers.authorization;
+  const bearer = BearerTokenSchema.safeParse(
+    authorization?.startsWith("Bearer ") ? authorization.slice("Bearer ".length) : undefined,
+  );
+  if (!runtimeId.success || !bearer.success) return null;
+  try {
+    return await authenticate({ runtimeId: runtimeId.data, bearerToken: bearer.data });
+  } catch (error: unknown) {
+    console.warn("[platform-collaboration] runtime authentication failed", error instanceof Error ? error.name : "UnknownError");
+    return null;
+  }
+}
+
+function safeJson(
+  c: import("hono").Context,
+  error: string,
+  status: 401 | 403 | 404 | 409 | 413 | 422 | 503,
+) {
+  c.header("Cache-Control", "no-store");
+  return c.json({ error }, status);
+}

--- a/packages/platform/src/collaboration/proof.ts
+++ b/packages/platform/src/collaboration/proof.ts
@@ -67,6 +67,7 @@ export class CollaborationProofSigner {
     scopeId: string;
     purpose: "events" | "terminal";
     path: string;
+    query?: string;
   }) {
     const issuedAt = this.now();
     const proof = CollaborationActorProofSchema.parse({
@@ -79,7 +80,7 @@ export class CollaborationProofSigner {
       purpose: input.purpose,
       method: "GET",
       path: input.path,
-      query: "",
+      query: input.query ?? "",
       bodyDigest: digestBody(new Uint8Array()),
       nonce: this.createNonce(),
       issuedAt: issuedAt.toISOString(),

--- a/packages/platform/src/collaboration/websocket.ts
+++ b/packages/platform/src/collaboration/websocket.ts
@@ -136,9 +136,10 @@ export class CollaborationWebSocketAuthorizer {
       scopeId: route.scopeId,
       purpose: route.purpose,
       path: route.path,
+      query: route.query,
     });
     return {
-      upstreamPath: route.path,
+      upstreamPath: `${route.path}${route.query ? `?${route.query}` : ""}`,
       runtimeId: directory.runtimeId,
       ownerId: directory.ownerId,
       scopeId: route.scopeId,
@@ -184,7 +185,13 @@ export class CollaborationWebSocketAuthorizer {
   }
 }
 
-function parseRoute(rawPath: string): { path: string; scopeId: string; purpose: Purpose; ticket?: string } {
+function parseRoute(rawPath: string): {
+  path: string;
+  query: string;
+  scopeId: string;
+  purpose: Purpose;
+  ticket?: string;
+} {
   if (rawPath.length > MAX_RAW_PATH_LENGTH || /[\r\n]/.test(rawPath)) {
     throw new CollaborationWebSocketError("invalid_route", "Collaboration socket route is invalid");
   }
@@ -200,11 +207,24 @@ function parseRoute(rawPath: string): { path: string; scopeId: string; purpose: 
   const match = COLLABORATION_SOCKET_PATH.exec(parsed.pathname);
   const keys = [...parsed.searchParams.keys()];
   const ticket = parsed.searchParams.get("ticket") ?? undefined;
-  if (!match || keys.some((key) => key !== "ticket") || keys.filter((key) => key === "ticket").length > 1
+  const after = parsed.searchParams.get("after") ?? undefined;
+  if (!match || keys.some((key) => !["ticket", "after"].includes(key))
+    || keys.filter((key) => key === "ticket").length > 1
+    || keys.filter((key) => key === "after").length > 1
     || (ticket !== undefined && (ticket.length < 43 || ticket.length > 256 || !/^[A-Za-z0-9_-]+$/.test(ticket)))) {
     throw new CollaborationWebSocketError("invalid_route", "Collaboration socket route is invalid");
   }
-  return { path: parsed.pathname, scopeId: match[1]!, purpose: match[2] as Purpose, ...(ticket ? { ticket } : {}) };
+  const purpose = match[2] as Purpose;
+  if (after !== undefined && (purpose !== "events" || !/^(?:0|[1-9][0-9]{0,18})$/.test(after))) {
+    throw new CollaborationWebSocketError("invalid_route", "Collaboration socket route is invalid");
+  }
+  return {
+    path: parsed.pathname,
+    query: after === undefined ? "" : `after=${after}`,
+    scopeId: match[1]!,
+    purpose,
+    ...(ticket ? { ticket } : {}),
+  };
 }
 
 function requireOrigin(value: string): string {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -249,6 +249,7 @@ export function createApp(deps: {
   internalFundedAiRuntimeRoutes?: Hono<any>;
   internalFundedAiRelayRoutes?: Hono<any>;
   internalFundedAiOperatorRoutes?: Hono<any>;
+  internalCollaborationRoutes?: Hono<any>;
   fundedAiRepository?: import('./ai-funded-policy-repository.js').AiFundedPolicyRepository;
   customerVpsService?: CustomerVpsService;
   goldenSnapshotService?: GoldenSnapshotService;
@@ -584,6 +585,10 @@ export function createApp(deps: {
       bookingBaseUrl: appEnv.ATS_BOOKING_BASE_URL,
       publicSiteUrl: appEnv.MATRIX_PUBLIC_SITE_URL ?? 'https://matrix-os.com',
     }));
+  }
+
+  if (deps.internalCollaborationRoutes) {
+    app.route('/', deps.internalCollaborationRoutes);
   }
 
   // Session-based routing:

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -8,12 +8,15 @@ import type { Hono, Context } from 'hono';
 import type { Server } from 'node:http';
 import type Dockerode from 'dockerode';
 import type { Agent } from 'undici';
+import type { Kysely } from 'kysely';
 import { randomBytes } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import {
   createPlatformDb,
   getContainer,
+  getPlatformUserByClerkId,
   getRunningUserMachineByHandle,
+  getUserMachine,
   listContainers,
   sweepStaleCheckoutAttempts,
   updateContainerStatus,
@@ -36,7 +39,7 @@ import {
   loadPlatformRuntimeConfig,
 } from './runtime-mode.js';
 import { resolvePlatformIntegrationConfig } from './integration-config.js';
-import { buildPlatformVerificationToken } from './platform-token.js';
+import { buildPlatformVerificationToken, timingSafeTokenEquals } from './platform-token.js';
 import { buildCustomMcpProjectionUrl } from './custom-mcp-projection.js';
 import { backfillFirstRunRecords } from './journey.js';
 import { logPlatformRouteError } from './platform-route-utils.js';
@@ -56,6 +59,9 @@ import {
   createStorageGatedHetznerClient,
   type R2CapabilityGate,
 } from './r2-capability.js';
+import { bootstrapPlatformCollaborationDatabase, type CollaborationPlatformDatabase } from './collaboration/database.js';
+import { createInternalCollaborationRoutes } from './collaboration/internal-routes.js';
+import { PlatformCollaborationRepository } from './collaboration/repository.js';
 
 interface GatewayPlatformUser {
   id: string;
@@ -199,6 +205,7 @@ type CreatePlatformApp = (deps: {
   internalFundedAiRuntimeRoutes?: Hono<any>;
   internalFundedAiRelayRoutes?: Hono<any>;
   internalFundedAiOperatorRoutes?: Hono<any>;
+  internalCollaborationRoutes?: Hono<any>;
   fundedAiRepository?: AiFundedPolicyRepository;
   customerVpsService?: CustomerVpsService;
   goldenSnapshotService?: GoldenSnapshotService;
@@ -293,6 +300,29 @@ async function startPlatformServerWithCleanup(
   const atsDatabaseUrl = resolveAtsDatabaseUrl(process.env);
   const db = createPlatformDb(runtimeConfig.platformDatabaseUrl);
   await db.ready;
+  let internalCollaborationRoutes: Hono | undefined;
+  if (process.env.MATRIX_COLLABORATION_ENABLED === 'true') {
+    if (!platformSecret) throw new Error('Platform collaboration runtime authentication is unavailable');
+    const collaborationDb = db.kysely as unknown as Kysely<CollaborationPlatformDatabase>;
+    await bootstrapPlatformCollaborationDatabase(collaborationDb);
+    internalCollaborationRoutes = createInternalCollaborationRoutes({
+      repository: new PlatformCollaborationRepository(collaborationDb),
+      authenticateRuntime: async ({ runtimeId, bearerToken }) => {
+        const machineId = parseCollaborationRuntimeId(runtimeId);
+        if (!machineId) return null;
+        const machine = await getUserMachine(db, machineId);
+        if (!machine || machine.status !== 'running'
+          || !timingSafeTokenEquals(bearerToken, buildPlatformVerificationToken(machine.handle, platformSecret))) {
+          return null;
+        }
+        return { runtimeId, ownerId: machine.clerkUserId };
+      },
+      resolveParticipant: async (actorId) => {
+        const user = await getPlatformUserByClerkId(db, actorId);
+        return user ? { actorId, displayName: user.displayName } : null;
+      },
+    });
+  }
   const fundedAiConfig = loadAiFundedControlPlaneConfig({
     ...process.env,
     PLATFORM_SECRET: platformSecret,
@@ -1078,6 +1108,7 @@ async function startPlatformServerWithCleanup(
     internalFundedAiRuntimeRoutes,
     internalFundedAiRelayRoutes,
     internalFundedAiOperatorRoutes,
+    internalCollaborationRoutes,
     fundedAiRepository,
     customerVpsService,
     goldenSnapshotService,
@@ -1188,4 +1219,9 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     }
     throw startupError;
   }
+}
+
+function parseCollaborationRuntimeId(runtimeId: string): string | null {
+  const match = /^vps:([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/.exec(runtimeId);
+  return match?.[1] ?? null;
 }

--- a/specs/121-collaboration-session-sharing/tasks.md
+++ b/specs/121-collaboration-session-sharing/tasks.md
@@ -47,7 +47,7 @@
 - [x] T017 (PR1) Add versioned owner-Postgres collaboration tables, constraints, indexes, Chat actor/purpose columns, and migration bookkeeping in `packages/gateway/src/collaboration/database.ts`
 - [x] T018 (PR1) Implement transactional scope, member, operation, audit, event, and directory-outbox persistence without owning the injected pool in `packages/gateway/src/collaboration/repository.ts`
 - [x] T019 (PR1) Implement current-member resolution, role/action authorization, capacity/expiry, lifecycle, auth-epoch, idempotency, and owner-protection rules in `packages/gateway/src/collaboration/authority.ts`
-- [ ] T020 [P] (PR1) Implement bounded directory-outbox delivery with idempotent event IDs, capped retry/backoff, safe errors, and shutdown drain in `packages/gateway/src/collaboration/directory-outbox.ts`
+- [x] T020 [P] (PR1) Implement bounded directory-outbox delivery with idempotent event IDs, capped retry/backoff, safe errors, and shutdown drain in `packages/gateway/src/collaboration/directory-outbox.ts`
 - [x] T021 [P] (PR1) Add platform Kysely tables and additive migrations for directory/index/policy/tickets in `packages/platform/src/collaboration/database.ts`
 - [x] T022 (PR1) Implement content-free platform directory/index and server-managed rollout policy repositories in `packages/platform/src/collaboration/repository.ts`
 - [x] T023 (PR1) Implement short-lived signed actor proofs and signed policy snapshots using managed keys in `packages/platform/src/collaboration/proof.ts`

--- a/specs/121-collaboration-session-sharing/tasks.md
+++ b/specs/121-collaboration-session-sharing/tasks.md
@@ -55,7 +55,7 @@
 - [x] T025 (PR1) Implement exact collaboration HTTP proxying, caller-header stripping, bounded fetch timeouts, and safe response mapping in `packages/platform/src/collaboration/proxy.ts`
 - [x] T026 (PR1) Implement hashed one-use connection tickets and exact collaboration WebSocket forwarding in `packages/platform/src/collaboration/websocket.ts`
 - [x] T027 (PR1) Implement the capped scope-event registry, authorized replay, heartbeat/stale sweep, failed-sender eviction, revoke notification, and drain in `packages/gateway/src/collaboration/events.ts`
-- [ ] T028 (PR1) Register gateway dependencies, migrations, recovery, exact HTTP/WS routes, workers, and shutdown ordering in `packages/gateway/src/collaboration/wiring.ts`
+- [x] T028 (PR1) Register gateway dependencies, migrations, recovery, exact HTTP/WS routes, workers, and shutdown ordering in `packages/gateway/src/collaboration/wiring.ts`
 - [ ] T029 (PR1) Register platform database, policy, exact proxy/WS paths, internal directory/policy endpoints, and shutdown ownership in `packages/platform/src/collaboration/wiring.ts`
 
 **Checkpoint**: A common authority and transport exist, but no story-specific resource adapter is advertised or enabled.
@@ -100,7 +100,7 @@
 - [ ] T041 [P] [US3] (PR1) Write red actor-scoped message idempotency and commit-with-outbox tests in `tests/gateway/collaboration-chat-discussion-postgres.test.ts`
 - [x] T042 [P] [US3] (PR1) Write red owner legacy bypass tests for start, queue, dispatch, steer, retry, approval, and reconnect paths in `tests/gateway/collaboration-m1-ai-gate.test.ts`
 - [ ] T043 [P] [US3] (PR1) Write red private draft/mode/account-switch and member-local read/pin/mute state tests in `tests/ui/collaboration-chat-state.test.tsx`
-- [ ] T044 [P] [US3] (PR1) Write red scoped event/reconnect tests proving no owner-wide cursor or duplicate discussion delivery in `tests/gateway/collaboration-chat-events.test.ts`
+- [x] T044 [P] [US3] (PR1) Write red scoped event/reconnect tests proving no owner-wide cursor or duplicate discussion delivery in `tests/gateway/collaboration-chat-events.test.ts`
 
 ### Implementation — M1 / PR1
 

--- a/specs/121-collaboration-session-sharing/tasks.md
+++ b/specs/121-collaboration-session-sharing/tasks.md
@@ -80,7 +80,7 @@
 
 - [x] T035 [US2] (PR1) Implement Chat scope preflight/create binding with active-work settlement and personal-dispatch fencing in `packages/gateway/src/collaboration/chat-scope.ts`
 - [ ] T036 [US2] (PR1) Implement canonical Chat-only read/search/history projection with inert unauthorized references in `packages/gateway/src/collaboration/chat-adapter.ts`
-- [ ] T037 [US2] (PR1) Register validated/body-limited standalone Chat scope and member routes in `packages/gateway/src/collaboration/routes.ts`
+- [x] T037 [US2] (PR1) Register validated/body-limited standalone Chat scope and member routes in `packages/gateway/src/collaboration/routes.ts`
 - [ ] T038 [US2] (PR4) Implement eligible terminal scope binding without replacement or sibling authority in `packages/gateway/src/collaboration/terminal-adapter.ts`
 - [ ] T039 [US2] (PR6) Reconcile direct Chat/terminal grants into sole project inheritance at the publication point in `packages/gateway/src/collaboration/project-membership-transition.ts`
 

--- a/tests/contracts/collaboration.test.ts
+++ b/tests/contracts/collaboration.test.ts
@@ -4,12 +4,14 @@ import {
   CollaborationConnectionTicketRequestSchema,
   CollaborationCreateDiscussionRequestSchema,
   CollaborationCreateInvitationRequestSchema,
+  CollaborationCreateScopeRequestSchema,
   CollaborationEventFrameSchema,
   CollaborationInvitationSchema,
   CollaborationMemberPatchRequestSchema,
   CollaborationPolicySchema,
   CollaborationRoleSchema,
   CollaborationScopeSchema,
+  CollaborationScopePreflightRequestSchema,
   CollaborationUserStatePatchSchema,
 } from "@matrix-os/contracts";
 import { describe, expect, it } from "vitest";
@@ -113,11 +115,31 @@ describe("collaboration contracts", () => {
       role: "viewer",
       clientRequestId: requestId,
       expectedRevision: "9",
+      expectedMemberRevision: "2",
     }).role).toBe("viewer");
     expect(CollaborationMemberPatchRequestSchema.safeParse({
       role: "owner",
       clientRequestId: requestId,
       expectedRevision: "9",
+      expectedMemberRevision: "2",
+    }).success).toBe(false);
+  });
+
+  it("keeps owner scope conversion bound to one selected resource and preflight", () => {
+    expect(CollaborationScopePreflightRequestSchema.parse({
+      kind: "chat",
+      resourceId: "chat_release",
+    })).toEqual({ kind: "chat", resourceId: "chat_release" });
+    expect(CollaborationCreateScopeRequestSchema.parse({
+      kind: "chat",
+      resourceId: "chat_release",
+      clientRequestId: requestId,
+      expectedRevision: "4",
+      confirmationToken: "a".repeat(64),
+    })).toMatchObject({ kind: "chat", resourceId: "chat_release" });
+    expect(CollaborationScopePreflightRequestSchema.safeParse({
+      kind: "document",
+      resourceId: "private-file",
     }).success).toBe(false);
   });
 

--- a/tests/gateway/collaboration-chat-events.test.ts
+++ b/tests/gateway/collaboration-chat-events.test.ts
@@ -1,0 +1,158 @@
+import { Hono, type Context } from "hono";
+import type { UpgradeWebSocket, WSEvents } from "hono/ws";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bootstrapChatDatabase } from "../../packages/gateway/src/chat/database.js";
+import { CollaborationActorProofVerifier } from "../../packages/gateway/src/collaboration/actor-proof.js";
+import { CollaborationAuthority } from "../../packages/gateway/src/collaboration/authority.js";
+import { bootstrapCollaborationDatabase } from "../../packages/gateway/src/collaboration/database.js";
+import { registerCollaborationEventWebSocketRoute } from "../../packages/gateway/src/collaboration/event-websocket-route.js";
+import { CollaborationEventRegistry } from "../../packages/gateway/src/collaboration/events.js";
+import { CollaborationRepository } from "../../packages/gateway/src/collaboration/repository.js";
+import { CollaborationProofSigner } from "../../packages/platform/src/collaboration/proof.js";
+import {
+  collaborationActors,
+  collaborationIds,
+  createCollaborationTestDatabase,
+  type CollaborationTestDatabase,
+} from "./collaboration-test-support.js";
+
+const now = new Date("2026-09-07T12:00:00.000Z");
+const key = "0123456789abcdef0123456789abcdef";
+const path = `/ws/collaboration/scopes/${collaborationIds.scope}/events`;
+
+describe("shared Chat event WebSocket", () => {
+  let fixture: CollaborationTestDatabase;
+  let registry: CollaborationEventRegistry;
+
+  beforeEach(async () => {
+    fixture = await createCollaborationTestDatabase();
+    await bootstrapChatDatabase(fixture.db);
+    await bootstrapCollaborationDatabase(fixture.db);
+    await seed(fixture);
+  });
+
+  afterEach(async () => {
+    registry?.shutdown();
+    await fixture.destroy();
+  });
+
+  it("attaches only after scoped proof authorization and resumes without duplicate history", async () => {
+    const repository = new CollaborationRepository(fixture.db, { now: () => now });
+    const authority = new CollaborationAuthority(repository, { now: () => now });
+    registry = new CollaborationEventRegistry({
+      db: fixture.db,
+      authorize: (scopeId, actorId) => authority.authorize({ scopeId, actorId, action: "read" }),
+      now: () => now,
+      startTimers: false,
+    });
+    let socketEvents: WSEvents<unknown> | undefined;
+    const upgradeWebSocket = ((factory: (context: Context) => WSEvents<unknown>) => (
+      async (context: Context) => {
+        socketEvents = factory(context);
+        return context.text("upgrade captured");
+      }
+    )) as unknown as UpgradeWebSocket;
+    const app = new Hono();
+    registerCollaborationEventWebSocketRoute({
+      app,
+      upgradeWebSocket,
+      verifier: new CollaborationActorProofVerifier({
+        runtimeId: collaborationIds.runtime,
+        keys: { "collaboration-key-1": key },
+        now: () => now,
+      }),
+      authority,
+      registry,
+      createConnectionId: () => "connection_editor",
+    });
+    const signer = new CollaborationProofSigner({
+      activeKeyId: "collaboration-key-1",
+      keys: { "collaboration-key-1": key },
+      now: () => now,
+      createNonce: () => "a".repeat(32),
+    });
+    const signed = signer.signSocket({
+      actorId: collaborationActors.editor,
+      ownerId: collaborationActors.owner,
+      runtimeId: collaborationIds.runtime,
+      scopeId: collaborationIds.scope,
+      purpose: "events",
+      path,
+      query: "after=1",
+    });
+    await app.request(`${path}?after=1`, {
+      headers: { "x-matrix-collaboration-proof": Buffer.from(JSON.stringify(signed)).toString("base64url") },
+    });
+    const ws = { send: vi.fn(), close: vi.fn() };
+    socketEvents!.onOpen?.({} as never, ws as never);
+    await vi.waitFor(() => expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"type":"ready"')));
+    expect(ws.send.mock.calls.map(([value]) => JSON.parse(value as string)))
+      .not.toContainEqual(expect.objectContaining({ type: "changed", sequence: "1" }));
+
+    await insertEvent(fixture, 2);
+    await registry.broadcastScope(collaborationIds.scope);
+    expect(ws.send.mock.calls.map(([value]) => JSON.parse(value as string)))
+      .toContainEqual(expect.objectContaining({ type: "changed", sequence: "2" }));
+    ws.send.mockClear();
+    socketEvents!.onMessage?.({ data: JSON.stringify({
+      version: 1,
+      type: "resume",
+      scopeId: collaborationIds.scope,
+      authorityGeneration: "1",
+      sequence: "2",
+    }) } as never, ws as never);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ws.send).not.toHaveBeenCalledWith(expect.stringContaining('"type":"changed"'));
+  });
+});
+
+async function seed(fixture: CollaborationTestDatabase): Promise<void> {
+  await fixture.db.insertInto("collaboration_scopes").values({
+    id: collaborationIds.scope,
+    owner_type: "personal",
+    owner_id: collaborationActors.owner,
+    kind: "chat",
+    resource_id: collaborationIds.chat,
+    parent_scope_id: null,
+    membership_mode: "direct",
+    lifecycle: "shared",
+    revision: 1,
+    auth_epoch: 1,
+    authority_runtime_id: collaborationIds.runtime,
+    authority_generation: 1,
+    execution_generation: null,
+    execution_eligibility: null,
+    deleted_at: null,
+    created_at: now.toISOString(),
+    updated_at: now.toISOString(),
+  }).execute();
+  await fixture.db.insertInto("collaboration_members").values({
+    scope_id: collaborationIds.scope,
+    actor_id: collaborationActors.editor,
+    role: "editor",
+    status: "accepted",
+    invitation_id: null,
+    invited_by: collaborationActors.owner,
+    accepted_at: now.toISOString(),
+    expires_at: null,
+    revision: 1,
+    joined_at: now.toISOString(),
+    updated_at: now.toISOString(),
+  }).execute();
+  await insertEvent(fixture, 1);
+}
+
+async function insertEvent(fixture: CollaborationTestDatabase, sequence: number): Promise<void> {
+  await fixture.db.insertInto("collaboration_events").values({
+    scope_id: collaborationIds.scope,
+    scope_seq: sequence,
+    event_id: `60000000-0000-4000-8000-${sequence.toString().padStart(12, "0")}`,
+    resource_kind: "chat",
+    resource_id: collaborationIds.chat,
+    revision: sequence,
+    authority_generation: 1,
+    event_type: "chat.discussion_appended",
+    payload: JSON.stringify({}),
+    created_at: now.toISOString(),
+  }).execute();
+}

--- a/tests/gateway/collaboration-chat-scope.test.ts
+++ b/tests/gateway/collaboration-chat-scope.test.ts
@@ -64,6 +64,13 @@ describe("CollaborationChatScopeService", () => {
       executionFenced: true,
     });
     expect(Number(chat.revision)).toBe(1);
+    expect(await fixture.db.selectFrom("collaboration_directory_outbox")
+      .select(["scope_id", "recipient_actor_ids", "discovery_state"])
+      .execute()).toEqual([{
+      scope_id: collaborationIds.scope,
+      recipient_actor_ids: [collaborationActors.owner],
+      discovery_state: "accepted",
+    }]);
   });
 
   it("returns the existing logical scope for an idempotent retry without reusing preflight authority", async () => {

--- a/tests/gateway/collaboration-chat-scope.test.ts
+++ b/tests/gateway/collaboration-chat-scope.test.ts
@@ -46,6 +46,8 @@ describe("CollaborationChatScopeService", () => {
     const scope = await service.shareChat({
       ownerId: collaborationActors.owner,
       chatId: collaborationIds.chat,
+      clientRequestId: "50000000-0000-4000-8000-000000000010",
+      payloadHash: "a".repeat(64),
       expectedChatRevision: 0,
       confirmationToken: preflight.confirmationToken!,
     });
@@ -78,16 +80,28 @@ describe("CollaborationChatScopeService", () => {
     const first = await service.shareChat({
       ownerId: collaborationActors.owner,
       chatId: collaborationIds.chat,
+      clientRequestId: "50000000-0000-4000-8000-000000000010",
+      payloadHash: "a".repeat(64),
       expectedChatRevision: 0,
       confirmationToken: preflight.confirmationToken!,
     });
     const repeated = await service.shareChat({
       ownerId: collaborationActors.owner,
       chatId: collaborationIds.chat,
+      clientRequestId: "50000000-0000-4000-8000-000000000010",
+      payloadHash: "a".repeat(64),
       expectedChatRevision: 0,
       confirmationToken: "expired-or-already-consumed-confirmation",
     });
     expect(repeated).toEqual(first);
+    await expect(service.shareChat({
+      ownerId: collaborationActors.owner,
+      chatId: collaborationIds.chat,
+      clientRequestId: "50000000-0000-4000-8000-000000000010",
+      payloadHash: "b".repeat(64),
+      expectedChatRevision: 0,
+      confirmationToken: "expired-or-already-consumed-confirmation",
+    })).rejects.toMatchObject({ code: "conflict" });
   });
 
   it("refuses conversion while private execution is active and leaves it intact", async () => {
@@ -97,6 +111,8 @@ describe("CollaborationChatScopeService", () => {
     await expect(service.shareChat({
       ownerId: collaborationActors.owner,
       chatId: collaborationIds.chat,
+      clientRequestId: "50000000-0000-4000-8000-000000000010",
+      payloadHash: "a".repeat(64),
       expectedChatRevision: 0,
       confirmationToken: "invalid",
     })).rejects.toBeInstanceOf(CollaborationChatScopeError);
@@ -110,6 +126,8 @@ describe("CollaborationChatScopeService", () => {
     await service.shareChat({
       ownerId: collaborationActors.owner,
       chatId: collaborationIds.chat,
+      clientRequestId: "50000000-0000-4000-8000-000000000010",
+      payloadHash: "a".repeat(64),
       expectedChatRevision: 0,
       confirmationToken: preflight.confirmationToken!,
     });
@@ -133,6 +151,8 @@ describe("CollaborationChatScopeService", () => {
     await service.shareChat({
       ownerId: collaborationActors.owner,
       chatId: collaborationIds.chat,
+      clientRequestId: "50000000-0000-4000-8000-000000000010",
+      payloadHash: "a".repeat(64),
       expectedChatRevision: 0,
       confirmationToken: preflight.confirmationToken!,
     });

--- a/tests/gateway/collaboration-chat-scope.test.ts
+++ b/tests/gateway/collaboration-chat-scope.test.ts
@@ -66,7 +66,7 @@ describe("CollaborationChatScopeService", () => {
     expect(Number(chat.revision)).toBe(1);
   });
 
-  it("returns the existing logical scope for a confirmed retry", async () => {
+  it("returns the existing logical scope for an idempotent retry without reusing preflight authority", async () => {
     const preflight = await service.preflight({ ownerId: collaborationActors.owner, chatId: collaborationIds.chat });
     const first = await service.shareChat({
       ownerId: collaborationActors.owner,
@@ -78,7 +78,7 @@ describe("CollaborationChatScopeService", () => {
       ownerId: collaborationActors.owner,
       chatId: collaborationIds.chat,
       expectedChatRevision: 0,
-      confirmationToken: preflight.confirmationToken!,
+      confirmationToken: "expired-or-already-consumed-confirmation",
     });
     expect(repeated).toEqual(first);
   });

--- a/tests/gateway/collaboration-directory-outbox.test.ts
+++ b/tests/gateway/collaboration-directory-outbox.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bootstrapChatDatabase } from "../../packages/gateway/src/chat/database.js";
+import { bootstrapCollaborationDatabase } from "../../packages/gateway/src/collaboration/database.js";
+import { CollaborationDirectoryOutbox } from "../../packages/gateway/src/collaboration/directory-outbox.js";
+import {
+  collaborationActors,
+  collaborationIds,
+  createCollaborationTestDatabase,
+  type CollaborationTestDatabase,
+} from "./collaboration-test-support.js";
+
+const now = new Date("2026-09-07T12:00:00.000Z");
+
+describe("CollaborationDirectoryOutbox", () => {
+  let fixture: CollaborationTestDatabase;
+
+  beforeEach(async () => {
+    fixture = await createCollaborationTestDatabase();
+    await bootstrapChatDatabase(fixture.db);
+    await bootstrapCollaborationDatabase(fixture.db);
+    await seedScopeAndOutbox(fixture);
+  });
+
+  afterEach(async () => {
+    await fixture.destroy();
+  });
+
+  it("delivers bounded content-free directory metadata and marks it after success", async () => {
+    await fixture.db.updateTable("collaboration_scopes").set({ revision: 9 })
+      .where("id", "=", collaborationIds.scope).execute();
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    const worker = new CollaborationDirectoryOutbox({
+      db: fixture.db,
+      platformBaseUrl: "https://platform.internal",
+      runtimeId: collaborationIds.runtime,
+      serviceToken: "runtime-service-secret-0123456789abcdef",
+      fetchImpl,
+      now: () => now,
+      startTimer: false,
+    });
+    expect(await worker.runOnce()).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://platform.internal/internal/collaboration/directory");
+    expect(init).toMatchObject({ method: "PUT", redirect: "error" });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    const headers = new Headers(init.headers);
+    expect(headers.get("authorization")).toBe("Bearer runtime-service-secret-0123456789abcdef");
+    const payload = JSON.parse(init.body as string);
+    expect(payload).toEqual({
+      eventId: "60000000-0000-4000-8000-000000000001",
+      scopeId: collaborationIds.scope,
+      runtimeId: collaborationIds.runtime,
+      ownerId: collaborationActors.owner,
+      kind: "chat",
+      authorityGeneration: 1,
+      metadataRevision: 1,
+      recipients: [{ actorId: collaborationActors.editor, status: "invited" }],
+    });
+    expect(JSON.stringify(payload)).not.toMatch(/title|message|content|transcript/i);
+    expect(await fixture.db.selectFrom("collaboration_directory_outbox")
+      .select(["attempts", "delivered_at"]).executeTakeFirstOrThrow()).toMatchObject({ attempts: 1 });
+    expect((await fixture.db.selectFrom("collaboration_directory_outbox")
+      .select("delivered_at").executeTakeFirstOrThrow()).delivered_at).not.toBeNull();
+    await worker.shutdown();
+  });
+
+  it("backs off safely, caps attempts, and never marks a failed delivery", async () => {
+    const fetchImpl = vi.fn(async () => new Response("provider database exploded", { status: 503 }));
+    const worker = new CollaborationDirectoryOutbox({
+      db: fixture.db,
+      platformBaseUrl: "https://platform.internal",
+      runtimeId: collaborationIds.runtime,
+      serviceToken: "runtime-service-secret-0123456789abcdef",
+      fetchImpl,
+      now: () => now,
+      startTimer: false,
+    });
+    expect(await worker.runOnce()).toBe(0);
+    const failed = await fixture.db.selectFrom("collaboration_directory_outbox")
+      .select(["attempts", "retry_after", "delivered_at"]).executeTakeFirstOrThrow();
+    expect(Number(failed.attempts)).toBe(1);
+    expect(new Date(failed.retry_after).getTime()).toBeGreaterThan(now.getTime());
+    expect(failed.delivered_at).toBeNull();
+    expect(await worker.runOnce()).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    await fixture.db.updateTable("collaboration_directory_outbox").set({ attempts: 20, retry_after: now.toISOString() })
+      .execute();
+    expect(await worker.runOnce()).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    await worker.shutdown();
+  });
+});
+
+async function seedScopeAndOutbox(fixture: CollaborationTestDatabase): Promise<void> {
+  await fixture.db.insertInto("collaboration_scopes").values({
+    id: collaborationIds.scope,
+    owner_type: "personal",
+    owner_id: collaborationActors.owner,
+    kind: "chat",
+    resource_id: collaborationIds.chat,
+    parent_scope_id: null,
+    membership_mode: "direct",
+    lifecycle: "shared",
+    revision: 1,
+    auth_epoch: 1,
+    authority_runtime_id: collaborationIds.runtime,
+    authority_generation: 1,
+    execution_generation: null,
+    execution_eligibility: null,
+    deleted_at: null,
+    created_at: now.toISOString(),
+    updated_at: now.toISOString(),
+  }).execute();
+  await fixture.db.insertInto("collaboration_directory_outbox").values({
+    event_id: "60000000-0000-4000-8000-000000000001",
+    scope_id: collaborationIds.scope,
+    recipient_actor_ids: JSON.stringify([collaborationActors.editor]),
+    authority_runtime_id: collaborationIds.runtime,
+    authority_generation: 1,
+    resource_kind: "chat",
+    discovery_state: "invited",
+    retry_after: now.toISOString(),
+    delivered_at: null,
+    created_at: now.toISOString(),
+  }).execute();
+  await fixture.db.insertInto("collaboration_events").values({
+    scope_id: collaborationIds.scope,
+    scope_seq: 1,
+    event_id: "60000000-0000-4000-8000-000000000001",
+    resource_kind: "chat",
+    resource_id: collaborationIds.chat,
+    revision: 1,
+    authority_generation: 1,
+    event_type: "invitation.created",
+    payload: JSON.stringify({}),
+    created_at: now.toISOString(),
+  }).execute();
+}

--- a/tests/gateway/collaboration-directory-outbox.test.ts
+++ b/tests/gateway/collaboration-directory-outbox.test.ts
@@ -25,6 +25,29 @@ describe("CollaborationDirectoryOutbox", () => {
     await fixture.destroy();
   });
 
+  it("never sends its service token over remote cleartext HTTP", async () => {
+    const fetchImpl = vi.fn();
+    expect(() => new CollaborationDirectoryOutbox({
+      db: fixture.db,
+      platformBaseUrl: "http://platform.internal",
+      runtimeId: collaborationIds.runtime,
+      serviceToken: "runtime-service-secret-0123456789abcdef",
+      fetchImpl,
+      startTimer: false,
+    })).toThrow("Collaboration platform URL is unavailable");
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    const loopback = new CollaborationDirectoryOutbox({
+      db: fixture.db,
+      platformBaseUrl: "http://localhost:8787",
+      runtimeId: collaborationIds.runtime,
+      serviceToken: "runtime-service-secret-0123456789abcdef",
+      fetchImpl,
+      startTimer: false,
+    });
+    await loopback.shutdown();
+  });
+
   it("delivers bounded content-free directory metadata and marks it after success", async () => {
     await fixture.db.updateTable("collaboration_scopes").set({ revision: 9 })
       .where("id", "=", collaborationIds.scope).execute();

--- a/tests/gateway/collaboration-directory-outbox.test.ts
+++ b/tests/gateway/collaboration-directory-outbox.test.ts
@@ -90,6 +90,57 @@ describe("CollaborationDirectoryOutbox", () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
     await worker.shutdown();
   });
+
+  it("quarantines malformed rows without blocking valid rows in the same batch", async () => {
+    await fixture.db.updateTable("collaboration_directory_outbox")
+      .set({ recipient_actor_ids: JSON.stringify([""]) })
+      .where("event_id", "=", "60000000-0000-4000-8000-000000000001")
+      .execute();
+    await fixture.db.insertInto("collaboration_events").values({
+      scope_id: collaborationIds.scope,
+      scope_seq: 2,
+      event_id: "60000000-0000-4000-8000-000000000002",
+      resource_kind: "chat",
+      resource_id: collaborationIds.chat,
+      revision: 2,
+      authority_generation: 1,
+      event_type: "member.accepted",
+      payload: JSON.stringify({}),
+      created_at: now.toISOString(),
+    }).execute();
+    await fixture.db.insertInto("collaboration_directory_outbox").values({
+      event_id: "60000000-0000-4000-8000-000000000002",
+      scope_id: collaborationIds.scope,
+      recipient_actor_ids: JSON.stringify([collaborationActors.editor]),
+      authority_runtime_id: collaborationIds.runtime,
+      authority_generation: 1,
+      resource_kind: "chat",
+      discovery_state: "accepted",
+      retry_after: now.toISOString(),
+      delivered_at: null,
+      created_at: now.toISOString(),
+    }).execute();
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    const worker = new CollaborationDirectoryOutbox({
+      db: fixture.db,
+      platformBaseUrl: "https://platform.internal",
+      runtimeId: collaborationIds.runtime,
+      serviceToken: "runtime-service-secret-0123456789abcdef",
+      fetchImpl,
+      now: () => now,
+      startTimer: false,
+    });
+
+    expect(await worker.runOnce()).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const rows = await fixture.db.selectFrom("collaboration_directory_outbox")
+      .select(["event_id", "attempts", "delivered_at"])
+      .orderBy("event_id")
+      .execute();
+    expect(rows[0]).toMatchObject({ attempts: 20, delivered_at: null });
+    expect(rows[1]?.delivered_at).not.toBeNull();
+    await worker.shutdown();
+  });
 });
 
 async function seedScopeAndOutbox(fixture: CollaborationTestDatabase): Promise<void> {

--- a/tests/gateway/collaboration-events.test.ts
+++ b/tests/gateway/collaboration-events.test.ts
@@ -80,6 +80,12 @@ describe("CollaborationEventRegistry", () => {
       expect.objectContaining({ type: "changed", scopeId: collaborationIds.scope, sequence: "2" }),
       expect.objectContaining({ type: "ready", scopeId: collaborationIds.scope, sequence: "2" }),
     ]);
+    ws.send.mockClear();
+    await insertEvent(fixture, 3);
+    await session.resume(2, 1);
+    expect(ws.send.mock.calls.map(([value]) => JSON.parse(value as string))).toEqual([
+      expect.objectContaining({ type: "changed", scopeId: collaborationIds.scope, sequence: "3" }),
+    ]);
   });
 
   it("rechecks current membership for every broadcast and drains revoked actors", async () => {
@@ -136,6 +142,30 @@ describe("CollaborationEventRegistry", () => {
     await registry.broadcastScope(collaborationIds.scope);
     expect(healthy.send).toHaveBeenCalled();
     expect(registry.connectionCount).toBe(1);
+  });
+
+  it("serializes overlapping resume and broadcast delivery for one connection", async () => {
+    const ws = socket();
+    const session = await registry.open({
+      connectionId: "connection_serialized",
+      scopeId: collaborationIds.scope,
+      actorId: collaborationActors.editor,
+      authorityGeneration: 1,
+      afterSequence: 2,
+      socket: ws,
+    });
+    ws.send.mockClear();
+    await insertEvent(fixture, 3);
+
+    await Promise.all([
+      session.resume(2, 1),
+      registry.broadcastScope(collaborationIds.scope),
+    ]);
+
+    const changed = ws.send.mock.calls
+      .map(([value]) => JSON.parse(value as string) as { type: string; sequence?: string })
+      .filter((frame) => frame.type === "changed" && frame.sequence === "3");
+    expect(changed).toHaveLength(1);
   });
 
   it("enforces per-actor caps, evicts stale connections, and drains on shutdown", async () => {

--- a/tests/gateway/collaboration-participant-resolver.test.ts
+++ b/tests/gateway/collaboration-participant-resolver.test.ts
@@ -5,6 +5,24 @@ import {
 } from "../../packages/gateway/src/collaboration/participant-resolver.js";
 
 describe("CollaborationParticipantResolver", () => {
+  it("never sends its service token over remote cleartext HTTP", () => {
+    const fetchImpl = vi.fn();
+    expect(() => new CollaborationParticipantResolver({
+      platformBaseUrl: "http://platform.internal",
+      runtimeId: "vps:10000000-0000-4000-8000-000000000001",
+      serviceToken: "s".repeat(32),
+      fetchImpl,
+    })).toThrow("Collaboration platform URL is unavailable");
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    expect(() => new CollaborationParticipantResolver({
+      platformBaseUrl: "http://127.0.0.1:8787",
+      runtimeId: "vps:10000000-0000-4000-8000-000000000001",
+      serviceToken: "s".repeat(32),
+      fetchImpl,
+    })).not.toThrow();
+  });
+
   it("returns a validated platform label and caches it", async () => {
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       expect(init).toMatchObject({ method: "GET", redirect: "error" });

--- a/tests/gateway/collaboration-participant-resolver.test.ts
+++ b/tests/gateway/collaboration-participant-resolver.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CollaborationParticipantResolver,
+  CollaborationParticipantResolverError,
+} from "../../packages/gateway/src/collaboration/participant-resolver.js";
+
+describe("CollaborationParticipantResolver", () => {
+  it("returns a validated platform label and caches it", async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init).toMatchObject({ method: "GET", redirect: "error" });
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return new Response(JSON.stringify({ actorId: "user_editor", displayName: "Editor Person" }));
+    });
+    const resolver = new CollaborationParticipantResolver({
+      platformBaseUrl: "https://platform.internal",
+      runtimeId: "vps:10000000-0000-4000-8000-000000000001",
+      serviceToken: "s".repeat(32),
+      fetchImpl,
+    });
+    await expect(resolver.resolve("user_editor")).resolves.toMatchObject({ displayName: "Editor Person" });
+    await expect(resolver.resolve("user_editor")).resolves.toMatchObject({ displayName: "Editor Person" });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("rejects mismatched and oversized identity projections generically", async () => {
+    const responses = [
+      new Response(JSON.stringify({ actorId: "user_other", displayName: "Wrong" })),
+      new Response("x".repeat(8_193)),
+    ];
+    const resolver = new CollaborationParticipantResolver({
+      platformBaseUrl: "https://platform.internal",
+      runtimeId: "vps:10000000-0000-4000-8000-000000000001",
+      serviceToken: "s".repeat(32),
+      fetchImpl: async () => responses.shift()!,
+    });
+    for (const actorId of ["user_editor", "user_viewer"]) {
+      await expect(resolver.resolve(actorId)).rejects.toBeInstanceOf(CollaborationParticipantResolverError);
+    }
+  });
+});

--- a/tests/gateway/collaboration-repository.test.ts
+++ b/tests/gateway/collaboration-repository.test.ts
@@ -253,4 +253,85 @@ describe("CollaborationRepository", () => {
       payloadHash: "9".repeat(64),
     })).rejects.toMatchObject({ code: "forbidden" });
   });
+
+  it("previews and conditionally revokes a pending invitation", async () => {
+    const scope = await createScope();
+    const invitation = await repository.createInvitation({
+      scopeId: scope.id,
+      actorId: collaborationActors.owner,
+      targetActorId: collaborationActors.editor,
+      role: "editor",
+      clientRequestId: uuid(60),
+      expectedRevision: 0,
+      payloadHash: "a".repeat(64),
+      expiresAt: future,
+    });
+    await expect(repository.getInvitation(invitation.invitationId)).resolves.toMatchObject({
+      scopeId: scope.id,
+      actorId: collaborationActors.editor,
+      invitedBy: collaborationActors.owner,
+      status: "pending",
+    });
+    await expect(repository.revokeInvitation({
+      scopeId: scope.id,
+      invitationId: invitation.invitationId,
+      actorId: collaborationActors.owner,
+      clientRequestId: uuid(61),
+      expectedRevision: 1,
+      expectedMemberRevision: 1,
+      payloadHash: "b".repeat(64),
+    })).resolves.toMatchObject({ status: "revoked", scopeRevision: 2 });
+    await expect(repository.acceptInvitation({
+      invitationId: invitation.invitationId,
+      actorId: collaborationActors.editor,
+      clientRequestId: uuid(62),
+      expectedRevision: 2,
+      payloadHash: "c".repeat(64),
+    })).rejects.toMatchObject({ code: "conflict" });
+  });
+
+  it("keeps read, pin, mute, and opened state local to each Chat participant", async () => {
+    await fixture.db.insertInto("chats").values({
+      id: collaborationIds.chat,
+      owner_type: "personal",
+      owner_id: collaborationActors.owner,
+      create_request_id: "request_user_state_chat",
+      project_id: null,
+      title: "Shared Chat",
+      lifecycle: "active",
+      attention: "none",
+      revision: 0,
+      collaboration: null,
+      user_state: null,
+      shell_state: null,
+      fork_provenance: null,
+      last_message_preview: null,
+      current_selection: null,
+      bound_driver_kind: null,
+      bound_instance_id: null,
+      bound_at_turn_id: null,
+      created_at: instant.toISOString(),
+      updated_at: instant.toISOString(),
+    }).execute();
+    await createScope();
+    await repository.updateChatUserState({
+      chatId: collaborationIds.chat,
+      actorId: collaborationActors.owner,
+      readThroughSeq: 12,
+      pinned: true,
+      muted: false,
+      openedAt: instant.toISOString(),
+    });
+    expect(await repository.getChatUserState(collaborationIds.chat, collaborationActors.owner)).toEqual({
+      readThroughSeq: 12,
+      pinned: true,
+      muted: false,
+      lastOpenedAt: instant.toISOString(),
+    });
+    expect(await repository.getChatUserState(collaborationIds.chat, collaborationActors.editor)).toEqual({
+      readThroughSeq: 0,
+      pinned: false,
+      muted: false,
+    });
+  });
 });

--- a/tests/gateway/collaboration-routes.test.ts
+++ b/tests/gateway/collaboration-routes.test.ts
@@ -241,6 +241,21 @@ describe("collaboration gateway routes", () => {
     expect(await ownerState.json()).toMatchObject({ pinned: false, muted: false });
   });
 
+  it("rejects unsafe and future read cursors without mutating private state", async () => {
+    await shareChat();
+    for (const readThroughSeq of ["9007199254740992", "1"]) {
+      const response = await signedJson({
+        actorId: collaborationActors.owner,
+        scopeId: collaborationIds.scope,
+        method: "PATCH",
+        path: `/api/collaboration/scopes/${collaborationIds.scope}/user-state`,
+        body: { readThroughSeq },
+      });
+      expect(response.status).toBe(400);
+    }
+    expect(await fixture.db.selectFrom("chat_user_state").selectAll().execute()).toEqual([]);
+  });
+
   it("applies downgrade immediately and revocation removes all live scope access", async () => {
     await shareChat();
     await signedJson({

--- a/tests/gateway/collaboration-routes.test.ts
+++ b/tests/gateway/collaboration-routes.test.ts
@@ -1,0 +1,417 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapChatDatabase } from "../../packages/gateway/src/chat/database.js";
+import { CollaborationActorProofVerifier } from "../../packages/gateway/src/collaboration/actor-proof.js";
+import { CollaborationAuthority } from "../../packages/gateway/src/collaboration/authority.js";
+import { CollaborationChatAdapter } from "../../packages/gateway/src/collaboration/chat-adapter.js";
+import { CollaborationChatScopeService } from "../../packages/gateway/src/collaboration/chat-scope.js";
+import { bootstrapCollaborationDatabase } from "../../packages/gateway/src/collaboration/database.js";
+import { CollaborationRepository } from "../../packages/gateway/src/collaboration/repository.js";
+import { createCollaborationRoutes } from "../../packages/gateway/src/collaboration/routes.js";
+import { CollaborationProofSigner } from "../../packages/platform/src/collaboration/proof.js";
+import {
+  collaborationActors,
+  collaborationIds,
+  createCollaborationTestDatabase,
+  type CollaborationTestDatabase,
+} from "./collaboration-test-support.js";
+
+const now = new Date("2026-09-07T12:00:00.000Z");
+const key = "0123456789abcdef0123456789abcdef";
+const invitationRequestId = "50000000-0000-4000-8000-000000000001";
+const acceptanceRequestId = "50000000-0000-4000-8000-000000000002";
+const discussionRequestId = "50000000-0000-4000-8000-000000000003";
+
+describe("collaboration gateway routes", () => {
+  let fixture: CollaborationTestDatabase;
+  let app: Hono;
+  let signer: CollaborationProofSigner;
+  let nonce: number;
+
+  beforeEach(async () => {
+    fixture = await createCollaborationTestDatabase();
+    await bootstrapChatDatabase(fixture.db);
+    await bootstrapCollaborationDatabase(fixture.db);
+    await seedChat(fixture);
+    const repository = new CollaborationRepository(fixture.db, {
+      now: () => now,
+      createId: () => collaborationIds.invitation,
+    });
+    const authority = new CollaborationAuthority(repository, { now: () => now });
+    const chatScope = new CollaborationChatScopeService(fixture.db, {
+      runtimeId: collaborationIds.runtime,
+      preflightSecret: "0123456789abcdef0123456789abcdef",
+      now: () => now,
+      createScopeId: () => collaborationIds.scope,
+    });
+    const resolveParticipant = async (actorId: string) => ({
+      actorId,
+      displayName: actorId === collaborationActors.owner
+        ? "Nima Owner"
+        : actorId === collaborationActors.editor ? "Ada Editor" : "Vi Viewer",
+    });
+    const chatAdapter = new CollaborationChatAdapter({
+      db: fixture.db,
+      authority,
+      resolveParticipant,
+      now: () => now,
+    });
+    nonce = 0;
+    signer = new CollaborationProofSigner({
+      activeKeyId: "collaboration-key-1",
+      keys: { "collaboration-key-1": key },
+      now: () => now,
+      createNonce: () => (++nonce).toString(16).padStart(32, "0"),
+    });
+    app = new Hono();
+    app.route("/", createCollaborationRoutes({
+      runtimeId: collaborationIds.runtime,
+      verifier: new CollaborationActorProofVerifier({
+        runtimeId: collaborationIds.runtime,
+        keys: { "collaboration-key-1": key },
+        now: () => now,
+        authority,
+      }),
+      authority,
+      repository,
+      chatScope,
+      chatAdapter,
+      resolveParticipant,
+      now: () => now,
+    }));
+  });
+
+  afterEach(async () => {
+    await fixture.destroy();
+  });
+
+  it("preflights and converts an owner Chat without accepting participant identity", async () => {
+    const preflight = await signedJson({
+      actorId: collaborationActors.owner,
+      method: "POST",
+      path: `/api/collaboration/runtimes/${collaborationIds.runtime}/scopes/preflight`,
+      body: { kind: "chat", resourceId: collaborationIds.chat },
+    });
+    expect(preflight.status).toBe(200);
+    const eligibility = await preflight.json() as { confirmationToken: string; resourceRevision: string };
+    const created = await signedJson({
+      actorId: collaborationActors.owner,
+      method: "POST",
+      path: `/api/collaboration/runtimes/${collaborationIds.runtime}/scopes`,
+      body: {
+        kind: "chat",
+        resourceId: collaborationIds.chat,
+        clientRequestId: "50000000-0000-4000-8000-000000000010",
+        expectedRevision: eligibility.resourceRevision,
+        confirmationToken: eligibility.confirmationToken,
+      },
+    });
+    expect(created.status).toBe(201);
+    expect(await created.json()).toMatchObject({
+      id: collaborationIds.scope,
+      ownerId: collaborationActors.owner,
+      kind: "chat",
+      role: "owner",
+      capabilities: { discuss: true, requestAi: false },
+    });
+  });
+
+  it("supports owner invite, exact-actor acceptance, history, and attributed discussion", async () => {
+    await shareChat();
+    const invitation = await signedJson({
+      actorId: collaborationActors.owner,
+      scopeId: collaborationIds.scope,
+      method: "POST",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/invitations`,
+      body: {
+        targetActorId: collaborationActors.editor,
+        role: "editor",
+        clientRequestId: invitationRequestId,
+        expectedRevision: "1",
+      },
+    });
+    expect(invitation.status).toBe(201);
+    expect(await invitation.json()).toMatchObject({
+      id: collaborationIds.invitation,
+      target: { actorId: collaborationActors.editor, displayName: "Ada Editor" },
+      status: "pending",
+    });
+    const preview = await signedJson({
+      actorId: collaborationActors.editor,
+      scopeId: collaborationIds.scope,
+      method: "GET",
+      path: `/api/collaboration/invitations/${collaborationIds.invitation}`,
+    });
+    expect(preview.status).toBe(200);
+    expect(await preview.json()).toMatchObject({ scopeKind: "chat", role: "editor", status: "pending" });
+
+    const accepted = await signedJson({
+      actorId: collaborationActors.editor,
+      scopeId: collaborationIds.scope,
+      method: "POST",
+      path: `/api/collaboration/invitations/${collaborationIds.invitation}/accept`,
+      body: { clientRequestId: acceptanceRequestId, expectedRevision: "2" },
+    });
+    expect(accepted.status).toBe(200);
+    const chat = await signedJson({
+      actorId: collaborationActors.editor,
+      scopeId: collaborationIds.scope,
+      method: "GET",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/chat`,
+    });
+    expect(chat.status).toBe(200);
+    const chatProjection = await chat.json();
+    expect(chatProjection).toMatchObject({ id: collaborationIds.chat, title: "Release discussion" });
+    expect(JSON.stringify(chatProjection)).not.toContain("project_private");
+    const discussion = await signedJson({
+      actorId: collaborationActors.editor,
+      scopeId: collaborationIds.scope,
+      method: "POST",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/chat/messages`,
+      body: {
+        clientRequestId: discussionRequestId,
+        expectedRevision: "3",
+        text: "This is human discussion, not an AI request.",
+      },
+    });
+    expect(discussion.status).toBe(201);
+    expect(await discussion.json()).toMatchObject({
+      purpose: "discussion",
+      actor: { actorId: collaborationActors.editor, displayName: "Ada Editor" },
+    });
+    const history = await signedJson({
+      actorId: collaborationActors.editor,
+      scopeId: collaborationIds.scope,
+      method: "GET",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/chat/messages`,
+      query: "after=0&limit=50",
+    });
+    expect(history.status).toBe(200);
+    expect(await history.json()).toMatchObject({
+      messages: [{ purpose: "discussion", actor: { actorId: collaborationActors.editor } }],
+    });
+  });
+
+  it("lets viewers read and keep private state but rejects every discussion write", async () => {
+    await shareChat();
+    const invitation = await signedJson({
+      actorId: collaborationActors.owner,
+      scopeId: collaborationIds.scope,
+      method: "POST",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/invitations`,
+      body: {
+        targetActorId: collaborationActors.viewer,
+        role: "viewer",
+        clientRequestId: invitationRequestId,
+        expectedRevision: "1",
+      },
+    });
+    expect(invitation.status).toBe(201);
+    const accepted = await signedJson({
+      actorId: collaborationActors.viewer,
+      scopeId: collaborationIds.scope,
+      method: "POST",
+      path: `/api/collaboration/invitations/${collaborationIds.invitation}/accept`,
+      body: { clientRequestId: acceptanceRequestId, expectedRevision: "2" },
+    });
+    expect(accepted.status).toBe(200);
+    const write = await signedJson({
+      actorId: collaborationActors.viewer,
+      scopeId: collaborationIds.scope,
+      method: "POST",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/chat/messages`,
+      body: { clientRequestId: discussionRequestId, expectedRevision: "3", text: "Viewer write" },
+    });
+    expect(write.status).toBe(403);
+    const state = await signedJson({
+      actorId: collaborationActors.viewer,
+      scopeId: collaborationIds.scope,
+      method: "PATCH",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/user-state`,
+      body: { pinned: true, muted: true, readThroughSeq: "0" },
+    });
+    expect(state.status).toBe(200);
+    expect(await state.json()).toMatchObject({ pinned: true, muted: true });
+    const ownerState = await signedJson({
+      actorId: collaborationActors.owner,
+      scopeId: collaborationIds.scope,
+      method: "GET",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/user-state`,
+    });
+    expect(await ownerState.json()).toMatchObject({ pinned: false, muted: false });
+  });
+
+  it("applies downgrade immediately and revocation removes all live scope access", async () => {
+    await shareChat();
+    await signedJson({
+      actorId: collaborationActors.owner,
+      scopeId: collaborationIds.scope,
+      method: "POST",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/invitations`,
+      body: {
+        targetActorId: collaborationActors.editor,
+        role: "editor",
+        clientRequestId: invitationRequestId,
+        expectedRevision: "1",
+      },
+    });
+    await signedJson({
+      actorId: collaborationActors.editor,
+      scopeId: collaborationIds.scope,
+      method: "POST",
+      path: `/api/collaboration/invitations/${collaborationIds.invitation}/accept`,
+      body: { clientRequestId: acceptanceRequestId, expectedRevision: "2" },
+    });
+    const downgraded = await signedJson({
+      actorId: collaborationActors.owner,
+      scopeId: collaborationIds.scope,
+      method: "PATCH",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/members/${collaborationActors.editor}`,
+      body: {
+        role: "viewer",
+        clientRequestId: "50000000-0000-4000-8000-000000000020",
+        expectedRevision: "3",
+        expectedMemberRevision: "2",
+      },
+    });
+    expect(downgraded.status).toBe(200);
+    expect(await downgraded.json()).toMatchObject({ role: "viewer", scopeRevision: 4 });
+    expect((await signedJson({
+      actorId: collaborationActors.editor,
+      scopeId: collaborationIds.scope,
+      method: "POST",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/chat/messages`,
+      body: { clientRequestId: discussionRequestId, expectedRevision: "4", text: "Stale editor" },
+    })).status).toBe(403);
+    const revoked = await signedJson({
+      actorId: collaborationActors.owner,
+      scopeId: collaborationIds.scope,
+      method: "DELETE",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}/members/${collaborationActors.editor}`,
+      body: {
+        clientRequestId: "50000000-0000-4000-8000-000000000021",
+        expectedRevision: "4",
+        expectedMemberRevision: "3",
+      },
+    });
+    expect(revoked.status).toBe(200);
+    expect((await signedJson({
+      actorId: collaborationActors.editor,
+      scopeId: collaborationIds.scope,
+      method: "GET",
+      path: `/api/collaboration/scopes/${collaborationIds.scope}`,
+    })).status).toBe(403);
+  });
+
+  it("rejects snapshot-token substitution and oversized mutation bodies", async () => {
+    const path = `/api/collaboration/scopes/${collaborationIds.scope}/chat/messages`;
+    expect((await app.request(path, {
+      method: "POST",
+      headers: { "x-matrix-collaboration-proof": "public-snapshot-token" },
+      body: JSON.stringify({ text: "not authorized" }),
+    })).status).toBe(401);
+    const oversized = "x".repeat(97 * 1024);
+    const body = JSON.stringify({
+      clientRequestId: discussionRequestId,
+      expectedRevision: "1",
+      text: oversized,
+    });
+    const bytes = new TextEncoder().encode(body);
+    const proof = signer.signHttp({
+      actorId: collaborationActors.owner,
+      ownerId: collaborationActors.owner,
+      runtimeId: collaborationIds.runtime,
+      scopeId: collaborationIds.scope,
+      method: "POST",
+      path,
+      query: "",
+      body: bytes,
+    });
+    expect((await app.request(path, {
+      method: "POST",
+      headers: {
+        "content-length": String(bytes.byteLength),
+        "content-type": "application/json",
+        "x-matrix-collaboration-proof": Buffer.from(JSON.stringify(proof)).toString("base64url"),
+      },
+      body,
+    })).status).toBe(413);
+  });
+
+  async function shareChat(): Promise<void> {
+    const preflightPath = `/api/collaboration/runtimes/${collaborationIds.runtime}/scopes/preflight`;
+    const preflight = await signedJson({
+      actorId: collaborationActors.owner,
+      method: "POST",
+      path: preflightPath,
+      body: { kind: "chat", resourceId: collaborationIds.chat },
+    });
+    const eligibility = await preflight.json() as { confirmationToken: string; resourceRevision: string };
+    await signedJson({
+      actorId: collaborationActors.owner,
+      method: "POST",
+      path: `/api/collaboration/runtimes/${collaborationIds.runtime}/scopes`,
+      body: {
+        kind: "chat",
+        resourceId: collaborationIds.chat,
+        clientRequestId: "50000000-0000-4000-8000-000000000010",
+        expectedRevision: eligibility.resourceRevision,
+        confirmationToken: eligibility.confirmationToken,
+      },
+    });
+  }
+
+  async function signedJson(input: {
+    actorId: string;
+    scopeId?: string;
+    method: "GET" | "POST" | "PATCH" | "DELETE";
+    path: string;
+    query?: string;
+    body?: unknown;
+  }): Promise<Response> {
+    const body = input.body === undefined ? new Uint8Array() : new TextEncoder().encode(JSON.stringify(input.body));
+    const proof = signer.signHttp({
+      actorId: input.actorId,
+      ownerId: collaborationActors.owner,
+      runtimeId: collaborationIds.runtime,
+      ...(input.scopeId ? { scopeId: input.scopeId } : {}),
+      method: input.method,
+      path: input.path,
+      query: input.query ?? "",
+      body,
+    });
+    return app.request(`${input.path}${input.query ? `?${input.query}` : ""}`, {
+      method: input.method,
+      headers: {
+        "content-type": "application/json",
+        "x-matrix-collaboration-proof": Buffer.from(JSON.stringify(proof)).toString("base64url"),
+      },
+      ...(input.body === undefined ? {} : { body: new TextDecoder().decode(body) }),
+    });
+  }
+});
+
+async function seedChat(fixture: CollaborationTestDatabase): Promise<void> {
+  await fixture.db.insertInto("chats").values({
+    id: collaborationIds.chat,
+    owner_type: "personal",
+    owner_id: collaborationActors.owner,
+    create_request_id: "request_routes_chat",
+    project_id: "project_private",
+    title: "Release discussion",
+    lifecycle: "active",
+    attention: "none",
+    revision: 1,
+    collaboration: null,
+    user_state: null,
+    shell_state: null,
+    fork_provenance: null,
+    last_message_preview: null,
+    current_selection: null,
+    bound_driver_kind: null,
+    bound_instance_id: null,
+    bound_at_turn_id: null,
+    created_at: now.toISOString(),
+    updated_at: now.toISOString(),
+  }).execute();
+}

--- a/tests/gateway/collaboration-test-support.ts
+++ b/tests/gateway/collaboration-test-support.ts
@@ -14,6 +14,7 @@ export const collaborationActors = {
 
 export const collaborationIds = {
   scope: "10000000-0000-4000-8000-000000000001",
+  invitation: "30000000-0000-4000-8000-000000000001",
   chat: "chat_collaboration_primary",
   runtime: "runtime_collaboration_owner",
 } as const;

--- a/tests/gateway/collaboration-wiring.test.ts
+++ b/tests/gateway/collaboration-wiring.test.ts
@@ -1,0 +1,68 @@
+import { Hono, type Context } from "hono";
+import type { UpgradeWebSocket, WSEvents } from "hono/ws";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapChatDatabase } from "../../packages/gateway/src/chat/database.js";
+import {
+  createGatewayCollaboration,
+  loadGatewayCollaborationConfig,
+} from "../../packages/gateway/src/collaboration/wiring.js";
+import {
+  collaborationIds,
+  createCollaborationTestDatabase,
+  type CollaborationTestDatabase,
+} from "./collaboration-test-support.js";
+
+describe("gateway collaboration wiring", () => {
+  let fixture: CollaborationTestDatabase;
+
+  beforeEach(async () => {
+    fixture = await createCollaborationTestDatabase();
+    await bootstrapChatDatabase(fixture.db);
+  });
+
+  afterEach(async () => {
+    await fixture.destroy();
+  });
+
+  it("fails closed on incomplete environment configuration", () => {
+    expect(loadGatewayCollaborationConfig({ MATRIX_COLLABORATION_ENABLED: "true" })).toBeNull();
+    expect(loadGatewayCollaborationConfig({
+      MATRIX_COLLABORATION_ENABLED: "true",
+      MATRIX_RUNTIME_ID: collaborationIds.runtime,
+      MATRIX_COLLABORATION_ACTIVE_KEY_ID: "key-1",
+      MATRIX_COLLABORATION_PROOF_KEYS: JSON.stringify({ "key-1": "a".repeat(32) }),
+      MATRIX_COLLABORATION_PREFLIGHT_SECRET: "b".repeat(32),
+      PLATFORM_INTERNAL_URL: "https://platform.internal",
+      UPGRADE_TOKEN: "c".repeat(32),
+    })).toMatchObject({ runtimeId: collaborationIds.runtime });
+  });
+
+  it("resolves dependencies before route registration and drains before database disposal", async () => {
+    const runtime = await createGatewayCollaboration({
+      db: fixture.db,
+      config: {
+        runtimeId: collaborationIds.runtime,
+        activeKeyId: "key-1",
+        proofKeys: { "key-1": "a".repeat(32) },
+        preflightSecret: "b".repeat(32),
+        platformBaseUrl: "https://platform.internal",
+        serviceToken: "c".repeat(32),
+      },
+      resolveParticipant: async (actorId) => ({ actorId, displayName: actorId }),
+      outboxFetch: async () => new Response(null, { status: 204 }),
+      startTimers: false,
+    });
+    const app = new Hono();
+    let registeredSocket = false;
+    const upgradeWebSocket = ((factory: (context: Context) => WSEvents<unknown>) => {
+      registeredSocket = typeof factory === "function";
+      return (context: Context) => context.text("upgrade");
+    }) as unknown as UpgradeWebSocket;
+    runtime.register({ app, upgradeWebSocket });
+    expect(registeredSocket).toBe(true);
+    expect(await fixture.db.selectFrom("collaboration_schema_migrations").select("version").execute())
+      .toEqual([{ version: 1 }]);
+    await runtime.shutdown();
+    await expect(runtime.outbox.runOnce()).resolves.toBe(0);
+  });
+});

--- a/tests/platform/collaboration-internal-routes.test.ts
+++ b/tests/platform/collaboration-internal-routes.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapPlatformCollaborationDatabase } from "../../packages/platform/src/collaboration/database.js";
+import { createInternalCollaborationRoutes } from "../../packages/platform/src/collaboration/internal-routes.js";
+import { PlatformCollaborationRepository } from "../../packages/platform/src/collaboration/repository.js";
+import {
+  createPlatformCollaborationTestDatabase,
+  destroyPlatformCollaborationTestDatabase,
+  platformCollaborationActors,
+  type PlatformCollaborationTestDatabase,
+} from "./collaboration-test-support.js";
+
+const runtimeId = "vps:10000000-0000-4000-8000-000000000001";
+const token = "s".repeat(32);
+
+describe("platform internal collaboration routes", () => {
+  let fixture: PlatformCollaborationTestDatabase;
+
+  beforeEach(async () => {
+    fixture = await createPlatformCollaborationTestDatabase();
+    await bootstrapPlatformCollaborationDatabase(fixture.collaborationDb);
+  });
+
+  afterEach(async () => destroyPlatformCollaborationTestDatabase(fixture));
+
+  it("authenticates the authority runtime and persists content-free directory events", async () => {
+    const app = createInternalCollaborationRoutes({
+      repository: new PlatformCollaborationRepository(fixture.collaborationDb),
+      authenticateRuntime: async (input) => input.runtimeId === runtimeId && input.bearerToken === token
+        ? { runtimeId, ownerId: platformCollaborationActors.owner }
+        : null,
+      resolveParticipant: async (actorId) => ({ actorId, displayName: "Known participant" }),
+    });
+    const response = await app.request("/internal/collaboration/directory", {
+      method: "PUT",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "x-matrix-runtime-id": runtimeId,
+      },
+      body: JSON.stringify({
+        eventId: "20000000-0000-4000-8000-000000000001",
+        scopeId: "10000000-0000-4000-8000-000000000001",
+        runtimeId,
+        ownerId: platformCollaborationActors.owner,
+        kind: "chat",
+        authorityGeneration: 1,
+        metadataRevision: 1,
+        recipients: [{ actorId: platformCollaborationActors.recipientWithoutComputer, status: "invited" }],
+      }),
+    });
+    expect(response.status).toBe(204);
+    expect(await fixture.collaborationDb.selectFrom("collaboration_directory").select("runtime_id").execute())
+      .toEqual([{ runtime_id: runtimeId }]);
+  });
+
+  it("serves validated participant labels only to authenticated runtimes", async () => {
+    const app = createInternalCollaborationRoutes({
+      repository: new PlatformCollaborationRepository(fixture.collaborationDb),
+      authenticateRuntime: async (input) => input.bearerToken === token
+        ? { runtimeId: input.runtimeId, ownerId: platformCollaborationActors.owner }
+        : null,
+      resolveParticipant: async (actorId) => ({ actorId, displayName: "Nima Owner" }),
+    });
+    expect((await app.request(`/internal/collaboration/participants/${platformCollaborationActors.owner}`)).status)
+      .toBe(401);
+    const response = await app.request(`/internal/collaboration/participants/${platformCollaborationActors.owner}`, {
+      headers: { authorization: `Bearer ${token}`, "x-matrix-runtime-id": runtimeId },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ actorId: platformCollaborationActors.owner, displayName: "Nima Owner" });
+  });
+});

--- a/tests/platform/collaboration-websocket.test.ts
+++ b/tests/platform/collaboration-websocket.test.ts
@@ -83,11 +83,11 @@ describe("CollaborationWebSocketAuthorizer", () => {
     const upgrade = await authorizer.authorizeUpgrade({
       actorId: platformCollaborationActors.recipientWithoutComputer,
       authentication: "ticket",
-      rawPath: `${eventPath}?ticket=${encodeURIComponent(issued.ticket)}`,
+      rawPath: `${eventPath}?ticket=${encodeURIComponent(issued.ticket)}&after=1`,
       origin: "https://app.matrix-os.com",
     });
     expect(upgrade).toMatchObject({
-      upstreamPath: eventPath,
+      upstreamPath: `${eventPath}?after=1`,
       runtimeId: "runtime_owner",
       ownerId: platformCollaborationActors.owner,
       scopeId,
@@ -102,6 +102,7 @@ describe("CollaborationWebSocketAuthorizer", () => {
       signedProof: upgrade.signedProof,
       purpose: "events",
       path: eventPath,
+      query: "after=1",
     })).resolves.toMatchObject({
       actorId: platformCollaborationActors.recipientWithoutComputer,
       scopeId,


### PR DESCRIPTION
## Summary

- Expose body-limited, Zod-validated standalone Chat scope, invitation/member, history, discussion, and private user-state routes.
- Add exact scoped WebSocket registration with awaited authorization and replay.
- Wire owner migrations, collaboration dependencies, bounded directory-outbox delivery/retry, recovery, and shutdown drains into the gateway.

Stack: 4/8 of PR1/M1, based on #1573.

## Tests

- Gateway route, wiring, outbox, scoped replay, authority, and boundary suites are included in the cumulative 148-test focused pass.
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit` passed.
- `pnpm run check:patterns` — 0 violations.

## Invariants

- **Source of truth:** Owner Postgres is authoritative for scope, membership, Chat, audit, event, operation, and outbox state.
- **Lock/transaction scope:** Resource and membership writes use repository transactions and conditional revisions. Directory delivery and per-subscriber socket sends happen after commit and are isolated from one another.
- **Acceptable orphan states:** Failed directory deliveries remain bounded retry records; failed/dead sockets are evicted and clients recover from the durable scoped cursor. Shutdown drains registries before owned dependencies close.
- **Auth source of truth:** Verified actor proof and current membership at the authoritative operation. Every mutation is body-limited and path/query/body validated.
- **Deferred scope:** Platform public ingress and clients follow in #1575/#1576. AI, terminal, and project milestones remain unavailable.

## Review/Monitoring

- Draft; review after #1573.
- Greptile and label-gated CI are pending.
