### PR TITLE
feat(collaboration): route shared Chats through platform

### DIFF
--- a/packages/contracts/src/collaboration.ts
+++ b/packages/contracts/src/collaboration.ts
@@ -263,6 +263,7 @@ export const CollaborationDirectoryEventSchema = z.object({
   recipients: z.array(z.object({
     actorId: CollaborationActorIdSchema,
     status: z.enum(["invited", "accepted", "revoked"]),
+    invitationId: CollaborationIdSchema.optional(),
   }).strict()).max(8),
 }).strict();
 

--- a/packages/contracts/src/collaboration.ts
+++ b/packages/contracts/src/collaboration.ts
@@ -116,6 +116,7 @@ export const CollaborationMemberSchema = z.object({
   actor: CollaborationParticipantSchema,
   role: CollaborationRoleSchema,
   status: CollaborationMemberStatusSchema,
+  invitationId: CollaborationIdSchema.optional(),
   revision: CollaborationRevisionSchema,
   joinedAt: z.iso.datetime().optional(),
   updatedAt: z.iso.datetime(),

--- a/packages/gateway/src/collaboration/chat-scope.ts
+++ b/packages/gateway/src/collaboration/chat-scope.ts
@@ -245,7 +245,7 @@ export class CollaborationChatScopeService {
       await trx.insertInto("collaboration_directory_outbox").values({
         event_id: eventId,
         scope_id: scope.id,
-        recipient_actor_ids: jsonb([input.ownerId]),
+        recipient_actor_ids: jsonb([{ actorId: input.ownerId }]),
         authority_runtime_id: this.options.runtimeId,
         authority_generation: 1,
         resource_kind: "chat",

--- a/packages/gateway/src/collaboration/directory-outbox.ts
+++ b/packages/gateway/src/collaboration/directory-outbox.ts
@@ -16,7 +16,7 @@ interface ClaimedDirectoryEvent {
   kind: "chat" | "terminal" | "project";
   authorityGeneration: number;
   metadataRevision: number;
-  recipientActorIds: string[];
+  recipientEntries: Array<{ actorId: string; invitationId?: string }>;
   discoveryState: "invited" | "accepted" | "revoked" | "deleted";
   attempt: number;
 }
@@ -87,8 +87,8 @@ export class CollaborationDirectoryOutbox {
         kind: event.kind,
         authorityGeneration: event.authorityGeneration,
         metadataRevision: event.metadataRevision,
-        recipients: event.recipientActorIds.map((actorId) => ({
-          actorId,
+        recipients: event.recipientEntries.map((recipient) => ({
+          ...recipient,
           status: event.discoveryState === "deleted" ? "revoked" : event.discoveryState,
         })),
       });
@@ -163,9 +163,9 @@ export class CollaborationDirectoryOutbox {
           .returning("event_id")
           .executeTakeFirst();
         if (!updated) continue;
-        let recipientActorIds: string[];
+        let recipientEntries: Array<{ actorId: string; invitationId?: string }>;
         try {
-          recipientActorIds = parseActorIds(row.recipient_actor_ids);
+          recipientEntries = parseRecipientEntries(row.recipient_actor_ids);
         } catch (error: unknown) {
           console.warn(
             "[collaboration-directory] quarantined malformed outbox event",
@@ -186,7 +186,7 @@ export class CollaborationDirectoryOutbox {
           kind: row.resource_kind,
           authorityGeneration: Number(row.authority_generation),
           metadataRevision: Number(row.revision),
-          recipientActorIds,
+          recipientEntries,
           discoveryState: row.discovery_state,
           attempt,
         });
@@ -196,11 +196,13 @@ export class CollaborationDirectoryOutbox {
   }
 }
 
-function parseActorIds(value: unknown): string[] {
+function parseRecipientEntries(value: unknown): Array<{ actorId: string; invitationId?: string }> {
   const parsed = typeof value === "string" ? JSON.parse(value) as unknown : value;
   return CollaborationDirectoryEventSchema.shape.recipients
-    .parse((Array.isArray(parsed) ? parsed : []).map((actorId) => ({ actorId, status: "accepted" })))
-    .map(({ actorId }) => actorId);
+    .parse((Array.isArray(parsed) ? parsed : []).map((entry) => (
+      typeof entry === "string" ? { actorId: entry, status: "accepted" } : { ...entry, status: "accepted" }
+    )))
+    .map(({ actorId, invitationId }) => ({ actorId, ...(invitationId ? { invitationId } : {}) }));
 }
 
 function backoffMs(attempt: number): number {

--- a/packages/gateway/src/collaboration/repository.ts
+++ b/packages/gateway/src/collaboration/repository.ts
@@ -328,7 +328,7 @@ export class CollaborationRepository {
         scope: { ...scope, revision: nextRevision, auth_epoch: Number(scope.auth_epoch) + 1 },
         actorId: input.actorId,
         action: "invitation.created",
-        recipients: [input.targetActorId],
+        recipients: [{ actorId: input.targetActorId, invitationId }],
         discoveryState: "invited",
         now,
       });
@@ -390,7 +390,7 @@ export class CollaborationRepository {
           scope: { ...scope, revision: nextRevision, auth_epoch: Number(scope.auth_epoch) + 1 },
           actorId: input.actorId,
           action: "invitation.expired",
-          recipients: [input.actorId],
+          recipients: [{ actorId: input.actorId, invitationId: input.invitationId }],
           discoveryState: "revoked",
           now,
           reasonCode: "expired",
@@ -433,7 +433,7 @@ export class CollaborationRepository {
         scope: { ...scope, revision: nextRevision, auth_epoch: Number(scope.auth_epoch) + 1 },
         actorId: input.actorId,
         action: "invitation.accepted",
-        recipients: [input.actorId],
+        recipients: [{ actorId: input.actorId, invitationId: input.invitationId }],
         discoveryState: "accepted",
         now,
       });
@@ -494,7 +494,7 @@ export class CollaborationRepository {
         scope: { ...scope, revision: nextRevision, auth_epoch: Number(scope.auth_epoch) + 1 },
         actorId: input.actorId,
         action: "invitation.revoked",
-        recipients: [member.actor_id],
+        recipients: [{ actorId: member.actor_id, invitationId: input.invitationId }],
         discoveryState: "revoked",
         now,
       });
@@ -627,7 +627,10 @@ export class CollaborationRepository {
         scope: { ...scope, revision: nextRevision, auth_epoch: Number(scope.auth_epoch) + 1 },
         actorId: input.actorId,
         action,
-        recipients: [input.targetActorId],
+        recipients: [{
+          actorId: input.targetActorId,
+          ...(member.invitation_id ? { invitationId: member.invitation_id } : {}),
+        }],
         discoveryState: status === "revoked" ? "revoked" : "accepted",
         now,
       });
@@ -747,7 +750,7 @@ async function appendMutationRecords(
     scope: ScopeRow;
     actorId: string;
     action: string;
-    recipients: string[];
+    recipients: Array<{ actorId: string; invitationId?: string }>;
     discoveryState: "invited" | "accepted" | "revoked" | "deleted";
     now: string;
     reasonCode?: string;

--- a/packages/gateway/src/collaboration/routes.ts
+++ b/packages/gateway/src/collaboration/routes.ts
@@ -409,6 +409,7 @@ async function memberProjection(
     actor: await options.resolveParticipant(member.actorId),
     role: member.role,
     status: member.status,
+    ...(member.invitationId ? { invitationId: member.invitationId } : {}),
     revision: String(member.revision),
     ...(member.joinedAt ? { joinedAt: member.joinedAt } : {}),
     updatedAt: member.updatedAt,

--- a/packages/gateway/src/collaboration/wiring.ts
+++ b/packages/gateway/src/collaboration/wiring.ts
@@ -14,6 +14,7 @@ import { CollaborationRepository } from "./repository.js";
 import { createCollaborationRoutes } from "./routes.js";
 
 const MAX_PROOF_KEYS = 8;
+const MACHINE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export interface GatewayCollaborationConfig {
   runtimeId: string;
@@ -26,7 +27,10 @@ export interface GatewayCollaborationConfig {
 
 export function loadGatewayCollaborationConfig(env: NodeJS.ProcessEnv): GatewayCollaborationConfig | null {
   if (env.MATRIX_COLLABORATION_ENABLED !== "true") return null;
-  const runtimeId = env.MATRIX_RUNTIME_ID?.trim();
+  const configuredRuntimeId = env.MATRIX_RUNTIME_ID?.trim();
+  const machineId = env.MATRIX_MACHINE_ID?.trim();
+  const runtimeId = configuredRuntimeId
+    || (machineId && MACHINE_ID_PATTERN.test(machineId) ? `vps:${machineId.toLowerCase()}` : undefined);
   const activeKeyId = env.MATRIX_COLLABORATION_ACTIVE_KEY_ID?.trim();
   const preflightSecret = env.MATRIX_COLLABORATION_PREFLIGHT_SECRET;
   const platformBaseUrl = env.PLATFORM_INTERNAL_URL?.trim();

--- a/packages/platform/src/collaboration/bootstrap.ts
+++ b/packages/platform/src/collaboration/bootstrap.ts
@@ -1,0 +1,85 @@
+import type { Kysely } from "kysely";
+import type { Agent } from "undici";
+import type { ClerkAuth } from "../clerk-auth.js";
+import {
+  getPlatformUserByClerkId,
+  getUserMachine,
+  type PlatformDB,
+} from "../db.js";
+import { createJourneyUserResolver } from "../journey-routes.js";
+import { buildPlatformVerificationToken, timingSafeTokenEquals } from "../platform-token.js";
+import type { CollaborationPlatformDatabase } from "./database.js";
+import {
+  createPlatformCollaboration,
+  loadPlatformCollaborationConfig,
+  type PlatformCollaborationRuntime,
+} from "./wiring.js";
+
+export interface BootstrapPlatformCollaborationOptions {
+  env: NodeJS.ProcessEnv;
+  db: PlatformDB;
+  platformSecret: string;
+  platformJwtSecret: string;
+  clerkAuth?: ClerkAuth;
+  customerVpsProxyDispatcher: Agent;
+}
+
+export async function bootstrapPlatformCollaboration(
+  options: BootstrapPlatformCollaborationOptions,
+): Promise<PlatformCollaborationRuntime | undefined> {
+  const config = loadPlatformCollaborationConfig(options.env);
+  if (options.env.MATRIX_COLLABORATION_ENABLED === "true" && !config) {
+    throw new Error("Platform collaboration configuration is incomplete");
+  }
+  if (!config) return undefined;
+  if (!options.platformSecret) {
+    throw new Error("Platform collaboration runtime authentication is unavailable");
+  }
+
+  return createPlatformCollaboration({
+    db: options.db.kysely as unknown as Kysely<CollaborationPlatformDatabase>,
+    config,
+    resolveActor: createJourneyUserResolver({
+      clerkAuth: options.clerkAuth,
+      syncJwtSecret: options.platformJwtSecret,
+    }),
+    authenticateRuntime: async ({ runtimeId, bearerToken }) => {
+      const machineId = parseVpsRuntimeId(runtimeId);
+      if (!machineId) return null;
+      const machine = await getUserMachine(options.db, machineId);
+      if (!machine || machine.status !== "running"
+        || !timingSafeTokenEquals(
+          bearerToken,
+          buildPlatformVerificationToken(machine.handle, options.platformSecret),
+        )) {
+        return null;
+      }
+      return { runtimeId, ownerId: machine.clerkUserId };
+    },
+    resolveParticipant: async (actorId) => {
+      const user = await getPlatformUserByClerkId(options.db, actorId);
+      return user ? { actorId, displayName: user.displayName } : null;
+    },
+    resolveRuntime: async (runtimeId) => {
+      const machineId = parseVpsRuntimeId(runtimeId);
+      if (!machineId) return null;
+      const machine = await getUserMachine(options.db, machineId);
+      if (!machine || machine.status !== "running" || !machine.publicIPv4) return null;
+      return {
+        runtimeId,
+        ownerId: machine.clerkUserId,
+        baseUrl: `https://${machine.publicIPv4}:443`,
+      };
+    },
+    fetchImpl: (input, init) => fetch(input, {
+      ...init,
+      signal: init?.signal ?? AbortSignal.timeout(10_000),
+      dispatcher: options.customerVpsProxyDispatcher,
+    } as RequestInit & { dispatcher: import("undici").Dispatcher }),
+  });
+}
+
+function parseVpsRuntimeId(runtimeId: string): string | null {
+  const match = /^vps:([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/.exec(runtimeId);
+  return match?.[1] ?? null;
+}

--- a/packages/platform/src/collaboration/proxy.ts
+++ b/packages/platform/src/collaboration/proxy.ts
@@ -6,6 +6,12 @@ const UUID = "[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f
 const ACTOR = "[A-Za-z0-9_-]{1,128}";
 const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const PROOF_HEADER = "x-matrix-collaboration-proof";
+const RUNTIME = "[A-Za-z0-9:_-]{1,128}";
+
+const RUNTIME_ROUTES = [
+  ["POST", new RegExp(`^/api/collaboration/runtimes/(${RUNTIME})/scopes/preflight$`)],
+  ["POST", new RegExp(`^/api/collaboration/runtimes/(${RUNTIME})/scopes$`)],
+] as const;
 
 const SCOPE_ROUTES = [
   ["GET", new RegExp(`^/api/collaboration/scopes/(${UUID})$`)],
@@ -27,7 +33,7 @@ const INVITATION_ROUTES = [
 ] as const;
 
 export interface ParsedCollaborationProxyRoute {
-  kind: "scope" | "invitation";
+  kind: "runtime" | "scope" | "invitation";
   identifier: string;
 }
 
@@ -35,6 +41,11 @@ export function parseCollaborationProxyRoute(
   method: string,
   path: string,
 ): ParsedCollaborationProxyRoute | null {
+  for (const [allowedMethod, pattern] of RUNTIME_ROUTES) {
+    if (method !== allowedMethod) continue;
+    const match = pattern.exec(path);
+    if (match) return { kind: "runtime", identifier: match[1]! };
+  }
   for (const [allowedMethod, pattern] of SCOPE_ROUTES) {
     if (method !== allowedMethod) continue;
     const match = pattern.exec(path);
@@ -78,15 +89,27 @@ export class CollaborationProxy {
     try {
       const directory = route.kind === "scope"
         ? await this.options.repository.getDirectoryRoute(route.identifier)
-        : await this.options.repository.getInvitationRoute(input.actorId, route.identifier);
-      if (!directory) return safeResponse("Collaboration route not found", 404);
+        : route.kind === "invitation"
+          ? await this.options.repository.getInvitationRoute(input.actorId, route.identifier)
+          : null;
+      let runtime = route.kind === "runtime"
+        ? await this.options.resolveRuntime(route.identifier)
+        : null;
+      if (route.kind === "runtime" && (!runtime || runtime.ownerId !== input.actorId)) {
+        return safeResponse("Collaboration route not found", 404);
+      }
+      if (route.kind !== "runtime" && !directory) return safeResponse("Collaboration route not found", 404);
+      const ownerId = runtime?.ownerId ?? directory!.ownerId;
+      const scopeId = directory?.scopeId;
       const policy = await this.options.repository.getPolicy("m1");
-      const participants = await this.options.repository.listScopeActors(directory.scopeId);
-      if (!policyAllows(policy, input.actorId, directory.ownerId, participants, input.method)) {
+      const participants = scopeId
+        ? await this.options.repository.listScopeActors(scopeId)
+        : [input.actorId];
+      if (!policyAllows(policy, input.actorId, ownerId, participants, input.method)) {
         return safeResponse("Collaboration unavailable", policy.mode === "read_only" ? 403 : 404);
       }
-      const runtime = await this.options.resolveRuntime(directory.runtimeId);
-      if (!runtime || runtime.runtimeId !== directory.runtimeId || runtime.ownerId !== directory.ownerId) {
+      runtime ??= await this.options.resolveRuntime(directory!.runtimeId);
+      if (!runtime || (directory && (runtime.runtimeId !== directory.runtimeId || runtime.ownerId !== directory.ownerId))) {
         return safeResponse("Collaboration unavailable", 503);
       }
       const baseUrl = parseRuntimeBaseUrl(runtime.baseUrl);
@@ -94,9 +117,9 @@ export class CollaborationProxy {
 
       const signedProof = this.options.signer.signHttp({
         actorId: input.actorId,
-        ownerId: directory.ownerId,
-        runtimeId: directory.runtimeId,
-        scopeId: directory.scopeId,
+        ownerId,
+        runtimeId: runtime.runtimeId,
+        ...(scopeId ? { scopeId } : {}),
         method: input.method as "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
         path: input.path,
         query: input.query,

--- a/packages/platform/src/collaboration/repository.ts
+++ b/packages/platform/src/collaboration/repository.ts
@@ -43,6 +43,7 @@ export interface CollaborationDirectoryEntry {
   kind: "chat" | "terminal" | "project";
   authorityGeneration: number;
   status: "invited" | "accepted" | "revoked";
+  invitationId?: string;
 }
 
 export interface CollaborationRolloutPolicyRecord {
@@ -185,6 +186,7 @@ export class PlatformCollaborationRepository {
         "directory.kind",
         "directory.authority_generation",
         "user_index.status",
+        "user_index.invitation_id",
       ])
       .where("user_index.actor_id", "=", actorId)
       .where("user_index.status", "!=", "revoked")
@@ -198,6 +200,7 @@ export class PlatformCollaborationRepository {
       kind: row.kind,
       authorityGeneration: Number(row.authority_generation),
       status: row.status,
+      ...(row.invitation_id === null ? {} : { invitationId: row.invitation_id }),
     }));
   }
 

--- a/packages/platform/src/collaboration/routes.ts
+++ b/packages/platform/src/collaboration/routes.ts
@@ -8,6 +8,7 @@ import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { z } from "zod/v4";
 import type { CollaborationProofSigner } from "./proof.js";
+import { parseCollaborationProxyRoute, type CollaborationProxy } from "./proxy.js";
 import {
   PlatformCollaborationRepositoryError,
   type CollaborationDirectoryEntry,
@@ -30,6 +31,7 @@ export function createPlatformCollaborationRoutes(options: {
   repository: PlatformCollaborationRepository;
   signer: CollaborationProofSigner;
   sockets: CollaborationWebSocketAuthorizer;
+  proxy?: CollaborationProxy;
   resolveActor(c: RouteContext): Promise<string | null>;
   authenticateRuntime(input: {
     runtimeId: string;
@@ -44,6 +46,30 @@ export function createPlatformCollaborationRoutes(options: {
 }): Hono {
   const app = new Hono();
   const now = options.now ?? (() => new Date());
+
+  app.on(
+    ["POST", "PUT", "PATCH", "DELETE"],
+    "/api/collaboration/*",
+    bodyLimit({ maxSize: COLLABORATION_HTTP_BODY_LIMIT, onError: (c) => safeJson(c, "Request too large", 413) }),
+  );
+  app.use("/api/collaboration/*", async (c, next) => {
+    c.header("Cache-Control", "private, no-store");
+    if (!options.proxy || !parseCollaborationProxyRoute(c.req.method, c.req.path)) {
+      await next();
+      return;
+    }
+    const actorId = await resolveValidatedActor(c, options.resolveActor);
+    if (!actorId) return safeJson(c, "Unauthorized", 401);
+    const body = new Uint8Array(await c.req.arrayBuffer());
+    return options.proxy.forward({
+      actorId,
+      method: c.req.method,
+      path: c.req.path,
+      query: new URL(c.req.url).search.slice(1),
+      body,
+      headers: c.req.raw.headers,
+    });
+  });
 
   app.put(
     "/internal/collaboration/directory",
@@ -150,12 +176,23 @@ async function listDiscovery(
   if (!actorId) return safeJson(c, "Unauthorized", 401);
   try {
     const entries = (await options.repository.listForActor(actorId)).filter((entry) => entry.status === status);
-    const resources = await mapLimited(entries, MAX_HYDRATION_CONCURRENCY, async (entry) => ({
-      entry,
-      resource: await options.hydrate({ actorId, entry }),
-    }));
+    const resources = await mapLimited(entries, MAX_HYDRATION_CONCURRENCY, async (entry) => {
+      try {
+        return { entry, resource: await options.hydrate({ actorId, entry }) };
+      } catch (error: unknown) {
+        console.warn(
+          "[platform-collaboration] discovery entry unavailable",
+          error instanceof Error ? error.name : "UnknownError",
+        );
+        return null;
+      }
+    });
     c.header("Cache-Control", "private, no-store");
-    return c.json({ items: resources.map(({ entry, resource }) => ({ ...entry, resource })) });
+    return c.json({
+      items: resources
+        .filter((result): result is NonNullable<typeof result> => result !== null)
+        .map(({ entry, resource }) => ({ ...entry, resource })),
+    });
   } catch (error: unknown) {
     console.warn("[platform-collaboration] discovery hydration failed", error instanceof Error ? error.name : "UnknownError");
     return safeJson(c, "Collaboration unavailable", 503);

--- a/packages/platform/src/collaboration/routes.ts
+++ b/packages/platform/src/collaboration/routes.ts
@@ -1,0 +1,247 @@
+import {
+  COLLABORATION_HTTP_BODY_LIMIT,
+  CollaborationActorIdSchema,
+  CollaborationConnectionTicketRequestSchema,
+  CollaborationDirectoryEventSchema,
+} from "@matrix-os/contracts";
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import type { CollaborationProofSigner } from "./proof.js";
+import {
+  PlatformCollaborationRepositoryError,
+  type CollaborationDirectoryEntry,
+  type PlatformCollaborationRepository,
+} from "./repository.js";
+import {
+  CollaborationWebSocketError,
+  type CollaborationWebSocketAuthorizer,
+} from "./websocket.js";
+
+const MAX_HYDRATION_CONCURRENCY = 4;
+const POLICY_LIFETIME_MS = 30_000;
+const RuntimeIdSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9:_-]+$/);
+const BearerTokenSchema = z.string().min(32).max(4_096).regex(/^[A-Za-z0-9._~-]+$/);
+const MilestoneSchema = z.enum(["m1", "m2", "m3", "m4"]);
+
+type RouteContext = Context;
+
+export function createPlatformCollaborationRoutes(options: {
+  repository: PlatformCollaborationRepository;
+  signer: CollaborationProofSigner;
+  sockets: CollaborationWebSocketAuthorizer;
+  resolveActor(c: RouteContext): Promise<string | null>;
+  authenticateRuntime(input: {
+    runtimeId: string;
+    bearerToken: string;
+  }): Promise<{ runtimeId: string; ownerId: string } | null>;
+  resolveParticipant(actorId: string): Promise<{ actorId: string; displayName: string } | null>;
+  hydrate(input: {
+    actorId: string;
+    entry: CollaborationDirectoryEntry;
+  }): Promise<unknown>;
+  now?: () => Date;
+}): Hono {
+  const app = new Hono();
+  const now = options.now ?? (() => new Date());
+
+  app.put(
+    "/internal/collaboration/directory",
+    bodyLimit({ maxSize: COLLABORATION_HTTP_BODY_LIMIT, onError: (c) => safeJson(c, "Request too large", 413) }),
+    async (c) => {
+      const runtime = await requireRuntime(c, options.authenticateRuntime);
+      if (!runtime) return safeJson(c, "Unauthorized", 401);
+      const event = await parseJson(c, CollaborationDirectoryEventSchema);
+      if (!event) return safeJson(c, "Invalid request", 422);
+      if (event.runtimeId !== runtime.runtimeId || event.ownerId !== runtime.ownerId) {
+        return safeJson(c, "Forbidden", 403);
+      }
+      try {
+        await options.repository.applyDirectoryEvent(event);
+        c.header("Cache-Control", "no-store");
+        return c.body(null, 204);
+      } catch (error: unknown) {
+        return repositoryFailure(c, "directory update", error);
+      }
+    },
+  );
+
+  app.get("/api/collaboration/inbox", async (c) => listDiscovery(c, "invited", options));
+  app.get("/api/collaboration/shared", async (c) => listDiscovery(c, "accepted", options));
+
+  app.post(
+    "/api/collaboration/scopes/:scopeId/connection-tickets",
+    bodyLimit({ maxSize: COLLABORATION_HTTP_BODY_LIMIT, onError: (c) => safeJson(c, "Request too large", 413) }),
+    async (c) => {
+      const actorId = await resolveValidatedActor(c, options.resolveActor);
+      if (!actorId) return safeJson(c, "Unauthorized", 401);
+      const scope = z.uuid().safeParse(c.req.param("scopeId"));
+      const request = await parseJson(c, CollaborationConnectionTicketRequestSchema);
+      if (!scope.success || !request) return safeJson(c, "Invalid request", 422);
+      try {
+        const ticket = await options.sockets.issueTicket({
+          actorId,
+          scopeId: scope.data,
+          purpose: request.purpose,
+          clientRequestId: request.clientRequestId,
+        });
+        c.header("Cache-Control", "no-store");
+        return c.json(ticket, 201);
+      } catch (error: unknown) {
+        return socketFailure(c, "ticket issue", error);
+      }
+    },
+  );
+
+  app.get("/internal/collaboration/participants/:actorId", async (c) => {
+    const runtime = await requireRuntime(c, options.authenticateRuntime);
+    if (!runtime) return safeJson(c, "Unauthorized", 401);
+    const actor = CollaborationActorIdSchema.safeParse(c.req.param("actorId"));
+    if (!actor.success) return safeJson(c, "Invalid request", 422);
+    try {
+      const participant = await options.resolveParticipant(actor.data);
+      const parsed = z.object({
+        actorId: CollaborationActorIdSchema,
+        displayName: z.string().trim().min(1).max(120),
+      }).strict().safeParse(participant);
+      if (!parsed.success || parsed.data.actorId !== actor.data) {
+        return safeJson(c, "Participant not found", 404);
+      }
+      c.header("Cache-Control", "private, no-store");
+      return c.json(parsed.data);
+    } catch (error: unknown) {
+      console.warn("[platform-collaboration] participant lookup failed", error instanceof Error ? error.name : "UnknownError");
+      return safeJson(c, "Collaboration unavailable", 503);
+    }
+  });
+
+  app.get("/internal/collaboration/policy", async (c) => {
+    const runtime = await requireRuntime(c, options.authenticateRuntime);
+    if (!runtime) return safeJson(c, "Unauthorized", 401);
+    const milestone = MilestoneSchema.safeParse(c.req.query("milestone"));
+    if (!milestone.success) return safeJson(c, "Invalid request", 422);
+    try {
+      const stored = await options.repository.getPolicy(milestone.data);
+      const issuedAt = now();
+      const signed = options.signer.signPolicy({
+        milestone: stored.milestone,
+        revision: String(stored.revision),
+        mode: stored.mode,
+        cohort: stored.cohort,
+        issuedAt: issuedAt.toISOString(),
+        expiresAt: new Date(issuedAt.getTime() + POLICY_LIFETIME_MS).toISOString(),
+      });
+      c.header("Cache-Control", "private, no-store");
+      return c.json(signed);
+    } catch (error: unknown) {
+      return repositoryFailure(c, "policy lookup", error);
+    }
+  });
+
+  return app;
+}
+
+async function listDiscovery(
+  c: RouteContext,
+  status: "invited" | "accepted",
+  options: Parameters<typeof createPlatformCollaborationRoutes>[0],
+) {
+  const actorId = await resolveValidatedActor(c, options.resolveActor);
+  if (!actorId) return safeJson(c, "Unauthorized", 401);
+  try {
+    const entries = (await options.repository.listForActor(actorId)).filter((entry) => entry.status === status);
+    const resources = await mapLimited(entries, MAX_HYDRATION_CONCURRENCY, async (entry) => ({
+      entry,
+      resource: await options.hydrate({ actorId, entry }),
+    }));
+    c.header("Cache-Control", "private, no-store");
+    return c.json({ items: resources.map(({ entry, resource }) => ({ ...entry, resource })) });
+  } catch (error: unknown) {
+    console.warn("[platform-collaboration] discovery hydration failed", error instanceof Error ? error.name : "UnknownError");
+    return safeJson(c, "Collaboration unavailable", 503);
+  }
+}
+
+async function requireRuntime(
+  c: RouteContext,
+  authenticate: Parameters<typeof createPlatformCollaborationRoutes>[0]["authenticateRuntime"],
+) {
+  const runtimeId = RuntimeIdSchema.safeParse(c.req.header("x-matrix-runtime-id"));
+  const authorization = c.req.header("authorization");
+  const bearer = BearerTokenSchema.safeParse(
+    authorization?.startsWith("Bearer ") ? authorization.slice("Bearer ".length) : undefined,
+  );
+  if (!runtimeId.success || !bearer.success) return null;
+  try {
+    return await authenticate({ runtimeId: runtimeId.data, bearerToken: bearer.data });
+  } catch (error: unknown) {
+    console.warn("[platform-collaboration] runtime authentication failed", error instanceof Error ? error.name : "UnknownError");
+    return null;
+  }
+}
+
+async function resolveValidatedActor(
+  c: RouteContext,
+  resolveActor: Parameters<typeof createPlatformCollaborationRoutes>[0]["resolveActor"],
+): Promise<string | null> {
+  try {
+    const parsed = CollaborationActorIdSchema.safeParse(await resolveActor(c));
+    return parsed.success ? parsed.data : null;
+  } catch (error: unknown) {
+    console.warn("[platform-collaboration] actor authentication failed", error instanceof Error ? error.name : "UnknownError");
+    return null;
+  }
+}
+
+async function parseJson<T>(c: RouteContext, schema: z.ZodType<T>): Promise<T | null> {
+  try {
+    const parsed = schema.safeParse(await c.req.json());
+    return parsed.success ? parsed.data : null;
+  } catch (error: unknown) {
+    if (!(error instanceof SyntaxError)) {
+      console.warn("[platform-collaboration] request parsing failed", error instanceof Error ? error.name : "UnknownError");
+    }
+    return null;
+  }
+}
+
+async function mapLimited<T, R>(items: readonly T[], concurrency: number, mapper: (item: T) => Promise<R>): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await mapper(items[index]!);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+function repositoryFailure(c: RouteContext, operation: string, error: unknown) {
+  if (error instanceof PlatformCollaborationRepositoryError && error.code === "conflict") {
+    return safeJson(c, "Collaboration state changed", 409);
+  }
+  console.warn(`[platform-collaboration] ${operation} failed`, error instanceof Error ? error.name : "UnknownError");
+  return safeJson(c, "Collaboration unavailable", 503);
+}
+
+function socketFailure(c: RouteContext, operation: string, error: unknown) {
+  if (error instanceof CollaborationWebSocketError) {
+    if (error.code === "unavailable") return safeJson(c, "Collaboration unavailable", 404);
+    if (error.code === "disabled") return safeJson(c, "Collaboration unavailable", 403);
+    if (error.code === "invalid_ticket" || error.code === "invalid_route") {
+      return safeJson(c, "Invalid request", 422);
+    }
+  }
+  if (error instanceof PlatformCollaborationRepositoryError && error.code === "capacity") {
+    return safeJson(c, "Too many pending connections", 429);
+  }
+  console.warn(`[platform-collaboration] ${operation} failed`, error instanceof Error ? error.name : "UnknownError");
+  return safeJson(c, "Collaboration unavailable", 503);
+}
+
+function safeJson(c: RouteContext, error: string, status: 401 | 403 | 404 | 409 | 413 | 422 | 429 | 503) {
+  c.header("Cache-Control", "no-store");
+  return c.json({ error }, status);
+}

--- a/packages/platform/src/collaboration/websocket.ts
+++ b/packages/platform/src/collaboration/websocket.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import type { IncomingMessage } from "node:http";
 import {
   CollaborationConnectionTicketRequestSchema,
   CollaborationConnectionTicketResponseSchema,
@@ -16,6 +17,14 @@ const COLLABORATION_SOCKET_PATH = new RegExp(
 const TICKET_LIFETIME_MS = 30_000;
 const MAX_RAW_PATH_LENGTH = 1_024;
 const MAX_ALLOWED_ORIGINS = 16;
+const FORWARDED_SOCKET_HEADERS = new Set([
+  "connection",
+  "upgrade",
+  "sec-websocket-key",
+  "sec-websocket-version",
+  "sec-websocket-protocol",
+  "sec-websocket-extensions",
+]);
 
 type SignedProof = ReturnType<CollaborationProofSigner["signSocket"]>;
 type Purpose = "events" | "terminal";
@@ -41,6 +50,47 @@ export interface CollaborationWebSocketUpgrade {
   scopeId: string;
   purpose: Purpose;
   signedProof: SignedProof;
+}
+
+export function isCollaborationWebSocketPath(rawPath: string): boolean {
+  if (rawPath.length > MAX_RAW_PATH_LENGTH || /[\r\n]/.test(rawPath)) return false;
+  try {
+    return COLLABORATION_SOCKET_PATH.test(new URL(rawPath, "https://platform.invalid").pathname);
+  } catch (error: unknown) {
+    if (!(error instanceof TypeError)) {
+      console.warn("[collaboration-websocket] path classification failed", error instanceof Error ? error.name : "UnknownError");
+    }
+    return false;
+  }
+}
+
+export function isCollaborationWebSocketCandidate(rawPath: string): boolean {
+  if (rawPath.length > MAX_RAW_PATH_LENGTH || /[\r\n]/.test(rawPath)) return false;
+  try {
+    return new URL(rawPath, "https://platform.invalid").pathname.startsWith("/ws/collaboration/");
+  } catch (error: unknown) {
+    if (!(error instanceof TypeError)) {
+      console.warn("[collaboration-websocket] candidate classification failed", error instanceof Error ? error.name : "UnknownError");
+    }
+    return false;
+  }
+}
+
+export function buildCollaborationWebSocketUpgradeHeaders(input: {
+  incomingHeaders: IncomingMessage["headers"];
+  externalHost: string;
+  signedProof: unknown;
+}): string {
+  const headers = Object.entries(input.incomingHeaders).flatMap(([name, raw]) => {
+    if (!FORWARDED_SOCKET_HEADERS.has(name) || raw === undefined) return [];
+    const value = Array.isArray(raw) ? raw.join(", ") : raw;
+    if (value.length > 8_192 || /[\r\n]/.test(value)) return [];
+    return `${name}: ${value}`;
+  });
+  headers.push(`x-forwarded-host: ${input.externalHost}`);
+  headers.push("x-forwarded-proto: https");
+  headers.push(`x-matrix-collaboration-proof: ${Buffer.from(JSON.stringify(input.signedProof)).toString("base64url")}`);
+  return headers.join("\r\n");
 }
 
 export class CollaborationWebSocketAuthorizer {

--- a/packages/platform/src/collaboration/wiring.ts
+++ b/packages/platform/src/collaboration/wiring.ts
@@ -1,0 +1,139 @@
+import type { Context, Hono } from "hono";
+import type { Kysely } from "kysely";
+import { bootstrapPlatformCollaborationDatabase, type CollaborationPlatformDatabase } from "./database.js";
+import { CollaborationProofSigner } from "./proof.js";
+import { CollaborationProxy, type CollaborationRuntimeRoute } from "./proxy.js";
+import { PlatformCollaborationRepository } from "./repository.js";
+import { createPlatformCollaborationRoutes } from "./routes.js";
+import { CollaborationWebSocketAuthorizer } from "./websocket.js";
+
+const MAX_PROOF_KEYS = 8;
+const MAX_ALLOWED_ORIGINS = 16;
+
+export interface PlatformCollaborationConfig {
+  activeKeyId: string;
+  proofKeys: Readonly<Record<string, string>>;
+  allowedOrigins: readonly string[];
+  enabledPurposes: readonly ["events"];
+}
+
+export function loadPlatformCollaborationConfig(env: NodeJS.ProcessEnv): PlatformCollaborationConfig | null {
+  if (env.MATRIX_COLLABORATION_ENABLED !== "true") return null;
+  const activeKeyId = env.MATRIX_COLLABORATION_ACTIVE_KEY_ID?.trim();
+  const allowedOrigins = [...new Set((env.MATRIX_COLLABORATION_ALLOWED_ORIGINS ?? "")
+    .split(",").map((value) => value.trim()).filter(Boolean))];
+  if (!activeKeyId || allowedOrigins.length < 1 || allowedOrigins.length > MAX_ALLOWED_ORIGINS) return null;
+  let proofKeys: Record<string, string>;
+  try {
+    const parsed = JSON.parse(env.MATRIX_COLLABORATION_PROOF_KEYS ?? "null") as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    proofKeys = Object.fromEntries(Object.entries(parsed).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ));
+  } catch (error: unknown) {
+    if (!(error instanceof SyntaxError)) {
+      console.warn("[platform-collaboration] proof key configuration parse failed", error instanceof Error ? error.name : "UnknownError");
+    }
+    return null;
+  }
+  const keys = Object.entries(proofKeys);
+  if (keys.length < 1 || keys.length > MAX_PROOF_KEYS
+    || keys.some(([keyId, key]) => !/^[A-Za-z0-9_.-]{1,80}$/.test(keyId) || Buffer.byteLength(key) < 32)
+    || !proofKeys[activeKeyId]) return null;
+  try {
+    const origins = allowedOrigins.map((value) => requireOrigin(value));
+    return { activeKeyId, proofKeys, allowedOrigins: origins, enabledPurposes: ["events"] };
+  } catch (error: unknown) {
+    console.warn("[platform-collaboration] origin configuration rejected", error instanceof Error ? error.name : "UnknownError");
+    return null;
+  }
+}
+
+export async function createPlatformCollaboration(options: {
+  db: Kysely<CollaborationPlatformDatabase>;
+  config: PlatformCollaborationConfig;
+  resolveActor(c: Context): Promise<string | null>;
+  authenticateRuntime(input: {
+    runtimeId: string;
+    bearerToken: string;
+  }): Promise<{ runtimeId: string; ownerId: string } | null>;
+  resolveParticipant(actorId: string): Promise<{ actorId: string; displayName: string } | null>;
+  resolveRuntime(runtimeId: string): Promise<CollaborationRuntimeRoute | null>;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+}) {
+  await bootstrapPlatformCollaborationDatabase(options.db);
+  const repository = new PlatformCollaborationRepository(options.db, { now: options.now });
+  const signer = new CollaborationProofSigner({
+    activeKeyId: options.config.activeKeyId,
+    keys: options.config.proofKeys,
+    now: options.now,
+  });
+  const sockets = new CollaborationWebSocketAuthorizer({
+    repository,
+    signer,
+    allowedOrigins: options.config.allowedOrigins,
+    enabledPurposes: options.config.enabledPurposes,
+    now: options.now,
+  });
+  const proxy = new CollaborationProxy({
+    repository,
+    signer,
+    resolveRuntime: options.resolveRuntime,
+    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+  });
+  const hydrate = async (input: { actorId: string; entry: import("./repository.js").CollaborationDirectoryEntry }) => {
+    const path = input.entry.status === "invited" && input.entry.invitationId
+      ? `/api/collaboration/invitations/${input.entry.invitationId}`
+      : `/api/collaboration/scopes/${input.entry.scopeId}`;
+    const response = await proxy.forward({
+      actorId: input.actorId,
+      method: "GET",
+      path,
+      query: "",
+      body: new Uint8Array(),
+      headers: new Headers({ accept: "application/json" }),
+    });
+    if (!response.ok) throw new Error("Collaboration projection unavailable");
+    return response.json() as Promise<unknown>;
+  };
+  const routes = createPlatformCollaborationRoutes({
+    repository,
+    signer,
+    sockets,
+    proxy,
+    resolveActor: options.resolveActor,
+    authenticateRuntime: options.authenticateRuntime,
+    resolveParticipant: options.resolveParticipant,
+    hydrate,
+    now: options.now,
+  });
+  let registered = false;
+  let closing = false;
+
+  return {
+    repository,
+    signer,
+    sockets,
+    proxy,
+    register(app: Hono<any>): void {
+      if (registered || closing) throw new Error("Platform collaboration routes are already registered or shutting down");
+      registered = true;
+      app.route("/", routes);
+    },
+    async shutdown(): Promise<void> {
+      if (closing) return;
+      closing = true;
+    },
+  };
+}
+
+export type PlatformCollaborationRuntime = Awaited<ReturnType<typeof createPlatformCollaboration>>;
+
+function requireOrigin(value: string): string {
+  const parsed = new URL(value);
+  if (!parsed.hostname || !["https:", "http:"].includes(parsed.protocol)
+    || parsed.username || parsed.password || parsed.pathname !== "/" || parsed.search || parsed.hash
+    || parsed.origin !== value) throw new Error("Invalid collaboration origin");
+  return parsed.origin;
+}

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -125,6 +125,7 @@ import {
   collectTenantPublicTelemetryEnv,
 } from './platform-startup-env.js';
 import type { PlatformApp } from './platform-app-types.js';
+import type { PlatformCollaborationRuntime } from './collaboration/wiring.js';
 export { escapeInlineScriptJson } from './auth-pages.js';
 export { buildPostAuthRedirectPath } from './request-routing.js';
 export type { PlatformApp } from './platform-app-types.js';
@@ -249,8 +250,8 @@ export function createApp(deps: {
   internalFundedAiRuntimeRoutes?: Hono<any>;
   internalFundedAiRelayRoutes?: Hono<any>;
   internalFundedAiOperatorRoutes?: Hono<any>;
-  internalCollaborationRoutes?: Hono<any>;
   fundedAiRepository?: import('./ai-funded-policy-repository.js').AiFundedPolicyRepository;
+  collaboration?: PlatformCollaborationRuntime;
   customerVpsService?: CustomerVpsService;
   goldenSnapshotService?: GoldenSnapshotService;
   goldenSnapshotConfig?: GoldenSnapshotRuntimeConfig;
@@ -587,9 +588,9 @@ export function createApp(deps: {
     }));
   }
 
-  if (deps.internalCollaborationRoutes) {
-    app.route('/', deps.internalCollaborationRoutes);
-  }
+  // Collaboration routes must precede personal session routing so recipients
+  // without a provisioned computer reach the owner's registered authority.
+  deps.collaboration?.register(app);
 
   // Session-based routing:
   // - app.matrix-os.com -> Clerk session -> Matrix OS shell/gateway

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -8,15 +8,12 @@ import type { Hono, Context } from 'hono';
 import type { Server } from 'node:http';
 import type Dockerode from 'dockerode';
 import type { Agent } from 'undici';
-import type { Kysely } from 'kysely';
 import { randomBytes } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import {
   createPlatformDb,
   getContainer,
-  getPlatformUserByClerkId,
   getRunningUserMachineByHandle,
-  getUserMachine,
   listContainers,
   sweepStaleCheckoutAttempts,
   updateContainerStatus,
@@ -39,7 +36,7 @@ import {
   loadPlatformRuntimeConfig,
 } from './runtime-mode.js';
 import { resolvePlatformIntegrationConfig } from './integration-config.js';
-import { buildPlatformVerificationToken, timingSafeTokenEquals } from './platform-token.js';
+import { buildPlatformVerificationToken } from './platform-token.js';
 import { buildCustomMcpProjectionUrl } from './custom-mcp-projection.js';
 import { backfillFirstRunRecords } from './journey.js';
 import { logPlatformRouteError } from './platform-route-utils.js';
@@ -59,13 +56,8 @@ import {
   createStorageGatedHetznerClient,
   type R2CapabilityGate,
 } from './r2-capability.js';
-import { createJourneyUserResolver } from './journey-routes.js';
-import type { CollaborationPlatformDatabase } from './collaboration/database.js';
-import {
-  createPlatformCollaboration,
-  loadPlatformCollaborationConfig,
-  type PlatformCollaborationRuntime,
-} from './collaboration/wiring.js';
+import { bootstrapPlatformCollaboration } from './collaboration/bootstrap.js';
+import type { PlatformCollaborationRuntime } from './collaboration/wiring.js';
 
 interface GatewayPlatformUser {
   id: string;
@@ -400,49 +392,14 @@ async function startPlatformServerWithCleanup(
     });
   }
 
-  const collaborationConfig = loadPlatformCollaborationConfig(process.env);
-  if (process.env.MATRIX_COLLABORATION_ENABLED === 'true' && !collaborationConfig) {
-    throw new Error('Platform collaboration configuration is incomplete');
-  }
-  let collaboration: PlatformCollaborationRuntime | undefined;
-  if (collaborationConfig) {
-    if (!platformSecret) throw new Error('Platform collaboration runtime authentication is unavailable');
-    collaboration = await createPlatformCollaboration({
-      db: db.kysely as unknown as Kysely<CollaborationPlatformDatabase>,
-      config: collaborationConfig,
-      resolveActor: createJourneyUserResolver({ clerkAuth, syncJwtSecret: platformJwtSecret }),
-      authenticateRuntime: async ({ runtimeId, bearerToken }) => {
-        const machineId = parseVpsRuntimeId(runtimeId);
-        if (!machineId) return null;
-        const machine = await getUserMachine(db, machineId);
-        if (!machine || machine.status !== 'running'
-          || !timingSafeTokenEquals(bearerToken, buildPlatformVerificationToken(machine.handle, platformSecret))) {
-          return null;
-        }
-        return { runtimeId, ownerId: machine.clerkUserId };
-      },
-      resolveParticipant: async (actorId) => {
-        const user = await getPlatformUserByClerkId(db, actorId);
-        return user ? { actorId, displayName: user.displayName } : null;
-      },
-      resolveRuntime: async (runtimeId) => {
-        const machineId = parseVpsRuntimeId(runtimeId);
-        if (!machineId) return null;
-        const machine = await getUserMachine(db, machineId);
-        if (!machine || machine.status !== 'running' || !machine.publicIPv4) return null;
-        return {
-          runtimeId,
-          ownerId: machine.clerkUserId,
-          baseUrl: `https://${machine.publicIPv4}:443`,
-        };
-      },
-      fetchImpl: (input, init) => fetch(input, {
-        ...init,
-        signal: init?.signal ?? AbortSignal.timeout(10_000),
-        dispatcher: customerVpsProxyDispatcher,
-      } as RequestInit & { dispatcher: import('undici').Dispatcher }),
-    });
-  }
+  const collaboration = await bootstrapPlatformCollaboration({
+    env: process.env,
+    db,
+    platformSecret,
+    platformJwtSecret,
+    clerkAuth,
+    customerVpsProxyDispatcher,
+  });
 
   let matrixProvisioner: MatrixProvisioner | undefined;
   const homeserverUrl = process.env.MATRIX_HOMESERVER_URL;
@@ -1246,9 +1203,4 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
     }
     throw startupError;
   }
-}
-
-function parseVpsRuntimeId(runtimeId: string): string | null {
-  const match = /^vps:([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/.exec(runtimeId);
-  return match?.[1] ?? null;
 }

--- a/packages/platform/src/platform-startup.ts
+++ b/packages/platform/src/platform-startup.ts
@@ -59,9 +59,13 @@ import {
   createStorageGatedHetznerClient,
   type R2CapabilityGate,
 } from './r2-capability.js';
-import { bootstrapPlatformCollaborationDatabase, type CollaborationPlatformDatabase } from './collaboration/database.js';
-import { createInternalCollaborationRoutes } from './collaboration/internal-routes.js';
-import { PlatformCollaborationRepository } from './collaboration/repository.js';
+import { createJourneyUserResolver } from './journey-routes.js';
+import type { CollaborationPlatformDatabase } from './collaboration/database.js';
+import {
+  createPlatformCollaboration,
+  loadPlatformCollaborationConfig,
+  type PlatformCollaborationRuntime,
+} from './collaboration/wiring.js';
 
 interface GatewayPlatformUser {
   id: string;
@@ -205,8 +209,8 @@ type CreatePlatformApp = (deps: {
   internalFundedAiRuntimeRoutes?: Hono<any>;
   internalFundedAiRelayRoutes?: Hono<any>;
   internalFundedAiOperatorRoutes?: Hono<any>;
-  internalCollaborationRoutes?: Hono<any>;
   fundedAiRepository?: AiFundedPolicyRepository;
+  collaboration?: PlatformCollaborationRuntime;
   customerVpsService?: CustomerVpsService;
   goldenSnapshotService?: GoldenSnapshotService;
   goldenSnapshotConfig?: GoldenSnapshotRuntimeConfig;
@@ -300,29 +304,6 @@ async function startPlatformServerWithCleanup(
   const atsDatabaseUrl = resolveAtsDatabaseUrl(process.env);
   const db = createPlatformDb(runtimeConfig.platformDatabaseUrl);
   await db.ready;
-  let internalCollaborationRoutes: Hono | undefined;
-  if (process.env.MATRIX_COLLABORATION_ENABLED === 'true') {
-    if (!platformSecret) throw new Error('Platform collaboration runtime authentication is unavailable');
-    const collaborationDb = db.kysely as unknown as Kysely<CollaborationPlatformDatabase>;
-    await bootstrapPlatformCollaborationDatabase(collaborationDb);
-    internalCollaborationRoutes = createInternalCollaborationRoutes({
-      repository: new PlatformCollaborationRepository(collaborationDb),
-      authenticateRuntime: async ({ runtimeId, bearerToken }) => {
-        const machineId = parseCollaborationRuntimeId(runtimeId);
-        if (!machineId) return null;
-        const machine = await getUserMachine(db, machineId);
-        if (!machine || machine.status !== 'running'
-          || !timingSafeTokenEquals(bearerToken, buildPlatformVerificationToken(machine.handle, platformSecret))) {
-          return null;
-        }
-        return { runtimeId, ownerId: machine.clerkUserId };
-      },
-      resolveParticipant: async (actorId) => {
-        const user = await getPlatformUserByClerkId(db, actorId);
-        return user ? { actorId, displayName: user.displayName } : null;
-      },
-    });
-  }
   const fundedAiConfig = loadAiFundedControlPlaneConfig({
     ...process.env,
     PLATFORM_SECRET: platformSecret,
@@ -416,6 +397,50 @@ async function startPlatformServerWithCleanup(
         return payload as { sub: string; [key: string]: unknown };
       },
       revokeSession: createClerkSessionRevoker({ secretKey: clerkSecretKey }),
+    });
+  }
+
+  const collaborationConfig = loadPlatformCollaborationConfig(process.env);
+  if (process.env.MATRIX_COLLABORATION_ENABLED === 'true' && !collaborationConfig) {
+    throw new Error('Platform collaboration configuration is incomplete');
+  }
+  let collaboration: PlatformCollaborationRuntime | undefined;
+  if (collaborationConfig) {
+    if (!platformSecret) throw new Error('Platform collaboration runtime authentication is unavailable');
+    collaboration = await createPlatformCollaboration({
+      db: db.kysely as unknown as Kysely<CollaborationPlatformDatabase>,
+      config: collaborationConfig,
+      resolveActor: createJourneyUserResolver({ clerkAuth, syncJwtSecret: platformJwtSecret }),
+      authenticateRuntime: async ({ runtimeId, bearerToken }) => {
+        const machineId = parseVpsRuntimeId(runtimeId);
+        if (!machineId) return null;
+        const machine = await getUserMachine(db, machineId);
+        if (!machine || machine.status !== 'running'
+          || !timingSafeTokenEquals(bearerToken, buildPlatformVerificationToken(machine.handle, platformSecret))) {
+          return null;
+        }
+        return { runtimeId, ownerId: machine.clerkUserId };
+      },
+      resolveParticipant: async (actorId) => {
+        const user = await getPlatformUserByClerkId(db, actorId);
+        return user ? { actorId, displayName: user.displayName } : null;
+      },
+      resolveRuntime: async (runtimeId) => {
+        const machineId = parseVpsRuntimeId(runtimeId);
+        if (!machineId) return null;
+        const machine = await getUserMachine(db, machineId);
+        if (!machine || machine.status !== 'running' || !machine.publicIPv4) return null;
+        return {
+          runtimeId,
+          ownerId: machine.clerkUserId,
+          baseUrl: `https://${machine.publicIPv4}:443`,
+        };
+      },
+      fetchImpl: (input, init) => fetch(input, {
+        ...init,
+        signal: init?.signal ?? AbortSignal.timeout(10_000),
+        dispatcher: customerVpsProxyDispatcher,
+      } as RequestInit & { dispatcher: import('undici').Dispatcher }),
     });
   }
 
@@ -1108,8 +1133,8 @@ async function startPlatformServerWithCleanup(
     internalFundedAiRuntimeRoutes,
     internalFundedAiRelayRoutes,
     internalFundedAiOperatorRoutes,
-    internalCollaborationRoutes,
     fundedAiRepository,
+    collaboration,
     customerVpsService,
     goldenSnapshotService,
     goldenSnapshotConfig,
@@ -1161,6 +1186,7 @@ async function startPlatformServerWithCleanup(
         }
         if (goldenSnapshotPromise) await goldenSnapshotPromise;
         await Promise.allSettled([
+          collaboration?.shutdown(),
           containerProxyDispatcher.close(),
           customerVpsProxyDispatcher.close(),
           customMcpShutdown?.(),
@@ -1199,6 +1225,7 @@ async function startPlatformServerWithCleanup(
     codeServerPort,
     getRuntimeEntitlementDecision,
     getRuntimeEntitlementDecisionForUser,
+    collaborationSockets: collaboration?.sockets,
   });
 }
 
@@ -1221,7 +1248,7 @@ export async function startPlatformServer(opts: StartPlatformServerOptions): Pro
   }
 }
 
-function parseCollaborationRuntimeId(runtimeId: string): string | null {
+function parseVpsRuntimeId(runtimeId: string): string | null {
   const match = /^vps:([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/.exec(runtimeId);
   return match?.[1] ?? null;
 }

--- a/packages/platform/src/platform-websocket-upgrade.ts
+++ b/packages/platform/src/platform-websocket-upgrade.ts
@@ -14,6 +14,7 @@ import {
   getContainer,
   getAccessibleRunningUserMachineByClerkId,
   getRunningUserMachineByHandle,
+  getUserMachine,
 } from './db.js';
 import { canClerkUserAccessMachine } from './customer-vps-preview.js';
 import type { EntitlementAccessDecision } from './profile-routing.js';
@@ -45,6 +46,13 @@ import { resolveContainerEndpoint } from './container-endpoint.js';
 import { describeError } from './platform-route-utils.js';
 import { shouldVerifyCustomerVpsTls } from './customer-vps-tls.js';
 import { handleInternalGeminiLiveProxyUpgrade } from './gemini-live-proxy.js';
+import {
+  buildCollaborationWebSocketUpgradeHeaders,
+  isCollaborationWebSocketCandidate,
+  isCollaborationWebSocketPath,
+  type CollaborationWebSocketAuthorizer,
+  type CollaborationWebSocketUpgrade,
+} from './collaboration/websocket.js';
 
 interface PlatformWebSocketTelemetry {
   capturePlatformEvent(event: MatrixTelemetryEvent, properties: Record<string, unknown>): void;
@@ -75,6 +83,7 @@ export interface RegisterPlatformWebSocketUpgradeHandlerOpts {
     runtimeSlot?: string,
     provisioningClass?: string,
   ): Promise<EntitlementAccessDecision>;
+  collaborationSockets?: CollaborationWebSocketAuthorizer;
 }
 
 export function registerPlatformWebSocketUpgradeHandler(
@@ -93,6 +102,7 @@ export function registerPlatformWebSocketUpgradeHandler(
     codeServerPort,
     getRuntimeEntitlementDecision,
     getRuntimeEntitlementDecisionForUser,
+    collaborationSockets,
   } = opts;
 
   server.on('upgrade', async (req: IncomingMessage, socket, head) => {
@@ -130,9 +140,15 @@ export function registerPlatformWebSocketUpgradeHandler(
     }
     const isCodeDomain = isCodeDomainHost(host);
     const isAppDomain = isAppDomainHost(host);
+    const isCollaborationCandidate = isAppDomain && isCollaborationWebSocketCandidate(path);
+    const isCollaborationSocket = isAppDomain && isCollaborationWebSocketPath(path);
+    if (isCollaborationCandidate && !isCollaborationSocket) {
+      socket.destroy();
+      return;
+    }
     const hostClass = classifySessionRoutedHost(host);
     const explicitVmRoute = isAppDomain ? readExplicitVmWebSocketRoute(path) : null;
-    const webSocketProxyPath = explicitVmRoute
+    let webSocketProxyPath = explicitVmRoute
       ? buildExplicitVmWebSocketUpstreamPath(path)
       : path;
     const pathClass = classifyWebSocketPath(webSocketProxyPath);
@@ -164,6 +180,7 @@ export function registerPlatformWebSocketUpgradeHandler(
         requestedHandle: explicitVmRoute?.handle,
         runtimeSlot: requestRuntimeSlot,
         wsToken,
+        clerkPrincipalOnly: isCollaborationSocket,
       });
       if (
         !identity
@@ -204,10 +221,38 @@ export function registerPlatformWebSocketUpgradeHandler(
       return;
     }
 
+    let collaborationUpgrade: CollaborationWebSocketUpgrade | undefined;
     let runtimeSlot = identity.runtimeSlot ?? requestRuntimeSlot;
     let requestedActiveMachine: UserMachineRecord | undefined;
     let runningMachine: UserMachineRecord | undefined;
-    if (explicitVmRoute) {
+    if (isCollaborationSocket) {
+      if (!collaborationSockets || !identity.userId) {
+        socket.destroy();
+        return;
+      }
+      try {
+        collaborationUpgrade = await collaborationSockets.authorizeUpgrade({
+          actorId: identity.userId,
+          authentication: collaborationAuthentication(path, req.headers.authorization),
+          rawPath: path,
+          origin: firstHeader(req.headers.origin),
+        });
+      } catch (err: unknown) {
+        console.warn(`[platform] collaboration websocket authorization failed error=${describeError(err)}`);
+        socket.destroy();
+        return;
+      }
+      const machineId = parseCollaborationRuntimeId(collaborationUpgrade.runtimeId);
+      const authorityMachine = machineId ? await getUserMachine(db, machineId) : undefined;
+      if (!authorityMachine || authorityMachine.status !== 'running' || !authorityMachine.publicIPv4
+        || authorityMachine.clerkUserId !== collaborationUpgrade.ownerId) {
+        socket.destroy();
+        return;
+      }
+      runningMachine = authorityMachine;
+      runtimeSlot = authorityMachine.runtimeSlot;
+      webSocketProxyPath = collaborationUpgrade.upstreamPath;
+    } else if (explicitVmRoute) {
       const explicitMachine = await getRunningUserMachineByHandle(
         db,
         explicitVmRoute.handle,
@@ -261,7 +306,13 @@ export function registerPlatformWebSocketUpgradeHandler(
     socket.on('error', onSocketError);
 
     const buildUpgradeHeaders = (handle: string, includePlatformProof: boolean): string => (
-      buildPlatformWebSocketUpgradeHeaders({
+      collaborationUpgrade
+        ? buildCollaborationWebSocketUpgradeHeaders({
+            incomingHeaders: req.headers,
+            externalHost: host,
+            signedProof: collaborationUpgrade.signedProof,
+          })
+        : buildPlatformWebSocketUpgradeHeaders({
         incomingHeaders: req.headers,
         externalHost: host,
         handle,
@@ -392,4 +443,27 @@ export function registerPlatformWebSocketUpgradeHandler(
       socket.destroy();
     });
   });
+}
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function collaborationAuthentication(
+  rawPath: string,
+  authorization: string | string[] | undefined,
+): 'session' | 'bearer' | 'ticket' {
+  try {
+    if (new URL(rawPath, 'https://platform.invalid').searchParams.has('ticket')) return 'ticket';
+  } catch (err: unknown) {
+    if (!(err instanceof TypeError)) {
+      console.warn('[platform] collaboration websocket credential parse failed:', describeError(err));
+    }
+  }
+  return firstHeader(authorization)?.startsWith('Bearer ') ? 'bearer' : 'session';
+}
+
+function parseCollaborationRuntimeId(runtimeId: string): string | null {
+  const match = /^vps:([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/.exec(runtimeId);
+  return match?.[1] ?? null;
 }

--- a/tests/gateway/collaboration-chat-scope.test.ts
+++ b/tests/gateway/collaboration-chat-scope.test.ts
@@ -70,7 +70,7 @@ describe("CollaborationChatScopeService", () => {
       .select(["scope_id", "recipient_actor_ids", "discovery_state"])
       .execute()).toEqual([{
       scope_id: collaborationIds.scope,
-      recipient_actor_ids: [collaborationActors.owner],
+      recipient_actor_ids: [{ actorId: collaborationActors.owner }],
       discovery_state: "accepted",
     }]);
   });

--- a/tests/gateway/collaboration-directory-outbox.test.ts
+++ b/tests/gateway/collaboration-directory-outbox.test.ts
@@ -78,7 +78,11 @@ describe("CollaborationDirectoryOutbox", () => {
       kind: "chat",
       authorityGeneration: 1,
       metadataRevision: 1,
-      recipients: [{ actorId: collaborationActors.editor, status: "invited" }],
+      recipients: [{
+        actorId: collaborationActors.editor,
+        status: "invited",
+        invitationId: collaborationIds.invitation,
+      }],
     });
     expect(JSON.stringify(payload)).not.toMatch(/title|message|content|transcript/i);
     expect(await fixture.db.selectFrom("collaboration_directory_outbox")
@@ -189,7 +193,10 @@ async function seedScopeAndOutbox(fixture: CollaborationTestDatabase): Promise<v
   await fixture.db.insertInto("collaboration_directory_outbox").values({
     event_id: "60000000-0000-4000-8000-000000000001",
     scope_id: collaborationIds.scope,
-    recipient_actor_ids: JSON.stringify([collaborationActors.editor]),
+    recipient_actor_ids: JSON.stringify([{
+      actorId: collaborationActors.editor,
+      invitationId: collaborationIds.invitation,
+    }]),
     authority_runtime_id: collaborationIds.runtime,
     authority_generation: 1,
     resource_kind: "chat",

--- a/tests/gateway/collaboration-participant-resolver.test.ts
+++ b/tests/gateway/collaboration-participant-resolver.test.ts
@@ -23,11 +23,14 @@ describe("CollaborationParticipantResolver", () => {
     })).not.toThrow();
   });
 
-  it("returns a validated platform label and caches it", async () => {
+  it("returns a validated platform label without forwarding provider errors", async () => {
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       expect(init).toMatchObject({ method: "GET", redirect: "error" });
       expect(init?.signal).toBeInstanceOf(AbortSignal);
-      return new Response(JSON.stringify({ actorId: "user_editor", displayName: "Editor Person" }));
+      expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${"s".repeat(32)}`);
+      return new Response(JSON.stringify({ actorId: "user_editor", displayName: "Editor Person" }), {
+        headers: { "content-type": "application/json" },
+      });
     });
     const resolver = new CollaborationParticipantResolver({
       platformBaseUrl: "https://platform.internal",
@@ -35,15 +38,19 @@ describe("CollaborationParticipantResolver", () => {
       serviceToken: "s".repeat(32),
       fetchImpl,
     });
-    await expect(resolver.resolve("user_editor")).resolves.toMatchObject({ displayName: "Editor Person" });
+    await expect(resolver.resolve("user_editor")).resolves.toEqual({
+      actorId: "user_editor",
+      displayName: "Editor Person",
+    });
     await expect(resolver.resolve("user_editor")).resolves.toMatchObject({ displayName: "Editor Person" });
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
-  it("rejects mismatched and oversized identity projections generically", async () => {
+  it("rejects mismatched, oversized, and unavailable identity projections generically", async () => {
     const responses = [
       new Response(JSON.stringify({ actorId: "user_other", displayName: "Wrong" })),
       new Response("x".repeat(8_193)),
+      new Response("provider database exploded", { status: 503 }),
     ];
     const resolver = new CollaborationParticipantResolver({
       platformBaseUrl: "https://platform.internal",
@@ -51,7 +58,7 @@ describe("CollaborationParticipantResolver", () => {
       serviceToken: "s".repeat(32),
       fetchImpl: async () => responses.shift()!,
     });
-    for (const actorId of ["user_editor", "user_viewer"]) {
+    for (const actorId of ["user_editor", "user_viewer", "user_outsider"]) {
       await expect(resolver.resolve(actorId)).rejects.toBeInstanceOf(CollaborationParticipantResolverError);
     }
   });

--- a/tests/gateway/collaboration-wiring.test.ts
+++ b/tests/gateway/collaboration-wiring.test.ts
@@ -37,6 +37,18 @@ describe("gateway collaboration wiring", () => {
     })).toMatchObject({ runtimeId: collaborationIds.runtime });
   });
 
+  it("derives the VPS runtime ID from the existing machine identity", () => {
+    expect(loadGatewayCollaborationConfig({
+      MATRIX_COLLABORATION_ENABLED: "true",
+      MATRIX_MACHINE_ID: "11111111-1111-4111-8111-111111111111",
+      MATRIX_COLLABORATION_ACTIVE_KEY_ID: "key-1",
+      MATRIX_COLLABORATION_PROOF_KEYS: JSON.stringify({ "key-1": "a".repeat(32) }),
+      MATRIX_COLLABORATION_PREFLIGHT_SECRET: "b".repeat(32),
+      PLATFORM_INTERNAL_URL: "https://platform.internal",
+      UPGRADE_TOKEN: "c".repeat(32),
+    })).toMatchObject({ runtimeId: "vps:11111111-1111-4111-8111-111111111111" });
+  });
+
   it("resolves dependencies before route registration and drains before database disposal", async () => {
     const runtime = await createGatewayCollaboration({
       db: fixture.db,

--- a/tests/platform/collaboration-bootstrap.test.ts
+++ b/tests/platform/collaboration-bootstrap.test.ts
@@ -1,0 +1,70 @@
+import { readFile } from "node:fs/promises";
+import type { Agent } from "undici";
+import { describe, expect, it } from "vitest";
+import type { PlatformDB } from "../../packages/platform/src/db.js";
+import { bootstrapPlatformCollaboration } from "../../packages/platform/src/collaboration/bootstrap.js";
+import {
+  createPlatformCollaborationTestDatabase,
+  destroyPlatformCollaborationTestDatabase,
+} from "./collaboration-test-support.js";
+
+const validEnvironment = {
+  MATRIX_COLLABORATION_ENABLED: "true",
+  MATRIX_COLLABORATION_ACTIVE_KEY_ID: "key-1",
+  MATRIX_COLLABORATION_PROOF_KEYS: JSON.stringify({ "key-1": "a".repeat(32) }),
+  MATRIX_COLLABORATION_ALLOWED_ORIGINS: "https://app.matrix-os.com",
+};
+
+describe("platform collaboration bootstrap", () => {
+  it("keeps collaboration composition out of the platform startup entrypoint", async () => {
+    const [startupSource, bootstrapSource] = await Promise.all([
+      readFile("packages/platform/src/platform-startup.ts", "utf8"),
+      readFile("packages/platform/src/collaboration/bootstrap.ts", "utf8"),
+    ]);
+
+    expect(startupSource).toContain("const collaboration = await bootstrapPlatformCollaboration({");
+    expect(startupSource).toContain("collaboration?.shutdown(),");
+    expect(startupSource).not.toContain("loadPlatformCollaborationConfig");
+    expect(startupSource).not.toContain("authenticateRuntime:");
+    expect(bootstrapSource).not.toContain(".shutdown()");
+  });
+
+  it("fails closed before database startup when enabled configuration is incomplete", async () => {
+    await expect(bootstrapPlatformCollaboration({
+      env: { MATRIX_COLLABORATION_ENABLED: "true" },
+      db: undefined as unknown as PlatformDB,
+      platformSecret: "platform-secret",
+      platformJwtSecret: "platform-jwt-secret",
+      customerVpsProxyDispatcher: undefined as unknown as Agent,
+    })).rejects.toThrow("Platform collaboration configuration is incomplete");
+  });
+
+  it("does not initialize collaboration dependencies while the feature is disabled", async () => {
+    await expect(bootstrapPlatformCollaboration({
+      env: {},
+      db: undefined as unknown as PlatformDB,
+      platformSecret: "platform-secret",
+      platformJwtSecret: "platform-jwt-secret",
+      customerVpsProxyDispatcher: undefined as unknown as Agent,
+    })).resolves.toBeUndefined();
+  });
+
+  it("returns an owner-shutdown runtime when collaboration is configured", async () => {
+    const fixture = await createPlatformCollaborationTestDatabase();
+    try {
+      const runtime = await bootstrapPlatformCollaboration({
+        env: validEnvironment,
+        db: { kysely: fixture.collaborationDb } as unknown as PlatformDB,
+        platformSecret: "platform-secret",
+        platformJwtSecret: "platform-jwt-secret",
+        customerVpsProxyDispatcher: {} as Agent,
+      });
+
+      expect(runtime).toBeDefined();
+      expect(runtime?.sockets).toBeDefined();
+      await runtime?.shutdown();
+    } finally {
+      await destroyPlatformCollaborationTestDatabase(fixture);
+    }
+  });
+});

--- a/tests/platform/collaboration-proxy.test.ts
+++ b/tests/platform/collaboration-proxy.test.ts
@@ -123,6 +123,42 @@ describe("CollaborationProxy", () => {
     });
   });
 
+  it("routes owner-only Chat sharing creation to the selected registered runtime", async () => {
+    const path = "/api/collaboration/runtimes/runtime_owner/scopes/preflight";
+    expect(parseCollaborationProxyRoute("POST", path)).toEqual({ kind: "runtime", identifier: "runtime_owner" });
+    const denied = await proxy.forward({
+      actorId: platformCollaborationActors.recipientWithoutComputer,
+      method: "POST",
+      path,
+      query: "",
+      body: new Uint8Array(),
+      headers: new Headers(),
+    });
+    expect(denied.status).toBe(404);
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    const response = await proxy.forward({
+      actorId: platformCollaborationActors.owner,
+      method: "POST",
+      path,
+      query: "",
+      body: new Uint8Array(),
+      headers: new Headers({ "content-type": "application/json" }),
+    });
+    expect(response.status).toBe(200);
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const signedProof = JSON.parse(Buffer.from(
+      new Headers(init.headers).get("x-matrix-collaboration-proof")!,
+      "base64url",
+    ).toString("utf8"));
+    expect(signedProof.proof).toMatchObject({
+      actorId: platformCollaborationActors.owner,
+      ownerId: platformCollaborationActors.owner,
+      runtimeId: "runtime_owner",
+    });
+    expect(signedProof.proof.scopeId).toBeUndefined();
+  });
+
   it.each([
     ["GET", `/api/collaboration/scopes/${scopeId}/../../files`],
     ["POST", `/api/collaboration/scopes/${scopeId}/terminal/input`],

--- a/tests/platform/collaboration-routes.test.ts
+++ b/tests/platform/collaboration-routes.test.ts
@@ -21,6 +21,7 @@ describe("platform collaboration routes", () => {
   let fixture: PlatformCollaborationTestDatabase;
   let repository: PlatformCollaborationRepository;
   let app: Hono;
+  let hydrate: (input: { actorId: string; entry: { scopeId: string; invitationId?: string; kind: string } }) => Promise<unknown>;
 
   beforeEach(async () => {
     fixture = await createPlatformCollaborationTestDatabase();
@@ -40,6 +41,11 @@ describe("platform collaboration routes", () => {
       now: () => now,
       createToken: () => "c".repeat(43),
     });
+    hydrate = async ({ actorId, entry }) => ({
+      id: entry.invitationId ?? entry.scopeId,
+      actorId,
+      kind: entry.kind,
+    });
     app = new Hono();
     app.route("/", createPlatformCollaborationRoutes({
       repository,
@@ -51,11 +57,7 @@ describe("platform collaboration routes", () => {
           ? { runtimeId, ownerId: platformCollaborationActors.owner }
           : null,
       resolveParticipant: async (actorId) => ({ actorId, displayName: `Name ${actorId}` }),
-      hydrate: async ({ actorId, entry }) => ({
-        id: entry.invitationId ?? entry.scopeId,
-        actorId,
-        kind: entry.kind,
-      }),
+      hydrate: (input) => hydrate(input),
       now: () => now,
     }));
   });
@@ -102,6 +104,34 @@ describe("platform collaboration routes", () => {
     });
     expect(shared.status).toBe(200);
     expect(await shared.json()).toMatchObject({ items: [{ status: "accepted", resource: { id: inviteId } }] });
+  });
+
+  it("keeps healthy discovery entries when one owner runtime cannot hydrate", async () => {
+    await repository.applyDirectoryEvent(directoryEvent("invited"));
+    const unavailableScopeId = "10000000-0000-4000-8000-000000000002";
+    await repository.applyDirectoryEvent({
+      ...directoryEvent("invited"),
+      eventId: "20000000-0000-4000-8000-000000000002",
+      scopeId: unavailableScopeId,
+      metadataRevision: 2,
+      recipients: [{
+        actorId: platformCollaborationActors.recipientWithoutComputer,
+        status: "invited",
+        invitationId: "30000000-0000-4000-8000-000000000002",
+      }],
+    });
+    hydrate = async ({ entry }) => {
+      if (entry.scopeId === unavailableScopeId) throw new Error("owner runtime stopped");
+      return { id: entry.invitationId ?? entry.scopeId };
+    };
+
+    const response = await app.request("/api/collaboration/inbox", {
+      headers: { "x-test-actor": platformCollaborationActors.recipientWithoutComputer },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      items: [{ scopeId, resource: { id: inviteId } }],
+    });
   });
 
   it("issues an events-only ticket to an accepted current member", async () => {

--- a/tests/platform/collaboration-routes.test.ts
+++ b/tests/platform/collaboration-routes.test.ts
@@ -1,0 +1,180 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapPlatformCollaborationDatabase } from "../../packages/platform/src/collaboration/database.js";
+import { CollaborationProofSigner } from "../../packages/platform/src/collaboration/proof.js";
+import { PlatformCollaborationRepository } from "../../packages/platform/src/collaboration/repository.js";
+import { createPlatformCollaborationRoutes } from "../../packages/platform/src/collaboration/routes.js";
+import { CollaborationWebSocketAuthorizer } from "../../packages/platform/src/collaboration/websocket.js";
+import {
+  createPlatformCollaborationTestDatabase,
+  destroyPlatformCollaborationTestDatabase,
+  platformCollaborationActors,
+  type PlatformCollaborationTestDatabase,
+} from "./collaboration-test-support.js";
+
+const now = new Date("2026-09-07T12:00:00.000Z");
+const scopeId = "10000000-0000-4000-8000-000000000001";
+const inviteId = "30000000-0000-4000-8000-000000000001";
+const runtimeSecret = "runtime-secret".repeat(3);
+
+describe("platform collaboration routes", () => {
+  let fixture: PlatformCollaborationTestDatabase;
+  let repository: PlatformCollaborationRepository;
+  let app: Hono;
+
+  beforeEach(async () => {
+    fixture = await createPlatformCollaborationTestDatabase();
+    await bootstrapPlatformCollaborationDatabase(fixture.collaborationDb);
+    repository = new PlatformCollaborationRepository(fixture.collaborationDb, { now: () => now });
+    const signer = new CollaborationProofSigner({
+      activeKeyId: "key-1",
+      keys: { "key-1": "a".repeat(32) },
+      now: () => now,
+      createNonce: () => "b".repeat(32),
+    });
+    const sockets = new CollaborationWebSocketAuthorizer({
+      repository,
+      signer,
+      allowedOrigins: ["https://app.matrix-os.com"],
+      enabledPurposes: ["events"],
+      now: () => now,
+      createToken: () => "c".repeat(43),
+    });
+    app = new Hono();
+    app.route("/", createPlatformCollaborationRoutes({
+      repository,
+      signer,
+      sockets,
+      resolveActor: async (c) => c.req.header("x-test-actor") ?? null,
+      authenticateRuntime: async ({ runtimeId, bearerToken }) =>
+        runtimeId === "runtime_owner" && bearerToken === runtimeSecret
+          ? { runtimeId, ownerId: platformCollaborationActors.owner }
+          : null,
+      resolveParticipant: async (actorId) => ({ actorId, displayName: `Name ${actorId}` }),
+      hydrate: async ({ actorId, entry }) => ({
+        id: entry.invitationId ?? entry.scopeId,
+        actorId,
+        kind: entry.kind,
+      }),
+      now: () => now,
+    }));
+  });
+
+  afterEach(async () => {
+    await destroyPlatformCollaborationTestDatabase(fixture);
+  });
+
+  it("accepts only an authenticated registered runtime's content-free directory event", async () => {
+    const event = directoryEvent("invited");
+    expect((await app.request("/internal/collaboration/directory", {
+      method: "PUT",
+      headers: {
+        authorization: "Bearer wrong",
+        "content-type": "application/json",
+        "x-matrix-runtime-id": "runtime_owner",
+      },
+      body: JSON.stringify(event),
+    })).status).toBe(401);
+    const accepted = await app.request("/internal/collaboration/directory", {
+      method: "PUT",
+      headers: {
+        authorization: `Bearer ${runtimeSecret}`,
+        "content-type": "application/json",
+        "x-matrix-runtime-id": "runtime_owner",
+      },
+      body: JSON.stringify(event),
+    });
+    expect(accepted.status).toBe(204);
+    expect(await repository.listForActor(platformCollaborationActors.recipientWithoutComputer))
+      .toMatchObject([{ scopeId, status: "invited", invitationId: inviteId }]);
+  });
+
+  it("hydrates an invite inbox and accepted shared list for an actor without a computer", async () => {
+    await repository.applyDirectoryEvent(directoryEvent("invited"));
+    const inbox = await app.request("/api/collaboration/inbox", {
+      headers: { "x-test-actor": platformCollaborationActors.recipientWithoutComputer },
+    });
+    expect(inbox.status).toBe(200);
+    expect(await inbox.json()).toMatchObject({ items: [{ status: "invited", resource: { id: inviteId } }] });
+    await repository.applyDirectoryEvent({ ...directoryEvent("accepted"), eventId: "20000000-0000-4000-8000-000000000002", metadataRevision: 2 });
+    const shared = await app.request("/api/collaboration/shared", {
+      headers: { "x-test-actor": platformCollaborationActors.recipientWithoutComputer },
+    });
+    expect(shared.status).toBe(200);
+    expect(await shared.json()).toMatchObject({ items: [{ status: "accepted", resource: { id: inviteId } }] });
+  });
+
+  it("issues an events-only ticket to an accepted current member", async () => {
+    await repository.applyDirectoryEvent({ ...directoryEvent("accepted"), metadataRevision: 2 });
+    await repository.setPolicy({
+      milestone: "m1",
+      expectedRevision: 0,
+      mode: "enabled",
+      cohort: [],
+      changedBy: "operator_test",
+    });
+    const response = await app.request(`/api/collaboration/scopes/${scopeId}/connection-tickets`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-test-actor": platformCollaborationActors.recipientWithoutComputer,
+      },
+      body: JSON.stringify({
+        clientRequestId: "40000000-0000-4000-8000-000000000001",
+        purpose: "events",
+      }),
+    });
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({ ticket: "c".repeat(43) });
+  });
+
+  it("serves bounded participant identity only to an authenticated runtime", async () => {
+    const denied = await app.request(`/internal/collaboration/participants/${platformCollaborationActors.recipientWithoutComputer}`);
+    expect(denied.status).toBe(401);
+    const response = await app.request(
+      `/internal/collaboration/participants/${platformCollaborationActors.recipientWithoutComputer}`,
+      { headers: { authorization: `Bearer ${runtimeSecret}`, "x-matrix-runtime-id": "runtime_owner" } },
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      actorId: platformCollaborationActors.recipientWithoutComputer,
+      displayName: `Name ${platformCollaborationActors.recipientWithoutComputer}`,
+    });
+  });
+
+  it("serves a short-lived signed rollout policy only to an authenticated runtime", async () => {
+    const denied = await app.request("/internal/collaboration/policy?milestone=m1");
+    expect(denied.status).toBe(401);
+    const response = await app.request("/internal/collaboration/policy?milestone=m1", {
+      headers: { authorization: `Bearer ${runtimeSecret}`, "x-matrix-runtime-id": "runtime_owner" },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      policy: {
+        milestone: "m1",
+        revision: "0",
+        mode: "off",
+        issuedAt: now.toISOString(),
+        expiresAt: new Date(now.getTime() + 30_000).toISOString(),
+      },
+      keyId: "key-1",
+    });
+  });
+});
+
+function directoryEvent(status: "invited" | "accepted") {
+  return {
+    eventId: "20000000-0000-4000-8000-000000000001",
+    scopeId,
+    runtimeId: "runtime_owner",
+    ownerId: platformCollaborationActors.owner,
+    kind: "chat" as const,
+    authorityGeneration: 1,
+    metadataRevision: 1,
+    recipients: [{
+      actorId: platformCollaborationActors.recipientWithoutComputer,
+      status,
+      invitationId: inviteId,
+    }],
+  };
+}

--- a/tests/platform/collaboration-websocket.test.ts
+++ b/tests/platform/collaboration-websocket.test.ts
@@ -4,8 +4,11 @@ import { bootstrapPlatformCollaborationDatabase } from "../../packages/platform/
 import { CollaborationProofSigner } from "../../packages/platform/src/collaboration/proof.js";
 import { PlatformCollaborationRepository } from "../../packages/platform/src/collaboration/repository.js";
 import {
+  buildCollaborationWebSocketUpgradeHeaders,
   CollaborationWebSocketAuthorizer,
   CollaborationWebSocketError,
+  isCollaborationWebSocketCandidate,
+  isCollaborationWebSocketPath,
 } from "../../packages/platform/src/collaboration/websocket.js";
 import {
   createPlatformCollaborationTestDatabase,
@@ -157,5 +160,35 @@ describe("CollaborationWebSocketAuthorizer", () => {
       rawPath: `${eventPath}?ticket=${encodeURIComponent(issued.ticket)}`,
       origin: "https://app.matrix-os.com",
     })).rejects.toMatchObject({ code: "unavailable" });
+  });
+
+  it("recognizes only exact collaboration socket paths and strips caller credentials upstream", () => {
+    expect(isCollaborationWebSocketPath(eventPath)).toBe(true);
+    expect(isCollaborationWebSocketPath(`${eventPath}?after=2`)).toBe(true);
+    expect(isCollaborationWebSocketPath(`${eventPath}/child`)).toBe(false);
+    expect(isCollaborationWebSocketPath(`/ws/collaboration/scopes/${scopeId}/unknown`)).toBe(false);
+    expect(isCollaborationWebSocketCandidate(`${eventPath}/child`)).toBe(true);
+
+    const headers = buildCollaborationWebSocketUpgradeHeaders({
+      incomingHeaders: {
+        connection: "Upgrade",
+        upgrade: "websocket",
+        "sec-websocket-key": "safe-key",
+        "sec-websocket-version": "13",
+        authorization: "Bearer caller-secret",
+        cookie: "__session=caller-secret",
+        "x-platform-user-id": "forged-owner",
+        "x-matrix-collaboration-proof": "forged-proof",
+      },
+      externalHost: "app.matrix-os.com",
+      signedProof: { proof: { value: "safe" }, signature: "signed" },
+    });
+    expect(headers).toContain("sec-websocket-key: safe-key");
+    expect(headers).toContain("x-matrix-collaboration-proof:");
+    expect(headers).not.toContain("caller-secret");
+    expect(headers).not.toContain("forged-owner");
+    expect(headers).not.toContain("forged-proof");
+    expect(headers).not.toContain("authorization:");
+    expect(headers).not.toContain("cookie:");
   });
 });

--- a/tests/platform/collaboration-wiring.test.ts
+++ b/tests/platform/collaboration-wiring.test.ts
@@ -1,0 +1,89 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPlatformCollaboration,
+  loadPlatformCollaborationConfig,
+} from "../../packages/platform/src/collaboration/wiring.js";
+import {
+  createPlatformCollaborationTestDatabase,
+  destroyPlatformCollaborationTestDatabase,
+  platformCollaborationActors,
+  type PlatformCollaborationTestDatabase,
+} from "./collaboration-test-support.js";
+
+const scopeId = "10000000-0000-4000-8000-000000000001";
+
+describe("platform collaboration wiring", () => {
+  let fixture: PlatformCollaborationTestDatabase;
+
+  beforeEach(async () => {
+    fixture = await createPlatformCollaborationTestDatabase();
+  });
+
+  afterEach(async () => {
+    await destroyPlatformCollaborationTestDatabase(fixture);
+  });
+
+  it("fails closed on incomplete environment configuration", () => {
+    expect(loadPlatformCollaborationConfig({ MATRIX_COLLABORATION_ENABLED: "true" })).toBeNull();
+    expect(loadPlatformCollaborationConfig({
+      MATRIX_COLLABORATION_ENABLED: "true",
+      MATRIX_COLLABORATION_ACTIVE_KEY_ID: "key-1",
+      MATRIX_COLLABORATION_PROOF_KEYS: JSON.stringify({ "key-1": "a".repeat(32) }),
+      MATRIX_COLLABORATION_ALLOWED_ORIGINS: "https://app.matrix-os.com",
+    })).toMatchObject({ activeKeyId: "key-1", enabledPurposes: ["events"] });
+  });
+
+  it("registers local and exact proxy routes after migrations", async () => {
+    const upstream = vi.fn(async () => new Response(JSON.stringify({ id: scopeId, role: "editor" }), {
+      headers: { "content-type": "application/json" },
+    }));
+    const runtime = await createPlatformCollaboration({
+      db: fixture.collaborationDb,
+      config: {
+        activeKeyId: "key-1",
+        proofKeys: { "key-1": "a".repeat(32) },
+        allowedOrigins: ["https://app.matrix-os.com"],
+        enabledPurposes: ["events"],
+      },
+      resolveActor: async (c) => c.req.header("x-test-actor") ?? null,
+      authenticateRuntime: async () => null,
+      resolveParticipant: async (actorId) => ({ actorId, displayName: actorId }),
+      resolveRuntime: async (runtimeId) => ({
+        runtimeId,
+        ownerId: platformCollaborationActors.owner,
+        baseUrl: "https://runtime.internal",
+      }),
+      fetchImpl: upstream,
+      now: () => new Date("2026-09-07T12:00:00.000Z"),
+    });
+    await runtime.repository.applyDirectoryEvent({
+      eventId: "20000000-0000-4000-8000-000000000001",
+      scopeId,
+      runtimeId: "runtime_owner",
+      ownerId: platformCollaborationActors.owner,
+      kind: "chat",
+      authorityGeneration: 1,
+      metadataRevision: 1,
+      recipients: [{ actorId: platformCollaborationActors.recipientWithoutComputer, status: "accepted" }],
+    });
+    await runtime.repository.setPolicy({
+      milestone: "m1",
+      expectedRevision: 0,
+      mode: "enabled",
+      cohort: [],
+      changedBy: "operator_test",
+    });
+    const app = new Hono();
+    runtime.register(app);
+    const response = await app.request(`/api/collaboration/scopes/${scopeId}`, {
+      headers: { "x-test-actor": platformCollaborationActors.recipientWithoutComputer },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: scopeId, role: "editor" });
+    expect(upstream).toHaveBeenCalledOnce();
+    const [, init] = upstream.mock.calls[0]!;
+    expect(new Headers(init?.headers).has("x-matrix-collaboration-proof")).toBe(true);
+    await runtime.shutdown();
+  });
+});


### PR DESCRIPTION
## Summary

- Add authenticated platform invite inbox/shared discovery, participant identity, rollout-policy, exact HTTP proxy, and collaboration WebSocket ingress routes.
- Hydrate invitations for recipients without a provisioned Matrix computer while keeping records content-free.
- Register platform migrations, repositories, proof signer, proxy, socket upgrade routing, and shutdown ownership.

Stack: 5/8 of PR1/M1, based on #1574.

## Tests

- Platform routes/proxy/WebSocket/wiring and gateway participant/outbox integration tests are included in the cumulative 148-test focused pass.
- Platform and gateway TypeScript checks passed.

## Invariants

- **Source of truth:** Platform directory data is content-free discovery/routing state; the owner runtime remains authoritative for membership and Chat content.
- **Lock/transaction scope:** Platform repository changes are atomic local transactions. Owner-runtime fetches use bounded timeouts outside database transactions.
- **Acceptable orphan states:** Discovery can lag the owner outbox; stale entries cannot authorize because every forwarded operation is rechecked by the owner runtime. A no-computer recipient may accept/open discovery before provisioning without creating a shadow copy.
- **Auth source of truth:** Authenticated platform principal becomes the signed actor proof; exact route matching strips caller proofs and owner tokens.
- **Deferred scope:** Shared clients and lifecycle UI follow above this layer. Collaboration policy remains off by default; AI/terminal/project capabilities remain unavailable.

## Review/Monitoring

- Draft; review after #1574.
- Greptile and label-gated CI are pending.
