### PR TITLE
fix(chat): recover stalled runtimes and preserve chat state

### DIFF
--- a/apps/mobile/__tests__/canonical-approval-message.test.tsx
+++ b/apps/mobile/__tests__/canonical-approval-message.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import { CanonicalApprovalMessage } from "@/components/CanonicalApprovalMessage";
+
+jest.mock("@clerk/clerk-expo", () => ({ useAuth: () => ({ getToken: async () => "test-token" }) }));
+// Unrelated ESM-only export from the contracts barrel; this suite exercises approval HTTP, not shared HTML.
+jest.mock("micromark", () => ({ micromark: jest.fn() }));
+jest.mock("micromark-extension-gfm", () => ({ gfm: jest.fn(), gfmHtml: jest.fn() }));
+
+const approval = {
+  id: "evt_approval", runId: "run_test", approvalId: "approval_test", title: "Use integration",
+  description: "The agent is waiting for your decision.", risk: "high" as const,
+  allowedDecisions: ["approve", "decline", "cancel"] as const, pending: true, timestamp: 0,
+};
+const refresh = jest.fn();
+const props = { chatId: "chat_test", gatewayUrl: "https://app.matrix-os.com/vm/pr-1580", onSettled: refresh };
+
+afterEach(() => { jest.restoreAllMocks(); refresh.mockClear(); });
+
+it("submits a one-time decision to the selected chat and run, then refreshes", async () => {
+  const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({ ok: true, json: async () => ({ approvalId: "approval_test", decision: "decline", submission: "accepted" }) } as Response);
+  render(<CanonicalApprovalMessage {...props} approval={{ ...approval, allowedDecisions: [...approval.allowedDecisions] }} />);
+  fireEvent.press(screen.getByText("Decline"));
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+  expect(fetchMock).toHaveBeenCalledWith(
+    "https://app.matrix-os.com/vm/pr-1580/api/chats/chat_test/runs/run_test/approvals/approval_test",
+    expect.objectContaining({ method: "POST", body: expect.stringContaining('"decision":"decline"'), signal: expect.anything() }),
+  );
+  await waitFor(() => expect(refresh).toHaveBeenCalled());
+});
+
+it("does not render action buttons on a settled approval", () => {
+  render(<CanonicalApprovalMessage {...props} approval={{ ...approval, pending: false, allowedDecisions: [...approval.allowedDecisions] }} />);
+  expect(screen.queryByText("Approve")).toBeNull();
+  expect(screen.getByText("Resolved")).toBeTruthy();
+});
+
+it("keeps failed submissions recoverable and never displays a raw server error", async () => {
+  jest.spyOn(global, "fetch").mockRejectedValue(new Error("private upstream token"));
+  render(<CanonicalApprovalMessage {...props} approval={{ ...approval, allowedDecisions: [...approval.allowedDecisions] }} />);
+  fireEvent.press(screen.getByText("Cancel"));
+  await waitFor(() => expect(screen.getByText("Could not submit approval. Try again.")).toBeTruthy());
+  expect(screen.queryByText("private upstream token")).toBeNull();
+});

--- a/apps/mobile/app/(drawer)/index.tsx
+++ b/apps/mobile/app/(drawer)/index.tsx
@@ -36,6 +36,8 @@ import { ModelPicker } from "@/components/ModelPicker";
 import { ProjectPicker } from "@/components/ProjectPicker";
 import { Icon, IconButton } from "@/components/ui";
 import { AnalyticsMask } from "@/lib/analytics";
+import { CanonicalApprovalMessage } from "@/components/CanonicalApprovalMessage";
+import { HOSTED_GATEWAY_URL } from "@/lib/storage";
 
 const rabbitArtwork = require("../../assets/app.icon/Assets/rabbit.svg");
 
@@ -55,7 +57,7 @@ export default function ChatScreen() {
     ?? user?.username
     ?? "there";
 
-  const { detail } = useCanonicalChatDetail(activeChatId);
+  const { detail, computer, refresh } = useCanonicalChatDetail(activeChatId);
   const { catalog } = useChatProviderCatalog();
   const { projects } = useProjects();
   const sendMessage = useSendChatMessage();
@@ -175,9 +177,13 @@ export default function ChatScreen() {
 
   const renderItem = useCallback(({ item }: ListRenderItemInfo<TranscriptMessage>) => (
     <AnalyticsMask>
-      <MessageBubble message={item} />
+      {item.approval && activeChatId && computer ? <CanonicalApprovalMessage
+        key={`${activeChatId}:${item.approval.runId}:${item.approval.approvalId}`}
+        approval={item.approval} chatId={activeChatId}
+        gatewayUrl={`${HOSTED_GATEWAY_URL}${computer.gatewayPath}`} onSettled={refresh}
+      /> : <MessageBubble message={item} />}
     </AnalyticsMask>
-  ), []);
+  ), [activeChatId, computer, refresh]);
 
   const keyExtractor = useCallback((item: TranscriptMessage) => item.id, []);
 

--- a/apps/mobile/components/CanonicalApprovalMessage.tsx
+++ b/apps/mobile/components/CanonicalApprovalMessage.tsx
@@ -1,0 +1,72 @@
+import { useRef, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import { useAuth } from "@clerk/clerk-expo";
+import {
+  CanonicalChatApprovalSubmissionResponseSchema,
+  CanonicalSubmitChatApprovalRequestSchema,
+  type CanonicalChatApprovalDecision,
+  type CanonicalChatApprovalView,
+} from "@matrix-os/contracts";
+import { canonicalChatRequestId } from "@/lib/requests/canonical-chat";
+import { buildGatewayRequestUrl, fetchAuthenticatedJson } from "@/lib/requests/http";
+
+export function CanonicalApprovalMessage({ approval, chatId, gatewayUrl, onSettled }: {
+  approval: CanonicalChatApprovalView;
+  chatId: string;
+  gatewayUrl: string;
+  onSettled: () => Promise<unknown> | void;
+}) {
+  const { getToken } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inFlight = useRef(false);
+  // At most four decision keys; preserve an ambiguous request's id on retry.
+  const requestIds = useRef<Partial<Record<CanonicalChatApprovalDecision, string>>>({});
+  async function submit(decision: CanonicalChatApprovalDecision) {
+    if (inFlight.current || submitted || !approval.pending || !approval.allowedDecisions.includes(decision)) return;
+    inFlight.current = true;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const token = await getToken();
+      if (!token) throw new Error("Not signed in");
+      const clientRequestId = requestIds.current[decision] ??= canonicalChatRequestId();
+      const body = CanonicalSubmitChatApprovalRequestSchema.parse({ decision, clientRequestId });
+      await fetchAuthenticatedJson({
+        url: buildGatewayRequestUrl(gatewayUrl, `/api/chats/${encodeURIComponent(chatId)}/runs/${encodeURIComponent(approval.runId)}/approvals/${encodeURIComponent(approval.approvalId)}`),
+        token, method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+        schema: CanonicalChatApprovalSubmissionResponseSchema,
+        errorMessage: "Could not submit approval. Try again.",
+      });
+      setSubmitted(true);
+    } catch (_error) {
+      setError("Could not submit approval. Try again.");
+    } finally {
+      try { await onSettled(); } catch (_error) { setError("Could not refresh chat. Try again."); }
+      inFlight.current = false;
+      setSubmitting(false);
+    }
+  }
+  return <View style={styles.card}>
+    <Text style={styles.text}>{approval.title}</Text>
+    <Text style={styles.text}>{approval.description}</Text>
+    {approval.pending && !submitted ? <View style={styles.actions}>
+      {approval.allowedDecisions.map(decision => <Pressable
+        key={decision} accessibilityRole="button" disabled={submitting}
+        accessibilityState={{ disabled: submitting }} style={styles.button}
+        onPress={() => void submit(decision)}>
+        <Text style={styles.text}>{decision === "approve_for_session" ? "Approve for session" : decision.charAt(0).toUpperCase() + decision.slice(1)}</Text>
+      </Pressable>)}
+    </View> : <Text style={styles.text}>Resolved</Text>}
+    {error ? <Text accessibilityRole="alert" style={styles.text}>{error}</Text> : null}
+  </View>;
+}
+
+const styles = StyleSheet.create(theme => ({
+  card: { padding: 12, gap: 8, borderWidth: 1, borderColor: theme.colors.border, borderRadius: 12 },
+  text: { color: theme.colors.foreground },
+  actions: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  button: { padding: 12, borderWidth: 1, borderColor: theme.colors.border, borderRadius: 8 },
+}));

--- a/apps/mobile/lib/canonical-chat-transcript.ts
+++ b/apps/mobile/lib/canonical-chat-transcript.ts
@@ -1,4 +1,4 @@
-import { canonicalChatTerminalNotices } from "@matrix-os/contracts";
+import { canonicalChatApprovals, canonicalChatTerminalNotices, type CanonicalChatApprovalView } from "@matrix-os/contracts";
 import type {
   CanonicalChatDetailResponse,
   CanonicalChatMessage,
@@ -25,6 +25,7 @@ export interface TranscriptToolCall {
 }
 
 export interface TranscriptMessage {
+  approval?: CanonicalChatApprovalView;
   id: string;
   role: "user" | "assistant" | "tool" | "system";
   text: string;
@@ -204,6 +205,18 @@ export function buildTranscript(detail: CanonicalChatDetailResponse | null): Tra
     });
   }
 
+  for (const approval of canonicalChatApprovals(detail)) {
+    const existing = transcript.find(message => message.id === approval.id);
+    if (existing) {
+      existing.approval = approval;
+      continue;
+    }
+    const index = approval.beforeMessageId ? transcript.findIndex(message => message.id === approval.beforeMessageId) : -1;
+    transcript.splice(index < 0 ? 0 : index + 1, 0, {
+      id: approval.id, role: "system", text: approval.title, toolCalls: [], activities: [],
+      isRunning: false, createdAt: approval.timestamp, approval,
+    });
+  }
   for (const notice of canonicalChatTerminalNotices(detail)) {
     const index = notice.beforeMessageId ? transcript.findIndex((message) => message.id === notice.beforeMessageId) : -1;
     transcript.splice(index < 0 ? 0 : index + 1, 0, {

--- a/apps/mobile/lib/canonical-chat-transcript.ts
+++ b/apps/mobile/lib/canonical-chat-transcript.ts
@@ -1,3 +1,4 @@
+import { canonicalChatTerminalNotices } from "@matrix-os/contracts";
 import type {
   CanonicalChatDetailResponse,
   CanonicalChatMessage,
@@ -203,5 +204,12 @@ export function buildTranscript(detail: CanonicalChatDetailResponse | null): Tra
     });
   }
 
+  for (const notice of canonicalChatTerminalNotices(detail)) {
+    const index = notice.beforeMessageId ? transcript.findIndex((message) => message.id === notice.beforeMessageId) : -1;
+    transcript.splice(index < 0 ? 0 : index + 1, 0, {
+      id: notice.id, role: "system", text: notice.text, toolCalls: [], activities: [],
+      isRunning: false, createdAt: notice.timestamp,
+    });
+  }
   return transcript;
 }

--- a/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
+++ b/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
@@ -1,3 +1,4 @@
+import { canonicalChatApprovals } from "@matrix-os/contracts";
 import type {
   CanonicalChatMessage,
   CanonicalChatRun,
@@ -509,7 +510,7 @@ function runPresentation(
     ...projectedActivityGroups,
     ...requestOrder.flatMap((key) => {
       const request = requests.get(key);
-      return request ? [request] : [];
+      return request ? [active ? request : { ...request, state: "resolved" as const, actions: undefined }] : [];
     }),
   ];
   const failed = run.status === "failed" || run.outcome === "failed";
@@ -560,6 +561,7 @@ export function canonicalChatPresentation(input: {
   runs: CanonicalChatRun[];
   activities: CanonicalChatRunActivity[];
 }): ConversationTurnPresentation[] {
+  const approvalViews = canonicalChatApprovals(input);
   const latestTurnId = input.turns.reduce<CanonicalChatTurn | undefined>((latest, turn) => (
     latest === undefined
       || turn.baseMessageSeq > latest.baseMessageSeq
@@ -626,7 +628,15 @@ export function canonicalChatPresentation(input: {
         otherIndex += 1;
       }
     }
-    const work = replaceThinkingPlaceholders(orderedWork, isActiveRun(run));
+    const seenApprovals = new Set<string>(); // Per-turn, bounded by snapshot activities/parts.
+    const work = replaceThinkingPlaceholders(orderedWork, isActiveRun(run)).flatMap((item): ConversationWorkPresentation[] => {
+      if (item.kind !== "request") return [item];
+      if (item.requestKind !== "approval") return [isActiveRun(run) ? item : { ...item, state: "resolved", actions: undefined }];
+      if (seenApprovals.has(item.requestId)) return [];
+      seenApprovals.add(item.requestId);
+      const approval = approvalViews.find(view => view.runId === run?.id && view.approvalId === item.requestId);
+      return [approval?.pending ? item : { ...item, state: "resolved", actions: undefined }];
+    });
     const timeline = [
       ...work.map((item, index) => ({
         kind: "work" as const,

--- a/desktop/src/renderer/src/features/chat/use-canonical-chat-route-controller.ts
+++ b/desktop/src/renderer/src/features/chat/use-canonical-chat-route-controller.ts
@@ -77,6 +77,15 @@ export function useCanonicalChatRouteController({
   const routeScopeRef = useRef<{ active: boolean; client: CanonicalChatClient; projectId: string | null } | null>(null);
   const listRequestSequence = useRef(0);
   const detailRequestSequence = useRef(0);
+  // Keep the stream checkpoint synchronous. React may defer/replay a state
+  // updater after a newer SSE frame has already advanced detailRef.
+  const updateDetail = useCallback((update: (
+    current: CanonicalChatDetailResponse | null,
+  ) => CanonicalChatDetailResponse | null) => {
+    const next = update(detailRef.current);
+    detailRef.current = next;
+    setDetail(next);
+  }, []);
   const acknowledgementAttemptRef = useRef<{
     client: CanonicalChatClient;
     chatId: string;
@@ -354,9 +363,8 @@ export function useCanonicalChatRouteController({
         projectId: targetProjectId,
       });
       if (!isCurrentScope()) return null;
-      setDetail((current) => {
+      updateDetail((current) => {
         const next = current ? detailWithRecord(current, record) : current;
-        detailRef.current = next;
         return next;
       });
       setItems((current) => current.map((item) => (
@@ -371,7 +379,7 @@ export function useCanonicalChatRouteController({
       await loadDetail(detail.record.chat.id);
       return null;
     }
-  }, [client, detail, loadDetail]);
+  }, [client, detail, loadDetail, updateDetail]);
 
   const submitTurn = useCallback(async (
     input: Omit<CanonicalCreateChatTurnRequest, "clientRequestId" | "baseRevision">,
@@ -470,7 +478,7 @@ export function useCanonicalChatRouteController({
       });
       if (!isCurrentScope()) return null;
       detailRequestSequence.current += 1;
-      setDetail((currentDetail) => {
+      updateDetail((currentDetail) => {
         if (!currentDetail || currentDetail.record.chat.id !== current.record.chat.id
           || currentDetail.record.chat.revision > current.record.chat.revision) return currentDetail;
         const messages = currentDetail.messages.some((message) => message.id === response.message.id)
@@ -489,7 +497,6 @@ export function useCanonicalChatRouteController({
           } : currentDetail.record,
           messages,
         };
-        detailRef.current = next;
         return next;
       });
       setError(null);
@@ -501,7 +508,7 @@ export function useCanonicalChatRouteController({
       await loadDetail(current.record.chat.id);
       return null;
     }
-  }, [client, loadDetail]);
+  }, [client, loadDetail, updateDetail]);
 
   const queueTurn = useCallback(async (
     input: Omit<CanonicalQueueChatTurnRequest, "clientRequestId" | "baseRevision">,
@@ -518,7 +525,7 @@ export function useCanonicalChatRouteController({
       });
       if (!isCurrentScope()) return null;
       detailRequestSequence.current += 1;
-      setDetail((currentDetail) => {
+      updateDetail((currentDetail) => {
         if (!currentDetail || currentDetail.record.chat.id !== current.record.chat.id
           || currentDetail.record.chat.revision > current.record.chat.revision) return currentDetail;
         const existing = currentDetail.queuedTurns ?? [];
@@ -537,7 +544,6 @@ export function useCanonicalChatRouteController({
           },
           queuedTurns,
         };
-        detailRef.current = next;
         return next;
       });
       setError(null);
@@ -549,7 +555,7 @@ export function useCanonicalChatRouteController({
       setError("The message could not be queued. Refresh and try again.");
       return null;
     }
-  }, [client, loadDetail]);
+  }, [client, loadDetail, updateDetail]);
 
   const updateQueuedTurn = useCallback(async (
     queuedTurnId: string,
@@ -567,7 +573,7 @@ export function useCanonicalChatRouteController({
       });
       if (!isCurrentScope()) return null;
       detailRequestSequence.current += 1;
-      setDetail((currentDetail) => {
+      updateDetail((currentDetail) => {
         if (!currentDetail || currentDetail.record.chat.id !== current.record.chat.id
           || currentDetail.record.chat.revision > current.record.chat.revision) return currentDetail;
         const next = {
@@ -584,7 +590,6 @@ export function useCanonicalChatRouteController({
             turn.id === queuedTurnId ? response.queuedTurn : turn
           )),
         };
-        detailRef.current = next;
         return next;
       });
       setError(null);
@@ -596,7 +601,7 @@ export function useCanonicalChatRouteController({
       await loadDetail(current.record.chat.id);
       return null;
     }
-  }, [client, loadDetail]);
+  }, [client, loadDetail, updateDetail]);
 
   const steerQueuedTurn = useCallback(async (queuedTurnId: string) => {
     const current = detailRef.current;
@@ -620,7 +625,7 @@ export function useCanonicalChatRouteController({
       );
       if (!isCurrentScope()) return null;
       detailRequestSequence.current += 1;
-      setDetail((currentDetail) => {
+      updateDetail((currentDetail) => {
         if (!currentDetail || currentDetail.record.chat.id !== current.record.chat.id
           || currentDetail.record.chat.revision > current.record.chat.revision) return currentDetail;
         const messages = currentDetail.messages.some((message) => message.id === response.message.id)
@@ -640,7 +645,6 @@ export function useCanonicalChatRouteController({
           messages,
           queuedTurns: (currentDetail.queuedTurns ?? []).filter((turn) => turn.id !== queuedTurnId),
         };
-        detailRef.current = next;
         return next;
       });
       setError(null);
@@ -652,7 +656,7 @@ export function useCanonicalChatRouteController({
       setError("The queued message could not steer this Run. It remains in Queue.");
       return null;
     }
-  }, [client, loadDetail]);
+  }, [client, loadDetail, updateDetail]);
 
   const reorderQueuedTurns = useCallback(async (queuedTurnIds: string[]) => {
     const current = detailRef.current;
@@ -667,7 +671,7 @@ export function useCanonicalChatRouteController({
       });
       if (!isCurrentScope()) return false;
       detailRequestSequence.current += 1;
-      setDetail((currentDetail) => {
+      updateDetail((currentDetail) => {
         if (!currentDetail || currentDetail.record.chat.id !== current.record.chat.id
           || currentDetail.record.chat.revision > current.record.chat.revision) return currentDetail;
         const next = {
@@ -681,7 +685,6 @@ export function useCanonicalChatRouteController({
           },
           queuedTurns: response.queuedTurns,
         };
-        detailRef.current = next;
         return next;
       });
       setError(null);
@@ -693,7 +696,7 @@ export function useCanonicalChatRouteController({
       await loadDetail(current.record.chat.id);
       return false;
     }
-  }, [client, loadDetail]);
+  }, [client, loadDetail, updateDetail]);
 
   const cancelQueuedTurn = useCallback(async (queuedTurnId: string) => {
     const current = detailRef.current;
@@ -707,7 +710,7 @@ export function useCanonicalChatRouteController({
       });
       if (!isCurrentScope()) return false;
       detailRequestSequence.current += 1;
-      setDetail((currentDetail) => {
+      updateDetail((currentDetail) => {
         if (!currentDetail || currentDetail.record.chat.id !== current.record.chat.id
           || currentDetail.record.chat.revision > current.record.chat.revision) return currentDetail;
         const next = {
@@ -721,7 +724,6 @@ export function useCanonicalChatRouteController({
           } : currentDetail.record,
           queuedTurns: (currentDetail.queuedTurns ?? []).filter((turn) => turn.id !== queuedTurnId),
         };
-        detailRef.current = next;
         return next;
       });
       setError(null);
@@ -733,7 +735,7 @@ export function useCanonicalChatRouteController({
       await loadDetail(current.record.chat.id);
       return false;
     }
-  }, [client, loadDetail]);
+  }, [client, loadDetail, updateDetail]);
 
   const submitApproval = useCallback(async (
     approvalId: string,

--- a/desktop/src/renderer/src/features/work/ChatFileNavigation.tsx
+++ b/desktop/src/renderer/src/features/work/ChatFileNavigation.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { InspectorFileTarget } from "../panels/InspectorFilesPanel";
 
 interface FileRequest {
@@ -11,15 +11,26 @@ const ChatFileNavigation = createContext<{
   open: (request: FileRequest) => void;
 } | null>(null);
 
-export function ChatFileNavigationProvider({ children, reveal }: {
+export function ChatFileNavigationProvider({ children, reveal, scopeKey = "default" }: {
   children: ReactNode;
   reveal: () => void;
+  scopeKey?: string;
 }) {
-  const [request, setRequest] = useState<FileRequest | null>(null);
+  const [state, setState] = useState<{ scopeKey: string; request: FileRequest | null }>({ scopeKey, request: null });
+  // Reset only inspector state, never remount the subtree that owns Chat drafts.
+  if (state.scopeKey !== scopeKey) setState({ scopeKey, request: null });
+  const scope = useMemo(() => ({}), [scopeKey]);
+  const committedScope = useRef<object | null>(scope);
+  useLayoutEffect(() => {
+    committedScope.current = scope;
+    return () => { committedScope.current = null; };
+  }, [scope]);
   const open = useCallback((next: FileRequest) => {
-    setRequest(next);
+    if (committedScope.current !== scope) return;
+    setState({ scopeKey, request: next });
     reveal();
-  }, [reveal]);
+  }, [reveal, scope, scopeKey]);
+  const request = state.scopeKey === scopeKey ? state.request : null;
   const value = useMemo(() => ({ request, open }), [request, open]);
   return <ChatFileNavigation.Provider value={value}>{children}</ChatFileNavigation.Provider>;
 }

--- a/desktop/src/renderer/src/features/work/WorkTab.tsx
+++ b/desktop/src/renderer/src/features/work/WorkTab.tsx
@@ -733,7 +733,7 @@ export default function WorkTab({
   }, [active, chromeSpec, surfaceChromeHost]);
 
   return (
-    <ChatFileNavigationProvider key={`${runtimeSlot}:${authGeneration}:${initialChatId ?? "draft"}`} reveal={openInspector}>
+    <ChatFileNavigationProvider key={`${runtimeSlot}:${authGeneration}`} scopeKey={`${route}:${projectSlug ?? ""}:${initialChatId ?? "draft"}`} reveal={openInspector}>
     <div
       ref={workRef}
       className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"

--- a/distro/customer-vps/host-bin/matrix-terminal-user-keeper.mjs
+++ b/distro/customer-vps/host-bin/matrix-terminal-user-keeper.mjs
@@ -1,6 +1,8 @@
 #!/opt/matrix/runtime/node/bin/node
+// matrix-terminal-readiness: invocation-v1
 import { spawn } from "node:child_process";
-import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { constants, lstatSync, readFileSync, realpathSync } from "node:fs";
+import { open } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -231,10 +233,11 @@ await new Promise((resolveStart) => {
     clearTimeout(startTimer);
     fail("session_start_failed");
   });
-  child.once("exit", (_code, signal) => {
+  child.once("exit", (code, signal) => {
     clearTimeout(startTimer);
     if (requestedSignal || signal) exitAfterChild(null, signal);
     if (startTimedOut) fail("session_start_timeout");
+    if (code !== 0) fail("session_start_failed");
     resolveStart();
   });
 });
@@ -254,3 +257,25 @@ child = spawn("/usr/bin/script", ["-qefc", watcherCommand, "/dev/null"], {
 });
 child.once("error", () => fail("pty_start_failed"));
 child.once("exit", (code, signal) => exitAfterChild(code, signal));
+
+// Do not use list-sessions to probe a just-created server: Zellij can panic on
+// a probe disconnect before FirstClientConnected has initialized session_data.
+// The per-unit invocation fences stale signals after restart, including SIGKILL.
+const invocationId = process.env.INVOCATION_ID;
+if (typeof invocationId === "string" && /^[0-9a-f]{32}$/.test(invocationId)) {
+  try {
+    const readyPath = join(homePath, "system", "terminal-runtimes", `${runtimeId}.ready.json`);
+    const handle = await open(readyPath, constants.O_WRONLY | constants.O_CREAT
+      | constants.O_NOFOLLOW | constants.O_NONBLOCK, 0o600);
+    try {
+      const stats = await handle.stat();
+      if (!stats.isFile() || stats.nlink !== 1) throw new Error("Invalid readiness target");
+      await handle.truncate(0);
+      await handle.writeFile(JSON.stringify({ version: 1, invocationId,
+        generation: descriptor.generation, createdAt: descriptor.createdAt }));
+    } finally { await handle.close(); }
+  } catch (error) {
+    process.stderr.write(`matrix-terminal-user-keeper: readiness_signal_failed (${error instanceof Error ? error.name : "unknown"})\n`);
+    forwardSignal("SIGTERM");
+  }
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -18,6 +18,7 @@
     "#canonical-chat": "./src/canonical-chat.ts",
     "#canonical-chat-api": "./src/canonical-chat-api.ts",
     "#canonical-chat-content": "./src/canonical-chat-content.ts",
+    "#canonical-chat-approvals": "./src/canonical-chat-approvals.ts",
     "#canonical-chat-primitives": "./src/canonical-chat-primitives.ts",
     "#canonical-chat-compatibility": "./src/canonical-chat-compatibility.ts",
     "#canonical-chat-compatibility-public": "./src/canonical-chat-compatibility-public.ts",

--- a/packages/contracts/src/canonical-chat-approvals.ts
+++ b/packages/contracts/src/canonical-chat-approvals.ts
@@ -1,0 +1,60 @@
+import type { CanonicalChatDetailResponse } from "./canonical-chat-api.js";
+import type { CanonicalChatApprovalDecision } from "./canonical-chat.js";
+
+export interface CanonicalChatApprovalView {
+  id: string;
+  runId: string;
+  approvalId: string;
+  title: string;
+  description: string;
+  risk: "low" | "medium" | "high";
+  allowedDecisions: CanonicalChatApprovalDecision[];
+  pending: boolean;
+  timestamp: number;
+  beforeMessageId?: string;
+}
+
+/** One run-scoped approval model for legacy message parts and native activities.
+ * Collections are request-local and bounded by the detail response schema.
+ * Terminal runs fence stale history even when an older runner lost resolution.
+ */
+export function canonicalChatApprovals(detail: Pick<CanonicalChatDetailResponse, "runs" | "turns" | "messages" | "activities">): CanonicalChatApprovalView[] {
+  const approvals = new Map<string, CanonicalChatApprovalView>();
+  const resolved = new Set<string>();
+  const key = (runId: string, approvalId: string) => `${runId}\0${approvalId}`;
+  for (const message of detail.messages) {
+    if (!message.runId) continue;
+    for (const part of message.parts) {
+      if (part.type === "approval_result") resolved.add(key(message.runId, part.approvalId));
+      if (part.type !== "approval_request") continue;
+      approvals.set(key(message.runId, part.approvalId), {
+        ...part, id: message.id, runId: message.runId,
+        pending: false, timestamp: Date.parse(message.createdAt),
+      });
+    }
+  }
+  for (const activity of detail.activities) {
+    if (activity.type === "approval.resolved") resolved.add(key(activity.runId, activity.approvalId));
+    if (activity.type !== "approval.requested") continue;
+    const identity = key(activity.runId, activity.approvalId);
+    if (approvals.has(identity)) continue;
+    approvals.set(identity, {
+      id: activity.id, runId: activity.runId, approvalId: activity.approvalId,
+      title: activity.title, description: "The agent is waiting for your decision.",
+      risk: activity.risk, allowedDecisions: activity.allowedDecisions,
+      pending: false, timestamp: Date.parse(activity.occurredAt),
+    });
+  }
+  return [...approvals.entries()].flatMap(([identity, approval]) => {
+    const run = detail.runs.find(r => r.id === approval.runId);
+    if (!run) return [];
+    const turn = detail.turns.find(t => t.id === run.turnId);
+    const input = detail.messages.find(m => m.id === turn?.inputMessageId);
+    const next = input && detail.messages.find(m => m.role === "user" && m.seq > input.seq && m.turnId !== run.turnId);
+    return [{ ...approval,
+      pending: ["accepted", "running", "waiting_for_approval", "waiting_for_input"].includes(run.status)
+        && !resolved.has(identity),
+      ...(next ? { beforeMessageId: next.id } : {}),
+    }];
+  });
+}

--- a/packages/contracts/src/canonical-chat-content.ts
+++ b/packages/contracts/src/canonical-chat-content.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 import { CanonicalChatDetailResponseSchema, CanonicalChatRecordSchema, CanonicalChatStreamEventSchema, CanonicalChatStreamServerFrameSchema } from "#canonical-chat-api";
 import { CanonicalChatMessageSchema } from "#canonical-chat";
+export { canonicalChatApprovals, type CanonicalChatApprovalView } from "#canonical-chat-approvals";
 
 // Opt-in v2 frames. Never send these to an unversioned notification client.
 export const CanonicalChatContentSchema = z.object({

--- a/packages/contracts/src/canonical-chat-content.ts
+++ b/packages/contracts/src/canonical-chat-content.ts
@@ -44,3 +44,21 @@ export type CanonicalChatContent = z.infer<typeof CanonicalChatContentSchema>;
 export type CanonicalChatContentFrame = z.infer<typeof CanonicalChatContentFrameSchema>;
 export const CanonicalChatTransportFrameSchema = z.union([CanonicalChatStreamServerFrameSchema, CanonicalChatContentFrameSchema]);
 export type CanonicalChatTransportFrame = z.infer<typeof CanonicalChatTransportFrameSchema>;
+
+/** Shared terminal outcome derivation; renderers only adapt placement and styling. */
+export function canonicalChatTerminalNotices(detail: z.infer<typeof CanonicalChatDetailResponseSchema>) {
+  const inputs = detail.turns.map((turn) => ({ turn,
+    message: detail.messages.find((message) => message.id === turn.inputMessageId),
+  })).filter((input) => input.message !== undefined).sort((a, b) => a.message!.seq - b.message!.seq);
+  return inputs.flatMap(({ turn }, index) => {
+    const run = detail.runs.filter((candidate) => candidate.turnId === turn.id)
+      .reduce<(typeof detail.runs)[number] | undefined>((latest, candidate) =>
+        !latest || candidate.attempt > latest.attempt ? candidate : latest, undefined);
+    if (!run || (run.status !== "failed" && run.status !== "aborted")) return [];
+    return [{ id: `${run.id}:terminal`, runId: run.id,
+      beforeMessageId: inputs[index + 1]?.turn.inputMessageId,
+      text: run.status === "failed" ? "Agent work failed. Please try again." : "Agent work stopped.",
+      timestamp: Date.parse(run.completedAt ?? run.updatedAt),
+    }];
+  });
+}

--- a/packages/gateway/src/agent-sandbox.ts
+++ b/packages/gateway/src/agent-sandbox.ts
@@ -209,6 +209,7 @@ async function prepareScratchPath(
   homePath: string,
   sessionId: string,
   nowMs: () => number,
+  reuseExisting = false,
 ): Promise<string | null> {
   const scratchRoot = join(homePath, "system", "agent-scratch");
   await mkdir(scratchRoot, { recursive: true, mode: 0o700 });
@@ -226,6 +227,12 @@ async function prepareScratchPath(
     return scratchPath;
   } catch (err: unknown) {
     if (!isErrnoCode(err, "EEXIST")) throw err;
+    if (reuseExisting) {
+      const existing = await lstat(scratchPath);
+      return existing.isDirectory() && !existing.isSymbolicLink()
+        && await realpath(scratchPath) === join(canonicalScratchRoot, sessionId)
+        ? scratchPath : null;
+    }
     if (!await reclaimStaleScratchPath(homePath, sessionId, nowMs)) return null;
     try {
       await mkdir(scratchPath, { mode: 0o700 });
@@ -284,7 +291,7 @@ export function createAgentSandbox(options: {
       return statusForUid(currentUid(options.getUid), required);
     },
 
-    async preflight(input: unknown): Promise<
+    async preflight(input: unknown, recovery?: { reuseCodexScratch: true }): Promise<
       | { ok: true; sandbox: AgentLaunchSandbox | undefined; status: AgentSandboxStatus }
       | Failure
     > {
@@ -365,7 +372,8 @@ export function createAgentSandbox(options: {
       }
 
       const scratchPath = sandboxMode === "workspace_write" && !effectiveReadOnly
-        ? await prepareScratchPath(homePath, request.sessionId, nowMs)
+        ? await prepareScratchPath(homePath, request.sessionId, nowMs,
+          request.agent === "codex" && recovery?.reuseCodexScratch === true)
         : null;
       if (sandboxMode === "workspace_write" && !effectiveReadOnly && !scratchPath) {
         return failure(409, "sandbox_unavailable", "Agent sandbox is unavailable", uidStatus);

--- a/packages/gateway/src/chat/coding-provider-adapter.ts
+++ b/packages/gateway/src/chat/coding-provider-adapter.ts
@@ -104,6 +104,13 @@ function normalizeEvent(
   event: AgentThreadEvent,
   toolActivities: Map<string, ToolActivity>,
 ): CanonicalProviderRunEvent[] {
+  // External supervision can terminate a run after its runner died before publishing tool completion.
+  // Settle every observed activity before the terminal event reaches any renderer.
+  const settled = event.type === "thread.error" || event.type === "thread.completed"
+    ? [...toolActivities.keys()].flatMap((toolCallId) => normalizeEvent({
+      type: "tool.completed", eventId: event.eventId, threadId: event.threadId, occurredAt: event.occurredAt,
+      toolCallId, outcome: event.type === "thread.error" || event.outcome === "failed" ? "failed" : "cancelled",
+    }, toolActivities)) : [];
   if (event.type === "assistant.text.delta") {
     return [CanonicalProviderRunEventSchema.parse({
       type: "assistant.delta",
@@ -203,7 +210,7 @@ function normalizeEvent(
     })];
   }
   if (event.type === "thread.error") {
-    return [CanonicalProviderRunEventSchema.parse({
+    return [...settled, CanonicalProviderRunEventSchema.parse({
       type: "run.completed",
       outcome: "failed",
       error: CanonicalChatSafeErrorSchema.parse({
@@ -215,7 +222,7 @@ function normalizeEvent(
     })];
   }
   if (event.type === "thread.completed") {
-    return [CanonicalProviderRunEventSchema.parse({ type: "run.completed", outcome: event.outcome })];
+    return [...settled, CanonicalProviderRunEventSchema.parse({ type: "run.completed", outcome: event.outcome })];
   }
   return [];
 }

--- a/packages/gateway/src/chat/idle-runtime-admission.ts
+++ b/packages/gateway/src/chat/idle-runtime-admission.ts
@@ -1,0 +1,34 @@
+import { sql, type Kysely } from "kysely";
+import type { ChatDatabase } from "./database.js";
+import type { IdleWorkspaceIdentity } from "../coding-agents/idle-workspace-state.js";
+
+/** Lock the canonical Chat row across the bounded local stop, excluding concurrent queue/run admission. */
+export async function withCanonicalIdleChat(
+  database: Kysely<ChatDatabase>,
+  identity: IdleWorkspaceIdentity,
+  reclaim: () => Promise<boolean>,
+): Promise<boolean> {
+  return database.transaction().execute(async (trx) => {
+    await sql`SET LOCAL lock_timeout = '2s'`.execute(trx);
+    await sql`SET LOCAL statement_timeout = '5s'`.execute(trx);
+    const matches = await trx.selectFrom("chats").select("chats.id")
+      .where("owner_type", "=", "personal").where("owner_id", "=", identity.ownerId)
+      .where("bound_driver_kind", "=", "codex")
+      .where((eb) => eb.exists(eb.selectFrom("chat_run_adapter_state as adapter")
+        .innerJoin("chat_runs as run", "run.id", "adapter.run_id").select("run.id")
+        .whereRef("run.chat_id", "=", "chats.id").where("adapter.driver_kind", "=", "codex")
+        .where(sql<string>`adapter.state->>'conversationId'`, "=", identity.threadId)))
+      .limit(2).forUpdate().execute();
+    // Forks or missing provenance cannot safely authorize runtime reclamation.
+    if (matches.length !== 1) return false;
+    const chatId = matches[0].id;
+    const active = await trx.selectFrom("chat_runs").select("id").where("chat_id", "=", chatId)
+      .where("status", "in", ["accepted", "running", "waiting_for_approval", "waiting_for_input"]).executeTakeFirst();
+    const queued = await trx.selectFrom("chat_queued_turns").select("id").where("chat_id", "=", chatId)
+      .where("status", "=", "queued").executeTakeFirst();
+    const pendingSteer = await trx.selectFrom("chat_run_steers").select("id").where("chat_id", "=", chatId)
+      .where("status", "=", "pending").executeTakeFirst();
+    if (active || queued || pendingSteer) return false;
+    return reclaim();
+  });
+}

--- a/packages/gateway/src/coding-agents/chat-idle-reaper.ts
+++ b/packages/gateway/src/coding-agents/chat-idle-reaper.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "node:crypto";
+import type { createUserSystemdTerminalRuntime } from "../shell/user-systemd-terminal-runtime.js";
+import { workspaceRuntimeId } from "../user-systemd-zellij-runtime.js";
+import type { WorkspaceSessionOrchestrator } from "../workspace-session-orchestrator.js";
+import type { CodingAgentThreadStore } from "./thread-store.js";
+import type { CodexControlClient } from "./codex-control-client.js";
+import type { IdleWorkspaceIdentity } from "./idle-workspace-state.js";
+
+type Report = { checked: number; reclaimed: number; skipped: number };
+const IDLE_MS = 5 * 60_000;
+const PRESSURE_IDLE_MS = 60_000;
+const RETRY_MS = 5 * 60_000;
+
+/** Reconcile durable ownership before stopping any runtime. Unknown/legacy sessions fail closed. */
+export function createChatIdleReaper(options: {
+  controller: Pick<ReturnType<typeof createUserSystemdTerminalRuntime>, "list" | "isRunning" | "hibernateWorkspace">;
+  sessions: Pick<WorkspaceSessionOrchestrator, "getSession">;
+  threads: Pick<CodingAgentThreadStore, "withIdleWorkspace">;
+  control: Pick<CodexControlClient, "hibernate">;
+  admitCanonical: (identity: IdleWorkspaceIdentity, reclaim: () => Promise<boolean>) => Promise<boolean>;
+  unwatch: (sessionId: string) => void;
+  underPressure: () => Promise<boolean>;
+  now?: () => number;
+}) {
+  const now = options.now ?? Date.now;
+  const retryAfter = new Map<string, number>(); // bounded by descriptor inventory; TTL cleanup on each sweep
+  let cursor = 0;
+  let closed = false;
+  let pending: Promise<Report> | undefined;
+
+  async function reconcile(): Promise<Report> {
+    const report = { checked: 0, reclaimed: 0, skipped: 0 };
+    if (closed || !options.control.hibernate) return report;
+    const time = now();
+    for (const [id, expires] of retryAfter) if (expires <= time) retryAfter.delete(id);
+    const cutoff = time - (await options.underPressure() ? PRESSURE_IDLE_MS : IDLE_MS);
+    const runtimes = await options.controller.list({ scope: "workspace" });
+    for (let scanned = 0; scanned < Math.min(runtimes.length, 8) && report.reclaimed < 2 && !closed; scanned++) {
+      cursor %= runtimes.length;
+      const runtime = runtimes[cursor++];
+      if (runtime.scope !== "workspace" || !/^sess_[A-Za-z0-9_-]+$/.test(runtime.displayName)
+        || runtime.runtimeId !== workspaceRuntimeId(runtime.displayName) || retryAfter.has(runtime.runtimeId)) continue;
+      report.checked++;
+      try {
+        const reclaimed = await options.threads.withIdleWorkspace(runtime.displayName, cutoff, async (identity) => {
+          const ownerSession = await options.sessions.getSession(identity.sessionId);
+          if (!ownerSession.ok || ownerSession.session.ownerId !== identity.ownerId
+            || ownerSession.session.id !== identity.sessionId || ownerSession.session.kind !== "agent"
+            || ownerSession.session.agent !== "codex" || ownerSession.session.attachedClients > 0
+            || !(Date.parse(ownerSession.session.lastActivityAt) <= cutoff)
+            || !await options.controller.isRunning(runtime.runtimeId)) return false;
+          return options.admitCanonical(identity, async () => {
+            if (closed) return false;
+            // A recorded stop intent survives a gateway crash. Otherwise require the live runner's idle boundary.
+            if (!runtime.hibernatedAt) await options.control.hibernate!({ sessionId: identity.sessionId,
+              providerThreadId: identity.providerThreadId, clientRequestId: `req_${randomUUID()}` });
+            await options.controller.hibernateWorkspace(runtime.runtimeId, runtime);
+            options.unwatch(identity.sessionId);
+            return true;
+          });
+        });
+        if (reclaimed) report.reclaimed++;
+        else report.skipped++;
+      } catch (error: unknown) {
+        report.skipped++;
+        if (retryAfter.size >= 256) retryAfter.delete(retryAfter.keys().next().value!);
+        retryAfter.set(runtime.runtimeId, time + RETRY_MS);
+        console.warn("[chat-runtime] idle reclamation deferred", { errorType: error instanceof Error ? error.name : "UnknownError" });
+      }
+    }
+    return report;
+  }
+
+  function sweep(): Promise<Report> {
+    if (pending) return pending;
+    pending = reconcile().finally(() => { pending = undefined; });
+    return pending;
+  }
+  const timer = setInterval(() => {
+    void sweep().then((report) => {
+      if (report.reclaimed) console.info("[chat-runtime] idle reclamation", report);
+    }).catch((error: unknown) => {
+      console.warn("[chat-runtime] idle reconciliation unavailable", { errorType: error instanceof Error ? error.name : "UnknownError" });
+    });
+  }, 10_000);
+  timer.unref();
+  return {
+    sweep,
+    async close() { closed = true; clearInterval(timer); await pending; retryAfter.clear(); },
+  };
+}

--- a/packages/gateway/src/coding-agents/codex-app-server-contract.json
+++ b/packages/gateway/src/coding-agents/codex-app-server-contract.json
@@ -65,7 +65,8 @@
     "item/commandExecution/requestApproval",
     "item/fileChange/requestApproval",
     "item/tool/requestUserInput",
-    "item/permissions/requestApproval"
+    "item/permissions/requestApproval",
+    "mcpServer/elicitation/request"
   ],
   "requiredServerNotifications": [
     "item/started",
@@ -85,6 +86,7 @@
     "item/fileChange/requestApproval": "ac5be166d6a7668792b810a97be8bdfb02b2107320d93d0c4d783a11d32d8cf9",
     "item/tool/requestUserInput": "f998a4ecef0e0d5dfc1bf5a093ee77663ec0b9f4dc71c41e02b8c13136f439c2",
     "item/permissions/requestApproval": "12ce5d7e867474efcdb8354bc1324e3fdd93b2078cacbbe7d5a0ad15a85a331f",
+    "mcpServer/elicitation/request": "7db52750b4b1e97486c99734d8a785fa3b112b29908458e3b166c6d6aa9bfecf",
     "item/started": "a67dae0c2bcd4245eec5a249c7ce71ae193604a2601a5ee2d14efd5e9beb2ed6",
     "item/completed": "c26cb115b8ebff983ca9d13b004a31183552df287d6d048988bc05af13e30cb0",
     "item/agentMessage/delta": "427d58ea4e1b0fd7afce1035cefd40df96d7dc48b82cbe293a2f69ed4e803bf9",

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -11,6 +11,7 @@ import { assertCodexProviderVersion } from "./codex-provider-version-check.mjs";
 import { createCodexSessionApprovalGrants } from "./codex-session-approvals.mjs";
 import { createCodexExecutionWatchdog } from "./codex-execution-watchdog.mjs";
 import { CodexHibernateControlSchema, createCodexIdleHibernation } from "./codex-idle-hibernation.mjs";
+import { createCodexMcpElicitations, rejectCodexServerRequest } from "./codex-mcp-elicitations.mjs";
 
 process.on("uncaughtException", () => {
   process.stderr.write("Codex app-server runner stopped unexpectedly.\n");
@@ -374,10 +375,11 @@ const pendingApprovals = new Map();
 const sessionApprovalGrants = createCodexSessionApprovalGrants();
 const pendingInputs = new Map();
 const completedControls = new Map();
+const mcpElicitations = createCodexMcpElicitations({ send: sendProvider, persist, safeText: safeExternalText });
 const idleHibernation = createCodexIdleHibernation(() => ({
   providerThreadId: nativeThreadId, completedTurns: terminalEventCount,
   active: activeTurn || stopping,
-  pending: pendingTurns.length + pendingApprovals.size + pendingInputs.size + pendingRpc.size,
+  pending: pendingTurns.length + pendingApprovals.size + pendingInputs.size + pendingRpc.size + mcpElicitations.size,
   otherControls: controlSockets.size > 1,
 }));
 const assistantItemsWithDelta = new Set();
@@ -389,7 +391,7 @@ let toolBoundaryVersion = 0;
 let executionExpired = false;
 let rejectExecution;
 const executionWatchdog = createCodexExecutionWatchdog({
-  waitingForHuman: () => pendingApprovals.size > 0 || pendingInputs.size > 0,
+  waitingForHuman: () => pendingApprovals.size > 0 || pendingInputs.size > 0 || mcpElicitations.size > 0,
   expire: (diagnostic) => {
     if (!activeTurn) return;
     executionExpired = true;
@@ -824,7 +826,7 @@ async function handleItemLifecycle(raw) {
 
 async function handleProviderMessage(raw) {
   const response = RpcResponseSchema.safeParse(raw);
-  if (response.success && pendingRpc.has(response.data.id)) {
+  if (raw?.method === undefined && response.success && pendingRpc.has(response.data.id)) {
     const pending = pendingRpc.get(response.data.id);
     pendingRpc.delete(response.data.id);
     clearTimeout(pending.timeout);
@@ -834,12 +836,19 @@ async function handleProviderMessage(raw) {
   }
   // A deadline settles this execution once. Do not accept late tool results,
   // approvals or a final answer while interruption/shutdown is in flight.
-  if (executionExpired) return;
-  if (!activeTurn) return;
+  if (executionExpired || !activeTurn) {
+    rejectCodexServerRequest(raw, sendProvider, -32000);
+    return;
+  }
   const notificationTurnId = raw?.params?.turnId ?? raw?.params?.turn?.id;
-  if (activeNativeTurnId && notificationTurnId && notificationTurnId !== activeNativeTurnId) return;
+  if (activeNativeTurnId && notificationTurnId && notificationTurnId !== activeNativeTurnId) {
+    rejectCodexServerRequest(raw, sendProvider, -32000);
+    return;
+  }
   if (await handleApproval(raw)) return;
   if (await handleInput(raw)) return;
+  if (await mcpElicitations.handle(raw, nativeThreadId)) return;
+  if (rejectCodexServerRequest(raw, sendProvider)) return;
   if (await handleItemLifecycle(raw)) return;
   const outputDelta = ToolOutputDeltaSchema.safeParse(raw);
   if (outputDelta.success) {
@@ -993,17 +1002,19 @@ async function applyControl(control) {
     if (!nativeThreadId || !activeNativeTurnId) return { ok: false };
     await request("turn/interrupt", { threadId: nativeThreadId, turnId: activeNativeTurnId });
   } else if (control.type === "approval") {
-    const pending = pendingApprovals.get(control.approvalId);
-    if (!pending || !pending.allowedDecisions.includes(control.decision)) return { ok: false };
-    const nativeDecision = pending.nativeDecisionByMatrixDecision[control.decision];
-    sendProvider({
-      id: pending.nativeRequestId,
-      result: { decision: nativeDecision },
-    });
-    if (control.decision === "approve_for_session") {
-      sessionApprovalGrants.grant(pending.method);
+    if (!mcpElicitations.decide(control.approvalId, control.decision)) {
+      const pending = pendingApprovals.get(control.approvalId);
+      if (!pending || !pending.allowedDecisions.includes(control.decision)) return { ok: false };
+      const nativeDecision = pending.nativeDecisionByMatrixDecision[control.decision];
+      sendProvider({
+        id: pending.nativeRequestId,
+        result: { decision: nativeDecision },
+      });
+      if (control.decision === "approve_for_session") {
+        sessionApprovalGrants.grant(pending.method);
+      }
+      pendingApprovals.delete(control.approvalId);
     }
-    pendingApprovals.delete(control.approvalId);
   } else {
     const pending = pendingInputs.get(control.requestId);
     if (!pending) return { ok: false };
@@ -1070,6 +1081,7 @@ await chmod(controlPath, 0o600);
 
 const cleanupTimer = setInterval(() => {
   const now = Date.now();
+  try { mcpElicitations.sweep(); } catch (_error) { stopping = true; }
   for (const [approvalId, pending] of pendingApprovals) {
     if (pending.expiresAt > now) continue;
     pendingApprovals.delete(approvalId);
@@ -1185,6 +1197,7 @@ function stop() {
 
 async function finishTurn(outcome) {
   executionWatchdog.stop();
+  mcpElicitations.drain();
   const hasUnsettledItems = assistantItemsWithDelta.size > 0 ||
     assistantDeltaBuffers.size > 0 ||
     startedToolItems.size > 0 ||

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -1002,7 +1002,7 @@ async function applyControl(control) {
     if (!nativeThreadId || !activeNativeTurnId) return { ok: false };
     await request("turn/interrupt", { threadId: nativeThreadId, turnId: activeNativeTurnId });
   } else if (control.type === "approval") {
-    if (!mcpElicitations.decide(control.approvalId, control.decision)) {
+    if (!await mcpElicitations.decide(control.approvalId, control.decision)) {
       const pending = pendingApprovals.get(control.approvalId);
       if (!pending || !pending.allowedDecisions.includes(control.decision)) return { ok: false };
       const nativeDecision = pending.nativeDecisionByMatrixDecision[control.decision];
@@ -1081,7 +1081,10 @@ await chmod(controlPath, 0o600);
 
 const cleanupTimer = setInterval(() => {
   const now = Date.now();
-  try { mcpElicitations.sweep(); } catch (_error) { stopping = true; }
+  void mcpElicitations.sweep().catch(() => {
+    process.stderr.write("Integration expiry could not be settled.\n");
+    stop();
+  });
   for (const [approvalId, pending] of pendingApprovals) {
     if (pending.expiresAt > now) continue;
     pendingApprovals.delete(approvalId);
@@ -1197,7 +1200,7 @@ function stop() {
 
 async function finishTurn(outcome) {
   executionWatchdog.stop();
-  mcpElicitations.drain();
+  await mcpElicitations.drain();
   const hasUnsettledItems = assistantItemsWithDelta.size > 0 ||
     assistantDeltaBuffers.size > 0 ||
     startedToolItems.size > 0 ||

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -10,6 +10,7 @@ import { z } from "zod/v4";
 import { assertCodexProviderVersion } from "./codex-provider-version-check.mjs";
 import { createCodexSessionApprovalGrants } from "./codex-session-approvals.mjs";
 import { createCodexExecutionWatchdog } from "./codex-execution-watchdog.mjs";
+import { CodexHibernateControlSchema, createCodexIdleHibernation } from "./codex-idle-hibernation.mjs";
 
 process.on("uncaughtException", () => {
   process.stderr.write("Codex app-server runner stopped unexpectedly.\n");
@@ -291,6 +292,7 @@ const SteerControlSchema = z.object({
   clientRequestId: ApprovalControlSchema.shape.clientRequestId,
 }).strict();
 const ControlSchema = z.discriminatedUnion("type", [
+  CodexHibernateControlSchema,
   TurnControlSchema,
   SteerControlSchema,
   InterruptControlSchema,
@@ -372,6 +374,12 @@ const pendingApprovals = new Map();
 const sessionApprovalGrants = createCodexSessionApprovalGrants();
 const pendingInputs = new Map();
 const completedControls = new Map();
+const idleHibernation = createCodexIdleHibernation(() => ({
+  providerThreadId: nativeThreadId, completedTurns: terminalEventCount,
+  active: activeTurn || stopping,
+  pending: pendingTurns.length + pendingApprovals.size + pendingInputs.size + pendingRpc.size,
+  otherControls: controlSockets.size > 1,
+}));
 const assistantItemsWithDelta = new Set();
 const assistantDeltaBuffers = new Map();
 const startedToolItems = new Set();
@@ -926,7 +934,7 @@ async function discardProviderErrors(stream) {
 }
 
 function controlResponse(socket, value) {
-  socket.end(`${JSON.stringify(value)}\n`);
+  socket.end(`${JSON.stringify(value)}\n`, () => { if (idleHibernation.closing) stop(); });
 }
 
 async function steerActiveTurn(control) {
@@ -970,6 +978,8 @@ async function steerActiveTurn(control) {
 }
 
 async function applyControl(control) {
+  if (control.type === "hibernate") return { ok: idleHibernation.prepare(control.providerThreadId) };
+  if (idleHibernation.closing) return { ok: false };
   const replay = completedControls.get(control.clientRequestId);
   if (replay) {
     const same = replay.fingerprint === digest([control]);
@@ -1122,7 +1132,7 @@ function enqueueTurn(line) {
 }
 
 function enqueuePendingTurn(turn) {
-  if (pendingTurns.length >= MAX_PENDING_TURNS) return false;
+  if (idleHibernation.closing || stopping || pendingTurns.length >= MAX_PENDING_TURNS) return false;
   pendingTurns.push(turn);
   wakeTurn?.();
   wakeTurn = undefined;
@@ -1200,7 +1210,7 @@ async function finishTurn(outcome) {
     await persist({
       type: "matrix.codex.tool.completed",
       toolCallId,
-      outcome: executionExpired ? "failed" : "cancelled",
+      outcome: outcome === "failed" ? "failed" : "cancelled",
     });
     startedToolItems.delete(toolCallId);
     toolItemsWithOutput.delete(toolCallId);
@@ -1301,6 +1311,10 @@ try {
   });
   nativeThreadId = z.object({ thread: z.object({ id: NativeReferenceSchema }).passthrough() })
     .passthrough().parse(started).thread.id;
+  if (config.providerThreadId && nativeThreadId !== config.providerThreadId) {
+    throw new Error("provider_resume_identity_mismatch");
+  }
+  await persist({ type: "thread.started", thread_id: nativeThreadId });
   let turn = PendingTurnSchema.parse({
     prompt: config.prompt,
     model: config.model,

--- a/packages/gateway/src/coding-agents/codex-control-client.ts
+++ b/packages/gateway/src/coding-agents/codex-control-client.ts
@@ -11,6 +11,7 @@ import {
   UserInputAnswerRequestSchema,
 } from "@matrix-os/contracts";
 import { codexProviderEventPath } from "./codex-event-bridge.js";
+import { CodexHibernateControlSchema } from "./codex-idle-hibernation.mjs";
 
 const SessionIdSchema = z.string().regex(/^sess_[A-Za-z0-9_-]{1,128}$/);
 const MatrixQuestionIdSchema = z.string().regex(/^question_codex_[a-f0-9]{24}$/);
@@ -52,6 +53,7 @@ const SteerFrameSchema = z.object({
   clientRequestId: RequestIdSchema,
 }).strict();
 const ControlFrameSchema = z.discriminatedUnion("type", [
+  CodexHibernateControlSchema,
   TurnFrameSchema,
   SteerFrameSchema,
   InterruptFrameSchema,
@@ -73,6 +75,7 @@ const MAX_CONTROL_FRAME_BYTES = 128 * 1024;
 const MAX_RESPONSE_BYTES = 4 * 1024;
 
 export interface CodexControlClient {
+  hibernate?(input: { sessionId: string; providerThreadId: string; clientRequestId: string }): Promise<void>;
   submitTurn(input: {
     sessionId: string;
     turnId: string;
@@ -111,7 +114,7 @@ export function codexProviderControlPath(homePath: string, sessionId: string): s
 export function createCodexControlClient(options: {
   homePath: string;
   timeoutMs?: number;
-}): CodexControlClient {
+}): CodexControlClient & Required<Pick<CodexControlClient, "hibernate">> {
   const homePath = resolve(options.homePath);
   const requestedTimeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const timeoutMs = Number.isFinite(requestedTimeoutMs)
@@ -126,6 +129,8 @@ export function createCodexControlClient(options: {
   ): Promise<void> {
     const frame = ControlFrameSchema.parse(input);
     const path = codexProviderControlPath(homePath, sessionId);
+    let sent = false;
+    let rejected = false;
     try {
       const info = await lstat(path);
       if (!info.isSocket() || info.isSymbolicLink()) throw new Error("control_unavailable");
@@ -151,7 +156,7 @@ export function createCodexControlClient(options: {
         socket.setEncoding("utf8");
         socket.setTimeout(operationTimeoutMs, fail);
         socket.once("error", fail);
-        socket.once("connect", () => socket.end(line));
+        socket.once("connect", () => { sent = true; socket.end(line); });
         socket.on("data", (chunk) => {
           responseText += chunk;
           if (Buffer.byteLength(responseText, "utf8") > MAX_RESPONSE_BYTES) fail();
@@ -171,13 +176,19 @@ export function createCodexControlClient(options: {
           if (!settled) fail();
         });
       });
-      if (!response.ok) throw new Error("control_rejected");
+      if (!response.ok) { rejected = true; throw new Error("control_rejected"); }
     } catch (_error) {
-      throw new Error("Codex control request failed");
+      const error = new Error("Codex control request failed");
+      error.name = rejected ? "CodexControlRejectedError" : sent ? "CodexControlTransportError" : "CodexControlUnavailableError";
+      throw error;
     }
   }
 
   return {
+    hibernate(input) {
+      return send(input.sessionId, { type: "hibernate", providerThreadId: input.providerThreadId,
+        clientRequestId: input.clientRequestId }, Math.min(timeoutMs, 2_000));
+    },
     submitTurn(input) {
       return send(input.sessionId, {
         type: "turn",

--- a/packages/gateway/src/coding-agents/codex-event-bridge.ts
+++ b/packages/gateway/src/coding-agents/codex-event-bridge.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { lstat, mkdir, open, readdir, realpath, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
@@ -18,6 +18,7 @@ import { codexExecContractStatus } from "./codex-version.js";
 import { codexAppServerContractStatus } from "./codex-app-server-version.js";
 import { CodexExecutableSchema, codexExecutableFromEnv } from "./codex-executable.js";
 import type { CodingAgentProviderEventBatch } from "./provider-adapter.js";
+import { runtimeUnavailable, type RuntimeSupervision } from "./codex-runtime-supervision.js";
 
 const SessionIdSchema = z.string().regex(/^sess_[A-Za-z0-9_-]{1,128}$/);
 const WatchInputSchema = z.object({
@@ -49,6 +50,8 @@ type ProviderEventStore = {
   ): Promise<unknown>;
 };
 type WatchEntry = {
+  supervision: RuntimeSupervision;
+  failureEvents?: AgentThreadEvent[];
   principal: RequestPrincipal;
   threadId: string;
   sessionId: string;
@@ -122,6 +125,7 @@ export function createCodexEventBridge(options: {
   pollIntervalMs?: number;
   now?: () => Date;
   nowMs?: () => number;
+  isRuntimeAlive?: (sessionId: string) => Promise<boolean>;
 }) {
   const homePath = resolve(options.homePath);
   const eventDir = join(homePath, "system", "coding-agents", "provider-events");
@@ -217,12 +221,13 @@ export function createCodexEventBridge(options: {
     }
   }
 
-  async function ingest(entry: WatchEntry, bytes: Buffer, consumedBytes: number): Promise<boolean> {
+  async function ingest(entry: WatchEntry, bytes: Buffer, consumedBytes: number): Promise<{ terminal: boolean; ready: boolean }> {
     if (!store) throw new Error("Codex event store is unavailable");
     const events: AgentThreadEvent[] = [];
     let providerThreadId: string | undefined;
     let tokenUsage: AiTokenUsage | undefined;
     let terminal = false;
+    let ready = false;
     let lineStart = 0;
     let absoluteOffset = entry.offset;
     const occurredAt = entry.pendingOccurredAt ?? now().toISOString();
@@ -238,6 +243,7 @@ export function createCodexEventBridge(options: {
         nextEventId: () => eventId(entry.sessionId, absoluteOffset, index++),
       });
       events.push(...parsed.events);
+      ready ||= parsed.events.length > 0 || !!parsed.providerThreadId || !!parsed.outcome;
       if (parsed.providerThreadId) {
         if (providerThreadId && providerThreadId !== parsed.providerThreadId) {
           throw new Error("Codex provider conversation changed");
@@ -268,10 +274,11 @@ export function createCodexEventBridge(options: {
         ...(index === chunks.length - 1 && terminal && tokenUsage ? { tokenUsage } : {}),
       });
     }
-    return terminal;
+    return { terminal, ready };
   }
 
-  async function drainEntry(entry: WatchEntry): Promise<void> {
+  // True means all complete records were consumed; an incomplete final line is not a durable event.
+  async function drainEntry(entry: WatchEntry): Promise<boolean> {
     const stoppedDrainExpired = () =>
       entry.stopRequestedAt !== undefined && nowMs() - entry.stopRequestedAt >= STOP_DRAIN_GRACE_MS;
     let handle;
@@ -279,11 +286,11 @@ export function createCodexEventBridge(options: {
       const info = await lstat(entry.path);
       if (info.isSymbolicLink() || !info.isFile() || info.size > MAX_TRANSCRIPT_BYTES) {
         watchers.delete(entry.sessionId);
-        return;
+        return false;
       }
       if (info.size <= entry.offset) {
         if (stoppedDrainExpired()) watchers.delete(entry.sessionId);
-        return;
+        return true;
       }
       const length = Math.min(info.size - entry.offset, MAX_DRAIN_BYTES);
       const bytes = Buffer.alloc(length);
@@ -293,20 +300,25 @@ export function createCodexEventBridge(options: {
       const lastNewline = data.lastIndexOf(0x0a);
       if (lastNewline < 0) {
         if (stoppedDrainExpired()) watchers.delete(entry.sessionId);
-        return;
+        return true;
       }
       const consumedBytes = lastNewline + 1;
-      const terminal = await ingest(entry, data, consumedBytes);
+      if (closed || watchers.get(entry.sessionId) !== entry) return false;
+      const { terminal, ready } = await ingest(entry, data, consumedBytes);
       entry.offset += consumedBytes;
+      entry.supervision.ready ||= ready;
+      entry.supervision.terminal ||= terminal;
       entry.lastTouchedAt = nowMs();
       entry.pendingOccurredAt = undefined;
       if (terminal && entry.stopRequestedAt !== undefined) watchers.delete(entry.sessionId);
+      return info.size - entry.offset <= data.length - consumedBytes;
     } catch (error: unknown) {
       if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
         if (stoppedDrainExpired()) watchers.delete(entry.sessionId);
-        return;
+        return true;
       }
       console.warn("[coding-agents] Codex event ingestion will retry");
+      return false;
     } finally {
       await handle?.close();
     }
@@ -315,11 +327,41 @@ export function createCodexEventBridge(options: {
   async function drainAll(): Promise<void> {
     if (closed) return;
     await cleanupOrphans();
-    for (const entry of watchers.values()) await drainEntry(entry);
+    const entries = [...watchers.values()];
+    for (let start = 0; start < entries.length; start += 10) {
+      await Promise.all(entries.slice(start, start + 10).map(async (entry) => {
+        await drainEntry(entry);
+        if (!store || !options.isRuntimeAlive || watchers.get(entry.sessionId) !== entry) return;
+        if (!entry.failureEvents && !await runtimeUnavailable(entry.supervision,
+          () => options.isRuntimeAlive!(entry.sessionId), nowMs())) return;
+        if (closed || watchers.get(entry.sessionId) !== entry || entry.supervision.terminal) return;
+        // A final batch may have arrived during the probe; give persisted output priority.
+        if (!await drainEntry(entry)) return;
+        if (entry.supervision.terminal || watchers.get(entry.sessionId) !== entry) return;
+        entry.failureEvents ??= completionEvents({ threadId: entry.threadId, outcome: "failed",
+          occurredAt: now().toISOString(), nextEventId: (() => {
+            let index = 0;
+            const epoch = randomUUID();
+            return () => eventId(`${entry.sessionId}:${epoch}`, entry.offset, 10_000 + index++);
+          })(),
+        });
+        try {
+          await store.ingestProviderEvents(entry.principal, entry.threadId, { events: entry.failureEvents });
+          if (watchers.get(entry.sessionId) === entry) watchers.delete(entry.sessionId);
+        } catch (error: unknown) {
+          console.warn("[coding-agents] Runtime failure persistence will retry", {
+            errorType: error instanceof Error ? error.name : "UnknownError",
+          });
+        }
+      }));
+    }
   }
 
+  let drainScheduled = false;
   const timer = setInterval(() => {
-    queue = queue.then(drainAll, drainAll);
+    if (drainScheduled) return;
+    drainScheduled = true;
+    queue = queue.then(drainAll, drainAll).finally(() => { drainScheduled = false; });
   }, pollIntervalMs);
   timer.unref();
 
@@ -351,12 +393,12 @@ export function createCodexEventBridge(options: {
         if (existing.threadId !== parsed.threadId || existing.principal.userId !== input.principal.userId) {
           throw new Error("Codex event watcher identity mismatch");
         }
-        existing.lastTouchedAt = nowMs();
-        return { path };
+        if (!parsed.startAtEnd) { existing.lastTouchedAt = nowMs(); return { path }; }
       }
-      evictIfNeeded();
-      let offset = 0;
-      if (parsed.startAtEnd) {
+      if (!existing) evictIfNeeded();
+      // Renew supervision without dropping bytes already owned by an active watcher.
+      let offset = existing?.offset ?? 0;
+      if (parsed.startAtEnd && !existing) {
         try {
           const info = await lstat(path);
           if (info.isSymbolicLink() || !info.isFile() || info.size > MAX_TRANSCRIPT_BYTES) {
@@ -370,6 +412,8 @@ export function createCodexEventBridge(options: {
         }
       }
       watchers.set(parsed.sessionId, {
+        supervision: { startedAt: nowMs(), nextProbeAt: nowMs() + 10_000, failures: 0,
+          ready: false, terminal: false },
         principal: input.principal,
         threadId: parsed.threadId,
         sessionId: parsed.sessionId,

--- a/packages/gateway/src/coding-agents/codex-events.ts
+++ b/packages/gateway/src/coding-agents/codex-events.ts
@@ -100,6 +100,11 @@ const CodexExecEventSchema = z.discriminatedUnion("type", [
 ]);
 const MatrixCodexRecordSchema = z.discriminatedUnion("type", [
   z.object({
+    type: z.literal("matrix.codex.approval.resolved"),
+    approvalId: ApprovalIdSchema,
+    decision: z.literal("cancel"),
+  }).strict(),
+  z.object({
     type: z.literal("matrix.codex.approval.requested"),
     approvalId: ApprovalIdSchema,
     correlationId: CorrelationIdSchema,
@@ -214,6 +219,9 @@ function appServerRecordEvents(
   context: CodexEventContext,
   record: z.infer<typeof MatrixCodexRecordSchema>,
 ): AgentThreadEvent[] {
+  if (record.type === "matrix.codex.approval.resolved") {
+    return [event(context, { type: "approval.resolved", approvalId: record.approvalId, decision: record.decision })];
+  }
   if (record.type === "matrix.codex.approval.requested") {
     return [event(context, {
       type: "approval.requested",

--- a/packages/gateway/src/coding-agents/codex-idle-hibernation.d.mts
+++ b/packages/gateway/src/coding-agents/codex-idle-hibernation.d.mts
@@ -1,0 +1,13 @@
+import type { z } from "zod/v4";
+export const CodexHibernateControlSchema: z.ZodObject<{
+  type: z.ZodLiteral<"hibernate">;
+  providerThreadId: z.ZodString;
+  clientRequestId: z.ZodString;
+}>;
+export function createCodexIdleHibernation(readState: () => {
+  providerThreadId?: string;
+  completedTurns: number;
+  active: boolean;
+  pending: number;
+  otherControls: boolean;
+}): { readonly closing: boolean; prepare(providerThreadId: string): boolean };

--- a/packages/gateway/src/coding-agents/codex-idle-hibernation.mjs
+++ b/packages/gateway/src/coding-agents/codex-idle-hibernation.mjs
@@ -1,0 +1,24 @@
+import { z } from "zod/v4";
+
+// Private owner-only control socket protocol; old runners reject it and are not auto-reaped.
+export const CodexHibernateControlSchema = z.object({
+  type: z.literal("hibernate"),
+  providerThreadId: z.string().min(1).max(512).regex(/^[A-Za-z0-9][A-Za-z0-9_-]*$/),
+  clientRequestId: z.string().min(1).max(160).regex(/^req_[A-Za-z0-9_-]+$/),
+}).strict();
+
+/** Reserve the idle boundary synchronously so queued input cannot race a successful handshake. */
+export function createCodexIdleHibernation(readState) {
+  let closing = false;
+  return {
+    get closing() { return closing; },
+    prepare(providerThreadId) {
+      const state = readState();
+      if (state.providerThreadId !== providerThreadId) return false;
+      if (closing) return true;
+      if (!state.completedTurns || state.active || state.pending || state.otherControls) return false;
+      closing = true;
+      return true;
+    },
+  };
+}

--- a/packages/gateway/src/coding-agents/codex-mcp-elicitations.mjs
+++ b/packages/gateway/src/coding-agents/codex-mcp-elicitations.mjs
@@ -35,6 +35,14 @@ export function createCodexMcpElicitations({ send, persist, safeText, now = Date
   // Owned by this runner; bounded admission, expiry sweep and turn-end drain.
   const pending = new Map();
   const cancel = entry => send({ id: entry.nativeRequestId, result: { action: "cancel", content: null } });
+  async function expire(approvalId, entry) {
+    pending.delete(approvalId); // Fence concurrent and late decisions before any await.
+    try {
+      await persist({ type: "matrix.codex.approval.resolved", approvalId, decision: "cancel" });
+    } finally {
+      try { cancel(entry); } catch (_error) { process.stderr.write("Integration cancellation could not be delivered.\n"); }
+    }
+  }
   return {
     get size() { return pending.size; },
     async handle(raw, threadId) {
@@ -63,10 +71,10 @@ export function createCodexMcpElicitations({ send, persist, safeText, now = Date
       });
       return true;
     },
-    decide(approvalId, decision) {
+    async decide(approvalId, decision) {
       const entry = pending.get(approvalId);
       if (!entry || !["approve", "decline", "cancel"].includes(decision)) return false;
-      if (entry.expiresAt <= now()) { pending.delete(approvalId); cancel(entry); return false; }
+      if (entry.expiresAt <= now()) { await expire(approvalId, entry); return false; }
       send({ id: entry.nativeRequestId, result: {
         action: decision === "approve" ? "accept" : decision,
         content: decision === "approve" ? {} : null,
@@ -74,18 +82,17 @@ export function createCodexMcpElicitations({ send, persist, safeText, now = Date
       pending.delete(approvalId);
       return true;
     },
-    sweep() {
+    async sweep() {
       for (const [id, entry] of pending) {
         if (entry.expiresAt > now()) continue;
-        pending.delete(id);
-        cancel(entry);
+        await expire(id, entry);
       }
     },
-    drain() {
-      const entries = [...pending.values()];
+    async drain() {
+      const entries = [...pending.entries()];
       pending.clear();
-      for (const entry of entries) {
-        try { cancel(entry); } catch (_error) { process.stderr.write("Integration cancellation could not be delivered.\n"); }
+      for (const [id, entry] of entries) {
+        await expire(id, entry);
       }
     },
   };

--- a/packages/gateway/src/coding-agents/codex-mcp-elicitations.mjs
+++ b/packages/gateway/src/coding-agents/codex-mcp-elicitations.mjs
@@ -35,13 +35,18 @@ export function createCodexMcpElicitations({ send, persist, safeText, now = Date
   // Owned by this runner; bounded admission, expiry sweep and turn-end drain.
   const pending = new Map();
   const cancel = entry => send({ id: entry.nativeRequestId, result: { action: "cancel", content: null } });
-  async function expire(approvalId, entry) {
-    pending.delete(approvalId); // Fence concurrent and late decisions before any await.
-    try {
-      await persist({ type: "matrix.codex.approval.resolved", approvalId, decision: "cancel" });
-    } finally {
-      try { cancel(entry); } catch (_error) { process.stderr.write("Integration cancellation could not be delivered.\n"); }
-    }
+  function expire(approvalId, entry) {
+    // Fence decisions immediately, but retain the bounded entry so terminal
+    // draining also waits for a resolution already started by the sweep.
+    entry.resolution ??= Promise.resolve().then(async () => {
+      try {
+        await persist({ type: "matrix.codex.approval.resolved", approvalId, decision: "cancel" });
+        pending.delete(approvalId);
+      } finally {
+        try { cancel(entry); } catch (_error) { process.stderr.write("Integration cancellation could not be delivered.\n"); }
+      }
+    });
+    return entry.resolution;
   }
   return {
     get size() { return pending.size; },
@@ -73,7 +78,7 @@ export function createCodexMcpElicitations({ send, persist, safeText, now = Date
     },
     async decide(approvalId, decision) {
       const entry = pending.get(approvalId);
-      if (!entry || !["approve", "decline", "cancel"].includes(decision)) return false;
+      if (!entry || entry.resolution || !["approve", "decline", "cancel"].includes(decision)) return false;
       if (entry.expiresAt <= now()) { await expire(approvalId, entry); return false; }
       send({ id: entry.nativeRequestId, result: {
         action: decision === "approve" ? "accept" : decision,
@@ -89,11 +94,7 @@ export function createCodexMcpElicitations({ send, persist, safeText, now = Date
       }
     },
     async drain() {
-      const entries = [...pending.entries()];
-      pending.clear();
-      for (const [id, entry] of entries) {
-        await expire(id, entry);
-      }
+      await Promise.all([...pending].map(([id, entry]) => expire(id, entry)));
     },
   };
 }

--- a/packages/gateway/src/coding-agents/codex-mcp-elicitations.mjs
+++ b/packages/gateway/src/coding-agents/codex-mcp-elicitations.mjs
@@ -1,0 +1,92 @@
+import { createHash } from "node:crypto";
+import { z } from "zod/v4";
+
+const RequestId = z.union([z.string().min(1).max(128), z.number().int().safe()]);
+const Reference = z.string().min(1).max(512);
+const SensitiveMessage = /[\u0000-\u001f\u007f]|(?:api[_-]?key|authorization|cookie|credential|password|secret|token)\s*(?:=|:|\s)/i;
+const Request = z.object({
+  id: RequestId,
+  method: z.literal("mcpServer/elicitation/request"),
+  params: z.object({
+    threadId: Reference,
+    turnId: Reference.nullable().optional(),
+    serverName: Reference,
+    mode: z.string().max(80),
+    message: z.string().max(2400),
+    requestedSchema: z.unknown().optional(),
+  }).passthrough(),
+}).passthrough();
+// Codex 0.153.4 emits this empty form for an MCP tool-use confirmation.
+// Forms requiring values and URL authentication need a dedicated UI, not an
+// empty "accept" response or a silently dropped server request.
+const Confirmation = z.object({
+  type: z.literal("object"),
+  properties: z.object({}).strict(),
+  required: z.array(z.never()).optional(),
+}).strict();
+
+export function rejectCodexServerRequest(raw, send, code = -32601) {
+  if (!raw || typeof raw.method !== "string" || !RequestId.safeParse(raw.id).success) return false;
+  send({ id: raw.id, error: { code, message: "This request is unavailable." } });
+  return true;
+}
+
+export function createCodexMcpElicitations({ send, persist, safeText, now = Date.now }) {
+  // Owned by this runner; bounded admission, expiry sweep and turn-end drain.
+  const pending = new Map();
+  const cancel = entry => send({ id: entry.nativeRequestId, result: { action: "cancel", content: null } });
+  return {
+    get size() { return pending.size; },
+    async handle(raw, threadId) {
+      const parsed = Request.safeParse(raw);
+      if (!parsed.success) return false;
+      const request = parsed.data;
+      if (request.params.threadId !== threadId) return rejectCodexServerRequest(raw, send, -32000);
+      if (request.params.mode !== "form" || !Confirmation.safeParse(request.params.requestedSchema).success) {
+        cancel({ nativeRequestId: request.id });
+        process.stderr.write("Unsupported integration confirmation was cancelled.\n");
+        return true;
+      }
+      const identity = createHash("sha256").update(JSON.stringify([
+        request.method, request.id, threadId, request.params.turnId, request.params.serverName,
+      ])).digest("hex").slice(0, 32);
+      const approvalId = `appr_codex_${identity}`;
+      if (pending.has(approvalId)) return true;
+      if (pending.size >= 20) { cancel({ nativeRequestId: request.id }); return true; }
+      pending.set(approvalId, { nativeRequestId: request.id, expiresAt: now() + 5 * 60_000 });
+      await persist({
+        type: "matrix.codex.approval.requested", approvalId,
+        correlationId: `corr_codex_${identity}`, title: "Use integration",
+        safeDescription: safeText(SensitiveMessage.test(request.params.message) ? "" : request.params.message,
+          "The coding agent wants to use an integration.", 600, 2400),
+        actionKind: "provider", risk: "high", allowedDecisions: ["approve", "decline", "cancel"],
+      });
+      return true;
+    },
+    decide(approvalId, decision) {
+      const entry = pending.get(approvalId);
+      if (!entry || !["approve", "decline", "cancel"].includes(decision)) return false;
+      if (entry.expiresAt <= now()) { pending.delete(approvalId); cancel(entry); return false; }
+      send({ id: entry.nativeRequestId, result: {
+        action: decision === "approve" ? "accept" : decision,
+        content: decision === "approve" ? {} : null,
+      } });
+      pending.delete(approvalId);
+      return true;
+    },
+    sweep() {
+      for (const [id, entry] of pending) {
+        if (entry.expiresAt > now()) continue;
+        pending.delete(id);
+        cancel(entry);
+      }
+    },
+    drain() {
+      const entries = [...pending.values()];
+      pending.clear();
+      for (const entry of entries) {
+        try { cancel(entry); } catch (_error) { process.stderr.write("Integration cancellation could not be delivered.\n"); }
+      }
+    },
+  };
+}

--- a/packages/gateway/src/coding-agents/codex-runtime-supervision.ts
+++ b/packages/gateway/src/coding-agents/codex-runtime-supervision.ts
@@ -1,0 +1,35 @@
+import { boundedOperation } from "../bounded-operation.js";
+
+export interface RuntimeSupervision {
+  startedAt: number;
+  nextProbeAt: number;
+  failures: number;
+  ready: boolean;
+  observedAlive?: boolean;
+  terminal: boolean;
+}
+
+/** Supervise outside the runner: its own watchdog cannot detect its death. */
+export async function runtimeUnavailable(
+  state: RuntimeSupervision,
+  probe: () => Promise<boolean>,
+  now: number,
+): Promise<boolean> {
+  if (state.terminal || now < state.nextProbeAt) return false;
+  state.nextProbeAt = now + 10_000;
+  try {
+    const alive = await boundedOperation(probe, 5_000);
+    state.failures = 0;
+    const startupExpired = now - state.startedAt >= 60_000;
+    if (alive) state.observedAlive = true;
+    return (!alive && (state.observedAlive === true || state.ready || startupExpired))
+      || (!state.ready && startupExpired);
+  } catch (error: unknown) {
+    state.failures += 1;
+    console.warn("[coding-agents] Runtime liveness unavailable", {
+      errorType: error instanceof Error ? error.name : "UnknownError", attempt: state.failures,
+    });
+    // Unknown is not immediately dead, but must not leave Working indefinitely.
+    return state.failures >= 3;
+  }
+}

--- a/packages/gateway/src/coding-agents/codex-workspace-recovery.ts
+++ b/packages/gateway/src/coding-agents/codex-workspace-recovery.ts
@@ -1,0 +1,32 @@
+import type { WorkspaceSessionOrchestrator } from "../workspace-session-orchestrator.js";
+import type { CodingAgentProviderAdapter } from "./thread-store.js";
+
+/** Cold resume requires owner-scoped durable identity; never substitute a fresh empty conversation. */
+export async function recoverCodexWorkspace(
+  runtime: Pick<WorkspaceSessionOrchestrator, "startSession"> & Partial<Pick<WorkspaceSessionOrchestrator, "getSession">>,
+  context: Parameters<NonNullable<CodingAgentProviderAdapter["resumeTurn"]>>[0],
+  sessionId: string,
+  prompt: string,
+) {
+  const { principal, thread, turn, resumeState, signal } = context;
+  signal.throwIfAborted();
+  const previous = await runtime.getSession?.(sessionId);
+  if (!resumeState.providerThreadId || !previous?.ok || previous.session.id !== sessionId
+    || previous.session.ownerId !== principal.userId || previous.session.kind !== "agent"
+    || previous.session.agent !== "codex" || previous.session.projectSlug !== thread.projectId) {
+    throw new Error("Workspace provider conversation recovery unavailable");
+  }
+  signal.throwIfAborted();
+  const restarted = await runtime.startSession({
+    ownerScope: { type: "user", id: principal.userId }, recoveryThreadId: thread.id,
+    request: {
+      sessionId, providerThreadId: resumeState.providerThreadId, kind: "agent", agent: "codex", prompt,
+      attachments: turn.attachments, model: turn.model, modelOptions: turn.modelOptions,
+      projectSlug: thread.projectId, worktreeId: previous.session.worktreeId, taskId: thread.taskId,
+      approvalPolicy: turn.approvalPolicy ?? "on_request", sandboxMode: turn.sandboxMode ?? "workspace_write",
+      runtimePreference: "zellij",
+    },
+  });
+  if (!restarted.ok) throw new Error("Workspace provider turn recovery failed");
+  return restarted.session;
+}

--- a/packages/gateway/src/coding-agents/idle-workspace-state.ts
+++ b/packages/gateway/src/coding-agents/idle-workspace-state.ts
@@ -1,0 +1,30 @@
+export interface IdleWorkspaceIdentity {
+  ownerId: string;
+  threadId: string;
+  sessionId: string;
+  providerThreadId: string;
+}
+
+type StoredThread = {
+  id: string; ownerId: string; providerId: string; status: string; attention: string;
+  updatedAt: string; activeTurnId?: string;
+  providerResumeState?: { conversationId: string; providerThreadId?: string };
+};
+
+/** Run inside the thread-store admission queue, not from an unlocked process inventory. */
+export async function withIdleWorkspaceState(
+  state: { threads: StoredThread[]; turns: Array<{ threadId: string; status: string }> },
+  sessionId: string,
+  cutoff: number,
+  action: (identity: IdleWorkspaceIdentity) => Promise<boolean>,
+): Promise<boolean> {
+  const thread = state.threads.find((candidate) => `sess_${candidate.id.slice("thread_".length)}` === sessionId);
+  if (!thread || thread.providerId !== "codex" || thread.activeTurnId
+    || !["completed", "failed", "aborted"].includes(thread.status)
+    || !["none", "failed"].includes(thread.attention)
+    || !Number.isFinite(cutoff) || !(Date.parse(thread.updatedAt) <= cutoff)
+    || thread.providerResumeState?.conversationId !== sessionId || !thread.providerResumeState.providerThreadId
+    || state.turns.some((turn) => turn.threadId === thread.id && ["accepted", "running"].includes(turn.status))) return false;
+  return action({ ownerId: thread.ownerId, threadId: thread.id, sessionId,
+    providerThreadId: thread.providerResumeState.providerThreadId });
+}

--- a/packages/gateway/src/coding-agents/provider-adapter.ts
+++ b/packages/gateway/src/coding-agents/provider-adapter.ts
@@ -147,6 +147,10 @@ export function parseCodingAgentProviderEvents(
 
 function providerMayEmit(event: AgentThreadEvent): boolean {
   switch (event.type) {
+    case "approval.resolved":
+      // Native expiry/turn shutdown can withdraw a request, never grant consent.
+      // Other decisions remain reserved for the authenticated approval route.
+      return event.decision === "cancel";
     case "thread.status":
     case "assistant.text.delta":
     case "assistant.text.completed":

--- a/packages/gateway/src/coding-agents/thread-fallback-events.ts
+++ b/packages/gateway/src/coding-agents/thread-fallback-events.ts
@@ -1,0 +1,125 @@
+import { AgentThreadEventSchema, SafeClientErrorSchema, type AgentThreadEvent, type ApprovalDecisionRequest, type UserInputAnswerRequest } from "@matrix-os/contracts";
+
+export function safeProviderRunError() {
+  return SafeClientErrorSchema.parse({
+    code: "provider_run_failed",
+    safeMessage: "Agent run could not continue. Try again.",
+    retryable: true,
+    recoveryActions: ["retry"],
+  });
+}
+
+export function safeProviderRunFailureEvents(threadId: string, now: () => Date, eventId: () => string): AgentThreadEvent[] {
+  return [
+    AgentThreadEventSchema.parse({
+      type: "thread.error",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      error: safeProviderRunError(),
+    }),
+    AgentThreadEventSchema.parse({
+      type: "thread.completed",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      outcome: "failed",
+    }),
+  ];
+}
+
+export function defaultAbortEvents(threadId: string, now: () => Date, eventId: () => string): AgentThreadEvent[] {
+  return [
+    AgentThreadEventSchema.parse({
+      type: "thread.status",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      status: "aborted",
+    }),
+    AgentThreadEventSchema.parse({
+      type: "thread.completed",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      outcome: "aborted",
+    }),
+  ];
+}
+
+export function terminalStoppedEvents(
+  threadId: string,
+  runtimeStatus: "starting" | "running" | "idle" | "waiting" | "exited" | "failed" | "degraded",
+  now: () => Date,
+  eventId: () => string,
+): AgentThreadEvent[] {
+  const failed = runtimeStatus !== "exited";
+  return [
+    AgentThreadEventSchema.parse({
+      type: "thread.status",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      status: failed ? "failed" : "completed",
+    }),
+    AgentThreadEventSchema.parse({
+      type: "thread.completed",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      outcome: failed ? "failed" : "completed",
+    }),
+  ];
+}
+
+export function defaultApprovalDecisionEvents(
+  threadId: string,
+  approvalId: string,
+  request: ApprovalDecisionRequest,
+  now: () => Date,
+  eventId: () => string,
+): AgentThreadEvent[] {
+  return [
+    AgentThreadEventSchema.parse({
+      type: "approval.resolved",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      approvalId,
+      decision: request.decision,
+    }),
+    AgentThreadEventSchema.parse({
+      type: "thread.status",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      status: "running",
+    }),
+  ];
+}
+
+export function defaultInputAnswerEvents(
+  threadId: string,
+  inputRequestId: string,
+  request: UserInputAnswerRequest,
+  now: () => Date,
+  eventId: () => string,
+): AgentThreadEvent[] {
+  return [
+    AgentThreadEventSchema.parse({
+      type: "user_input.answered",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      requestId: inputRequestId,
+      correlationId: request.correlationId,
+    }),
+    AgentThreadEventSchema.parse({
+      type: "thread.status",
+      eventId: eventId(),
+      threadId,
+      occurredAt: now().toISOString(),
+      status: "running",
+    }),
+  ];
+}

--- a/packages/gateway/src/coding-agents/thread-steering.ts
+++ b/packages/gateway/src/coding-agents/thread-steering.ts
@@ -1,0 +1,17 @@
+import { z } from "zod/v4";
+import { AgentTurnIdSchema, CreateAgentTurnRequestSchema, RequestIdSchema } from "@matrix-os/contracts";
+
+export const CodingAgentSteerRequestSchema = z.object({
+  expectedTurnId: AgentTurnIdSchema.optional(),
+  message: CreateAgentTurnRequestSchema.shape.message,
+  clientRequestId: RequestIdSchema,
+}).strict();
+
+/** Dispatch completion is not completion of a background provider's turn. */
+export function matchesSteeringTurn(
+  thread: { activeTurnId?: string; deliveredTurnId?: string },
+  expectedTurnId: string | undefined,
+): boolean {
+  // A newly admitted dispatch always fences the previously delivered turn.
+  return (thread.activeTurnId ?? thread.deliveredTurnId) === expectedTurnId;
+}

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -51,6 +51,9 @@ import {
 } from "./provider-adapter.js";
 import type { AiTokenUsage } from "../ai-analytics.js";
 import { createCodingAgentTurnDispatcher } from "./turn-dispatcher.js";
+import { withIdleWorkspaceState, type IdleWorkspaceIdentity } from "./idle-workspace-state.js";
+import { safeProviderRunError, safeProviderRunFailureEvents, defaultAbortEvents, terminalStoppedEvents,
+  defaultApprovalDecisionEvents, defaultInputAnswerEvents } from "./thread-fallback-events.js";
 import {
   deriveThreadProjectionChanges,
   publishThreadProjectionChanges,
@@ -184,6 +187,7 @@ export interface CodingAgentThreadStoreOptions {
 }
 
 export interface CodingAgentThreadStore {
+  withIdleWorkspace(sessionId: string, cutoff: number, action: (identity: IdleWorkspaceIdentity) => Promise<boolean>): Promise<boolean>;
   createThread(principal: RequestPrincipal, request: CreateAgentThreadRequest): Promise<ThreadCreateResult>;
   createShellThread(principal: RequestPrincipal, request: CreateAgentThreadRequest): Promise<ThreadCreateResult>;
   adoptLegacyThread(
@@ -597,129 +601,6 @@ function consumePendingTerminalStop(
   };
 }
 
-function safeProviderRunError() {
-  return SafeClientErrorSchema.parse({
-    code: "provider_run_failed",
-    safeMessage: "Agent run could not continue. Try again.",
-    retryable: true,
-    recoveryActions: ["retry"],
-  });
-}
-
-function safeProviderRunFailureEvents(threadId: string, now: () => Date, eventId: () => string): AgentThreadEvent[] {
-  return [
-    AgentThreadEventSchema.parse({
-      type: "thread.error",
-      eventId: eventId(),
-      threadId,
-      occurredAt: now().toISOString(),
-      error: safeProviderRunError(),
-    }),
-    AgentThreadEventSchema.parse({
-      type: "thread.completed",
-      eventId: eventId(),
-      threadId,
-      occurredAt: now().toISOString(),
-      outcome: "failed",
-    }),
-  ];
-}
-
-function defaultAbortEvents(threadId: string, now: () => Date, eventId: () => string): AgentThreadEvent[] {
-  return [
-    AgentThreadEventSchema.parse({
-      type: "thread.status",
-      eventId: eventId(),
-      threadId,
-      occurredAt: now().toISOString(),
-      status: "aborted",
-    }),
-    AgentThreadEventSchema.parse({
-      type: "thread.completed",
-      eventId: eventId(),
-      threadId,
-      occurredAt: now().toISOString(),
-      outcome: "aborted",
-    }),
-  ];
-}
-
-function terminalStoppedEvents(
-  threadId: string,
-  runtimeStatus: TerminalSessionStoppedReconciliation["runtimeStatus"],
-  now: () => Date,
-  eventId: () => string,
-): AgentThreadEvent[] {
-  const failed = runtimeStatus !== "exited";
-  return [
-    AgentThreadEventSchema.parse({
-      type: "thread.status",
-      eventId: eventId(),
-      threadId,
-      occurredAt: now().toISOString(),
-      status: failed ? "failed" : "completed",
-    }),
-    AgentThreadEventSchema.parse({
-      type: "thread.completed",
-      eventId: eventId(),
-      threadId,
-      occurredAt: now().toISOString(),
-      outcome: failed ? "failed" : "completed",
-    }),
-  ];
-}
-
-function defaultApprovalDecisionEvents(
-  threadId: string,
-  approvalId: string,
-  request: ApprovalDecisionRequest,
-  now: () => Date,
-  eventId: () => string,
-): AgentThreadEvent[] {
-  return [
-    AgentThreadEventSchema.parse({
-      type: "approval.resolved",
-      eventId: eventId(),
-      threadId,
-      occurredAt: now().toISOString(),
-      approvalId,
-      decision: request.decision,
-    }),
-    AgentThreadEventSchema.parse({
-      type: "thread.status",
-      eventId: eventId(),
-      threadId,
-      occurredAt: now().toISOString(),
-      status: "running",
-    }),
-  ];
-}
-
-function defaultInputAnswerEvents(
-  threadId: string,
-  inputRequestId: string,
-  request: UserInputAnswerRequest,
-  now: () => Date,
-  eventId: () => string,
-): AgentThreadEvent[] {
-  return [
-    AgentThreadEventSchema.parse({
-      type: "user_input.answered",
-      eventId: eventId(),
-      threadId,
-      occurredAt: now().toISOString(),
-      requestId: inputRequestId,
-      correlationId: request.correlationId,
-    }),
-    AgentThreadEventSchema.parse({
-      type: "thread.status",
-      eventId: eventId(),
-      threadId,
-      occurredAt: now().toISOString(),
-      status: "running",
-    }),
-  ];
-}
 
 function invalidInputAnswer(message: string): never {
   throw new z.ZodError([{ code: "custom", message, path: ["structuredAnswers"] }]);
@@ -1392,6 +1273,9 @@ export function createCodingAgentThreadStore(
   return {
     createThread(principal, request) {
       return createThreadInternal(principal, request);
+    },
+    async withIdleWorkspace(sessionId, cutoff, action) {
+      return inspect((state) => withIdleWorkspaceState(state, sessionId, cutoff, action));
     },
     createShellThread(principal, request) {
       if (!options.relationValidator) {

--- a/packages/gateway/src/coding-agents/thread-store.ts
+++ b/packages/gateway/src/coding-agents/thread-store.ts
@@ -30,6 +30,7 @@ import {
 import { atomicWriteJson } from "../state-ops.js";
 import type { RequestPrincipal } from "../request-principal.js";
 import { logCodingAgentWarning } from "./diagnostics.js";
+import { CodingAgentSteerRequestSchema, matchesSteeringTurn } from "./thread-steering.js";
 import {
   CodingAgentProjectWorkspaceError,
   type CodingAgentProjectThreadProjection,
@@ -89,12 +90,6 @@ const DEFAULT_INITIAL_RUN_TIMEOUT_MS = 10 * 60_000;
 
 const OwnerIdSchema = z.string().min(1).max(160).regex(/^[A-Za-z0-9_.:@-]+$/);
 const WorkspaceSessionIdSchema = z.string().min(1).max(160).regex(/^sess_[A-Za-z0-9_-]+$/);
-const CodingAgentSteerRequestSchema = z.object({
-  expectedTurnId: AgentTurnIdSchema.optional(),
-  message: CreateAgentTurnRequestSchema.shape.message,
-  clientRequestId: RequestIdSchema,
-}).strict();
-
 const StoredThreadSchema = AgentThreadSummarySchema.extend({
   ownerId: OwnerIdSchema,
   clientRequestId: RequestIdSchema,
@@ -102,6 +97,7 @@ const StoredThreadSchema = AgentThreadSummarySchema.extend({
   approvalDecisionClientRequestIds: z.array(RequestIdSchema).max(MAX_APPROVAL_DECISION_REQUEST_IDS).default([]),
   inputAnswerClientRequestIds: z.array(RequestIdSchema).max(MAX_INPUT_ANSWER_REQUEST_IDS).default([]),
   activeTurnId: AgentTurnIdSchema.optional(),
+  deliveredTurnId: AgentTurnIdSchema.optional(),
   providerResumeState: CodingAgentProviderResumeStateSchema.optional(),
 }).strict();
 
@@ -446,6 +442,7 @@ function stripOwner(thread: StoredThread): AgentThreadSummary {
     approvalDecisionClientRequestIds: _approvalDecisionClientRequestIds,
     inputAnswerClientRequestIds: _inputAnswerClientRequestIds,
     activeTurnId: _activeTurnId,
+    deliveredTurnId: _deliveredTurnId,
     providerResumeState: _providerResumeState,
     ...summary
   } = thread;
@@ -846,7 +843,7 @@ export function createCodingAgentThreadStore(
   }
 
   function clearActiveTurn(thread: StoredThread): StoredThread {
-    const { activeTurnId: _activeTurnId, ...cleared } = thread;
+    const { activeTurnId: _activeTurnId, deliveredTurnId: _deliveredTurnId, ...cleared } = thread;
     return cleared;
   }
 
@@ -938,6 +935,9 @@ export function createCodingAgentThreadStore(
         ...nextThread,
         ...(input.resumeState ? { providerResumeState: input.resumeState } : {}),
       });
+      if (input.outcome === "delivered" && activeThread(nextThread)) {
+        nextThread = { ...nextThread, deliveredTurnId: input.turnId };
+      }
       return {
         state: {
           ...state,
@@ -1402,6 +1402,7 @@ export function createCodingAgentThreadStore(
           const nextThread: StoredThread = {
             ...thread,
             activeTurnId: turnId,
+            deliveredTurnId: undefined,
             status: "running",
             attention: "none",
             updatedAt: acceptedAt,
@@ -1469,7 +1470,7 @@ export function createCodingAgentThreadStore(
         candidate.ownerId === principal.userId && candidate.id === threadId
       );
       if (!thread) throw new CodingAgentTurnError("thread_not_found");
-      if (thread.activeTurnId !== request.expectedTurnId || !activeThread(thread) || !thread.providerResumeState) {
+      if (!matchesSteeringTurn(thread, request.expectedTurnId) || !activeThread(thread) || !thread.providerResumeState) {
         throw new CodingAgentTurnError("thread_busy");
       }
       const provider = providerFor(thread.providerId);

--- a/packages/gateway/src/coding-agents/workspace-provider.ts
+++ b/packages/gateway/src/coding-agents/workspace-provider.ts
@@ -21,9 +21,10 @@ import {
 import type { CodingAgentProviderAdapter } from "./thread-store.js";
 import type { CodexEventBridge } from "./codex-event-bridge.js";
 import type { CodexControlClient } from "./codex-control-client.js";
+import { recoverCodexWorkspace } from "./codex-workspace-recovery.js";
 
 type WorkspaceRuntime = Pick<WorkspaceSessionOrchestrator, "startSession" | "stopSession"> &
-  Partial<Pick<WorkspaceSessionOrchestrator, "sendInput">>;
+  Partial<Pick<WorkspaceSessionOrchestrator, "sendInput" | "getSession">>;
 type SetupAgent = Extract<SupportedAgent, "claude" | "codex">;
 
 const SETUP_AGENTS: Record<SetupAgent, { installPackage: string; connectCommand: string }> = {
@@ -314,7 +315,8 @@ export function createWorkspaceCodingAgentProvider(
         resumeState: { conversationId: sessionId },
       };
     },
-    async resumeTurn({ principal, thread, turn, resumeState, signal }) {
+    async resumeTurn(context) {
+      const { principal, thread, turn, resumeState, signal, now, nextEventId } = context;
       if (!runnable) {
         throw new Error("Workspace provider turn resume unavailable");
       }
@@ -343,32 +345,26 @@ export function createWorkspaceCodingAgentProvider(
             modelOptions: turn.modelOptions ?? [],
           });
         } catch (error: unknown) {
+          if (!(error instanceof Error) || error.name !== "CodexControlUnavailableError") {
+            // An accepted frame with a lost acknowledgement must not be replayed into a new process.
+            options.codexEvents.unwatch(sessionId);
+            throw error;
+          }
           console.warn(
             "[coding-agents] Codex turn control failed; restarting session",
             { errorName: safeRecoveryErrorName(error) },
           );
-          const restarted = await options.runtime.startSession({
-            ownerScope: { type: "user", id: principal.userId },
-            recoveryThreadId: thread.id,
-            request: {
-              sessionId,
-              ...(resumeState.providerThreadId
-                ? { providerThreadId: resumeState.providerThreadId }
-                : {}),
-              kind: "agent",
-              agent,
-              prompt,
-              attachments: turn.attachments,
-              model: turn.model,
-              modelOptions: turn.modelOptions,
-              projectSlug: thread.projectId,
-              taskId: thread.taskId,
-              approvalPolicy: turn.approvalPolicy ?? "on_request",
-              sandboxMode: turn.sandboxMode ?? "workspace_write",
-              runtimePreference: "zellij",
-            },
-          });
-          if (!restarted.ok) throw new Error("Workspace provider turn recovery failed");
+          try {
+            const session = await recoverCodexWorkspace(options.runtime, context, sessionId, prompt);
+            return { events: [AgentThreadEventSchema.parse({
+              type: "terminal.bound", eventId: nextEventId(), threadId: thread.id,
+              occurredAt: now().toISOString(), terminalSessionId: terminalSessionIdFor(session),
+              terminalSessionCreatedAt: session.runtime.createdAt,
+            })], outcome: "delivered", resumeState };
+          } catch (recoveryError: unknown) {
+            options.codexEvents.unwatch(sessionId);
+            throw recoveryError;
+          }
         }
         return { events: [], outcome: "delivered", resumeState };
       }

--- a/packages/gateway/src/coding-agents/workspace-provider.ts
+++ b/packages/gateway/src/coding-agents/workspace-provider.ts
@@ -349,6 +349,7 @@ export function createWorkspaceCodingAgentProvider(
           );
           const restarted = await options.runtime.startSession({
             ownerScope: { type: "user", id: principal.userId },
+            recoveryThreadId: thread.id,
             request: {
               sessionId,
               ...(resumeState.providerThreadId

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -181,6 +181,9 @@ import { createCodingAgentNotificationPreferenceStore } from "./coding-agents/no
 import { createCodingAgentProjectMutationService } from "./coding-agents/project-mutations.js";
 import { createCodexEventBridge, type CodexEventBridge } from "./coding-agents/codex-event-bridge.js";
 import { createCodexControlClient } from "./coding-agents/codex-control-client.js";
+import { createChatIdleReaper } from "./coding-agents/chat-idle-reaper.js";
+import { withCanonicalIdleChat } from "./chat/idle-runtime-admission.js";
+import { terminalTasksUnderPressure } from "./shell/terminal-runtime-capacity.js";
 import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
@@ -1012,6 +1015,7 @@ export async function createGateway(config: GatewayConfig) {
   let canvasSubscriptionHub: CanvasSubscriptionHub | null = null;
   let canvasCleanupTimer: ReturnType<typeof setInterval> | null = null;
   let chatRepository: ChatRepository | null = null;
+  let chatIdleReaper: ReturnType<typeof createChatIdleReaper> | null = null;
   let canonicalChatEventStream: ReturnType<typeof createCanonicalChatEventStream> | null = null;
   let canonicalChatOrchestrator: CanonicalChatOrchestrator | null = null;
   let canonicalChatExecutionRoots: ChatExecutionRootResolver | null = null;
@@ -4418,6 +4422,22 @@ export async function createGateway(config: GatewayConfig) {
     for (const ownerId of new Set(codingAgentOwnerIds)) {
       await canonicalChatOrchestrator.reconcileActiveRuns({ type: "personal", ownerId });
     }
+    if (userSystemdTerminalController && codingAgentThreadStore && codingAgentWorkspaceRuntime && codexEventBridge) {
+      const repository = chatRepository;
+      const bridge = codexEventBridge;
+      const uid = process.getuid?.();
+      chatIdleReaper = createChatIdleReaper({
+        controller: userSystemdTerminalController,
+        sessions: codingAgentWorkspaceRuntime,
+        threads: codingAgentThreadStore,
+        control: createCodexControlClient({ homePath }),
+        admitCanonical: (identity, reclaim) => withCanonicalIdleChat(repository.kysely, identity, reclaim),
+        unwatch: (sessionId) => bridge.unwatch(sessionId),
+        underPressure: () => terminalTasksUnderPressure(
+          `/sys/fs/cgroup/user.slice/user-${uid}.slice/user@${uid}.service/matrix.slice/matrix-terminal.slice`,
+        ),
+      });
+    }
   }
   if (canonicalChatEventStream) {
     registerCanonicalChatEventWebSocketRoute({
@@ -4743,6 +4763,10 @@ export async function createGateway(config: GatewayConfig) {
     pluginRegistry,
     hookRunner,
     async close() {
+      await chatIdleReaper?.close().catch((error: unknown) => {
+        logBestEffortFailure("Chat idle runtime reconciliation shutdown failed", error);
+      });
+      chatIdleReaper = null;
       chatAttachmentCleanup.close();
       await chatAttachmentCleanup.waitForIdle().catch((error: unknown) => {
         logBestEffortFailure("Temporary Chat attachment cleanup shutdown failed", error);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -70,7 +70,7 @@ import {
 import { createWorkspaceEventStore } from "./workspace-events.js";
 import { createWorkspaceEventPublisher } from "./workspace-event-publisher.js";
 import { createZellijRuntime } from "./zellij-runtime.js";
-import { createUserSystemdZellijRuntime } from "./user-systemd-zellij-runtime.js";
+import { createUserSystemdZellijRuntime, workspaceRuntimeId } from "./user-systemd-zellij-runtime.js";
 import { resolveUserSystemdTerminalActivation } from "./terminal-user-systemd-activation.js";
 import { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
 import { reconcilePendingShellSessionDeletions } from "./shell/session-deletion-reconciler.js";
@@ -776,7 +776,11 @@ export async function createGateway(config: GatewayConfig) {
   if (codingAgentWorkspaceAgents.length > 0) {
     const codingAgentProjectManager = createProjectManager({ homePath });
     codexEventBridge = codexExecutable
-      ? createCodexEventBridge({ homePath, codexExecutable })
+      ? createCodexEventBridge({ homePath, codexExecutable,
+        ...(userSystemdTerminalController ? {
+          isRuntimeAlive: (sessionId: string) => userSystemdTerminalController.isRunning(workspaceRuntimeId(sessionId)),
+        } : {}),
+      })
       : undefined;
     const codingAgentSessionManager = createAgentSessionManager({
       homePath,

--- a/packages/gateway/src/shell/terminal-runtime-capacity.ts
+++ b/packages/gateway/src/shell/terminal-runtime-capacity.ts
@@ -5,6 +5,31 @@ const HEADROOM = 128;
 const RESERVATION_MS = 30_000;
 const MAX_RESERVATIONS = 64;
 
+async function taskBudget(root: string): Promise<{ current: number; maximum: number } | null> {
+  let currentText: string;
+  let maximumText: string;
+  try {
+    [currentText, maximumText] = await Promise.all([
+      readFile(join(root, "pids.current"), "utf8"), readFile(join(root, "pids.max"), "utf8"),
+    ]);
+  } catch (error: unknown) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+    throw new Error("Terminal runtime capacity unavailable", { cause: error });
+  }
+  const current = Number(currentText.trim());
+  const maximum = maximumText.trim() === "max" ? Infinity : Number(maximumText.trim());
+  if (!/^\d+$/.test(currentText.trim()) || !Number.isSafeInteger(current) || current < 0
+    || (maximum !== Infinity && (!/^\d+$/.test(maximumText.trim()) || !Number.isSafeInteger(maximum) || maximum <= 0))) {
+    throw new Error("Terminal runtime capacity unavailable");
+  }
+  return { current, maximum };
+}
+
+export async function terminalTasksUnderPressure(root: string): Promise<boolean> {
+  const budget = await taskBudget(root);
+  return budget !== null && budget.current >= budget.maximum * 0.85;
+}
+
 /** Admission only: never kills sessions or changes cgroup limits. Call under the runtime mutation lock. */
 export function createTerminalCapacityAdmission(options: { root: string; now?: () => number }) {
   const reservations = new Map<string, number>();
@@ -20,24 +45,9 @@ export function createTerminalCapacityAdmission(options: { root: string; now?: (
         throw new Error("Terminal runtime capacity unavailable", { cause: error });
       }
     }
-    let currentText: string;
-    let maximumText: string;
-    try {
-      [currentText, maximumText] = await Promise.all([
-        readFile(join(options.root, "pids.current"), "utf8"),
-        readFile(join(options.root, "pids.max"), "utf8"),
-      ]);
-    } catch (error: unknown) {
-      // An aggregate cgroup does not exist before its first unit starts.
-      if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
-      throw new Error("Terminal runtime capacity unavailable", { cause: error });
-    }
-    const current = Number(currentText.trim());
-    const maximum = maximumText.trim() === "max" ? Infinity : Number(maximumText.trim());
-    if (!/^\d+$/.test(currentText.trim()) || !Number.isSafeInteger(current) || current < 0
-      || (maximum !== Infinity && (!/^\d+$/.test(maximumText.trim()) || !Number.isSafeInteger(maximum) || maximum <= 0))) {
-      throw new Error("Terminal runtime capacity unavailable");
-    }
+    const budget = await taskBudget(options.root);
+    if (!budget) return; // The aggregate cgroup does not exist before its first launch.
+    const { current, maximum } = budget;
     if (reservations.has(runtimeId)) return;
     if (reservations.size >= MAX_RESERVATIONS || maximum - current < HEADROOM * (reservations.size + 1)) {
       throw new Error("Terminal runtime capacity unavailable");

--- a/packages/gateway/src/shell/terminal-runtime-capacity.ts
+++ b/packages/gateway/src/shell/terminal-runtime-capacity.ts
@@ -1,0 +1,47 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const HEADROOM = 128;
+const RESERVATION_MS = 30_000;
+const MAX_RESERVATIONS = 64;
+
+/** Admission only: never kills sessions or changes cgroup limits. Call under the runtime mutation lock. */
+export function createTerminalCapacityAdmission(options: { root: string; now?: () => number }) {
+  const reservations = new Map<string, number>();
+  const now = options.now ?? Date.now;
+  return async (runtimeId: string): Promise<void> => {
+    const time = now();
+    for (const [id, expires] of reservations) if (expires <= time) reservations.delete(id);
+    try {
+      const existing = await readFile(join(options.root, `matrix-zellij@${runtimeId}.service`, "pids.current"), "utf8");
+      if (/^\d+$/.test(existing.trim()) && Number(existing) > 0) return;
+    } catch (error: unknown) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+        throw new Error("Terminal runtime capacity unavailable", { cause: error });
+      }
+    }
+    let currentText: string;
+    let maximumText: string;
+    try {
+      [currentText, maximumText] = await Promise.all([
+        readFile(join(options.root, "pids.current"), "utf8"),
+        readFile(join(options.root, "pids.max"), "utf8"),
+      ]);
+    } catch (error: unknown) {
+      // An aggregate cgroup does not exist before its first unit starts.
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+      throw new Error("Terminal runtime capacity unavailable", { cause: error });
+    }
+    const current = Number(currentText.trim());
+    const maximum = maximumText.trim() === "max" ? Infinity : Number(maximumText.trim());
+    if (!/^\d+$/.test(currentText.trim()) || !Number.isSafeInteger(current) || current < 0
+      || (maximum !== Infinity && (!/^\d+$/.test(maximumText.trim()) || !Number.isSafeInteger(maximum) || maximum <= 0))) {
+      throw new Error("Terminal runtime capacity unavailable");
+    }
+    if (reservations.has(runtimeId)) return;
+    if (reservations.size >= MAX_RESERVATIONS || maximum - current < HEADROOM * (reservations.size + 1)) {
+      throw new Error("Terminal runtime capacity unavailable");
+    }
+    reservations.set(runtimeId, time + RESERVATION_MS);
+  };
+}

--- a/packages/gateway/src/shell/terminal-runtime-readiness.ts
+++ b/packages/gateway/src/shell/terminal-runtime-readiness.ts
@@ -1,0 +1,61 @@
+import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod/v4";
+import type { UserSystemdCommandRunner, UserSystemdTerminalDescriptor } from "./user-systemd-terminal-runtime.js";
+
+const CAPABILITY = "// matrix-terminal-readiness: invocation-v1";
+const ReadySchema = z.object({
+  version: z.literal(1),
+  invocationId: z.string().regex(/^[0-9a-f]{32}$/),
+  generation: z.string(),
+  createdAt: z.string(),
+}).strict();
+
+async function readBounded(path: string, bytes: number): Promise<string | null> {
+  try {
+    const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    try {
+      const stats = await handle.stat();
+      if (!stats.isFile()) throw new Error("Invalid runtime readiness file");
+      const buffer = Buffer.alloc(bytes);
+      const result = await handle.read(buffer, 0, bytes, 0);
+      return buffer.subarray(0, result.bytesRead).toString("utf8");
+    } finally { await handle.close(); }
+  } catch (error: unknown) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+/** null selects legacy generations; absence of a modern signal is never permission to probe IPC. */
+export async function probeKeeperReadiness(options: {
+  descriptor: UserSystemdTerminalDescriptor;
+  terminalRuntimeRoot: string;
+  homePath: string;
+  env: NodeJS.ProcessEnv;
+  runCommand: UserSystemdCommandRunner;
+}): Promise<boolean | null> {
+  const { descriptor, homePath, runCommand } = options;
+  // The capability header is part of the immutable, content-addressed keeper bytes.
+  // Old generations remain runnable without rewriting their descriptors or installed assets.
+  const keeper = await readBounded(join(options.terminalRuntimeRoot, "generations",
+    descriptor.generation, "matrix-terminal-user-keeper.mjs"), 512);
+  if (!keeper?.split("\n").includes(CAPABILITY)) return null;
+  const { stdout } = await runCommand("systemctl", ["--user", "show",
+    `matrix-zellij@${descriptor.runtimeId}.service`, "--property=ActiveState", "--property=InvocationID"],
+  { cwd: homePath, env: options.env, timeoutMs: 2_000 });
+  const invocationId = /^InvocationID=([0-9a-f]{32})$/m.exec(stdout)?.[1];
+  if (!/^ActiveState=active$/m.test(stdout) || !invocationId) return false;
+  const raw = await readBounded(join(homePath, "system", "terminal-runtimes", `${descriptor.runtimeId}.ready.json`), 1_025);
+  if (!raw || Buffer.byteLength(raw) > 1_024) return false;
+  let value: unknown;
+  try { value = JSON.parse(raw); }
+  catch (error: unknown) {
+    if (error instanceof SyntaxError) return false; // A bounded signal write may still be in progress.
+    throw error;
+  }
+  const ready = ReadySchema.safeParse(value);
+  return ready.success && ready.data.invocationId === invocationId
+    && ready.data.generation === descriptor.generation && ready.data.createdAt === descriptor.createdAt;
+}

--- a/packages/gateway/src/shell/user-systemd-terminal-runtime.ts
+++ b/packages/gateway/src/shell/user-systemd-terminal-runtime.ts
@@ -576,10 +576,14 @@ export function createUserSystemdTerminalRuntime(options: {
       const { stdout } = await runSystemctl(["is-active", unitName(runtimeId)]);
       return ["inactive", "failed", "unknown"].includes(stdout.trim());
     } catch (error: unknown) {
-      if (!(error instanceof Error && "code" in error)) throw error;
-      if (error.code === 4 || error.code === "4") return true;
-      if ((error.code === 3 || error.code === "3") && "stdout" in error && typeof error.stdout === "string") {
-        return ["inactive", "failed"].includes(error.stdout.trim());
+      // execFile rejects the normal systemctl inactive result (exit 3).
+      // runSystemctl wraps it for safe outward errors; inspect the retained
+      // cause here rather than losing the state output at that boundary.
+      const commandError = error instanceof TerminalRuntimeUnavailableError ? error.cause : error;
+      if (!(commandError instanceof Error && "code" in commandError)) throw error;
+      if (commandError.code === 4 || commandError.code === "4") return true;
+      if ((commandError.code === 3 || commandError.code === "3") && "stdout" in commandError && typeof commandError.stdout === "string") {
+        return ["inactive", "failed"].includes(commandError.stdout.trim());
       }
       throw error;
     }

--- a/packages/gateway/src/shell/user-systemd-terminal-runtime.ts
+++ b/packages/gateway/src/shell/user-systemd-terminal-runtime.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { z } from "zod/v4";
 import { resolveWithinHome } from "../path-security.js";
 import { createTerminalCapacityAdmission } from "./terminal-runtime-capacity.js";
+import { probeKeeperReadiness } from "./terminal-runtime-readiness.js";
 
 const execFileAsync = promisify(execFile);
 const RuntimeIdSchema = z.string().regex(/^rt_[0-9a-f]{32}$/);
@@ -439,6 +440,9 @@ export function createUserSystemdTerminalRuntime(options: {
   }
 
   async function defaultReadinessProbe(descriptor: UserSystemdTerminalDescriptor): Promise<boolean> {
+    const ready = await probeKeeperReadiness({ descriptor, terminalRuntimeRoot, homePath,
+      env: systemdEnv, runCommand });
+    if (ready !== null) return ready;
     const zellijPath = join(terminalRuntimeRoot, "generations", descriptor.generation, "zellij");
     try {
       const { stdout } = await runCommand(zellijPath, ["list-sessions", "--no-formatting"], {
@@ -823,6 +827,7 @@ export function createUserSystemdTerminalRuntime(options: {
             await removePath(descriptor.layoutPath);
           }
           await removePath(join(descriptorRoot, `${parsed.data}.json`));
+          await removePath(join(descriptorRoot, `${parsed.data}.ready.json`));
         } catch (err: unknown) {
           if (err instanceof TerminalRuntimeUnavailableError) throw err;
           throw new TerminalRuntimeUnavailableError(err);

--- a/packages/gateway/src/shell/user-systemd-terminal-runtime.ts
+++ b/packages/gateway/src/shell/user-systemd-terminal-runtime.ts
@@ -5,6 +5,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "nod
 import { promisify } from "node:util";
 import { z } from "zod/v4";
 import { resolveWithinHome } from "../path-security.js";
+import { createTerminalCapacityAdmission } from "./terminal-runtime-capacity.js";
 
 const execFileAsync = promisify(execFile);
 const RuntimeIdSchema = z.string().regex(/^rt_[0-9a-f]{32}$/);
@@ -317,11 +318,15 @@ export function createUserSystemdTerminalRuntime(options: {
   now?: () => string;
   readinessTimeoutMs?: number;
   readinessStabilityMs?: number;
+  capacityAdmission?: (runtimeId: string) => Promise<void>;
   generationLockHelperPath?: string;
   removePath?: (path: string) => Promise<void>;
 }) {
   const homePath = resolve(options.homePath);
   const uid = options.uid ?? process.getuid?.();
+  const admitCapacity = options.capacityAdmission ?? createTerminalCapacityAdmission({
+    root: `/sys/fs/cgroup/user.slice/user-${uid}.slice/user@${uid}.service/matrix.slice/matrix-terminal.slice`,
+  });
   const generation = GenerationSchema.parse(options.generation);
   const terminalRuntimeRoot = resolve(options.terminalRuntimeRoot ?? "/opt/matrix/terminal-runtime");
   const runCommand = options.runCommand ?? defaultRunCommand;
@@ -547,6 +552,8 @@ export function createUserSystemdTerminalRuntime(options: {
   }
 
   async function startInterruptedRuntime(descriptor: UserSystemdTerminalDescriptor): Promise<void> {
+    try { await admitCapacity(descriptor.runtimeId); }
+    catch (error: unknown) { throw new TerminalRuntimeUnavailableError(error); }
     await runSystemctl(["start", unitName(descriptor.runtimeId)]);
     try {
       await waitUntilReady(descriptor);

--- a/packages/gateway/src/shell/user-systemd-terminal-runtime.ts
+++ b/packages/gateway/src/shell/user-systemd-terminal-runtime.ts
@@ -24,6 +24,8 @@ const DescriptorSchema = z.object({
   environmentPath: z.string().min(1).max(4096).optional(),
   generation: GenerationSchema,
   createdAt: z.iso.datetime(),
+  // A durable stop intent. Cold recovery must replace this descriptor before the keeper may start it.
+  hibernatedAt: z.iso.datetime().optional(),
 }).strict();
 
 export type UserSystemdTerminalDescriptor = z.infer<typeof DescriptorSchema>;
@@ -569,6 +571,20 @@ export function createUserSystemdTerminalRuntime(options: {
     await waitUntilReady(descriptor);
   }
 
+  async function isSettledInactive(runtimeId: string): Promise<boolean> {
+    try {
+      const { stdout } = await runSystemctl(["is-active", unitName(runtimeId)]);
+      return ["inactive", "failed", "unknown"].includes(stdout.trim());
+    } catch (error: unknown) {
+      if (!(error instanceof Error && "code" in error)) throw error;
+      if (error.code === 4 || error.code === "4") return true;
+      if ((error.code === 3 || error.code === "3") && "stdout" in error && typeof error.stdout === "string") {
+        return ["inactive", "failed"].includes(error.stdout.trim());
+      }
+      throw error;
+    }
+  }
+
   async function deleteExactZellijSession(descriptor: UserSystemdTerminalDescriptor): Promise<void> {
     const zellijPath = join(terminalRuntimeRoot, "generations", descriptor.generation, "zellij");
     try {
@@ -605,7 +621,7 @@ export function createUserSystemdTerminalRuntime(options: {
       }
     },
 
-    async create(input: CreateUserSystemdRuntimeInput): Promise<UserSystemdRuntimeResult> {
+    async create(input: CreateUserSystemdRuntimeInput, recovery: { replaceInactiveWorkspace?: boolean } = {}): Promise<UserSystemdRuntimeResult> {
       const parsed = z.object({
         runtimeId: RuntimeIdSchema,
         scope: RuntimeScopeSchema,
@@ -651,10 +667,36 @@ export function createUserSystemdTerminalRuntime(options: {
         ) {
           throw new TerminalRuntimeUnavailableError();
         }
-        const persisted = await writeDescriptorExclusive(
-          join(descriptorRoot, `${descriptor.runtimeId}.json`),
-          descriptor,
-        );
+        const path = join(descriptorRoot, `${descriptor.runtimeId}.json`);
+        const existing = descriptors.find((entry) => entry.runtimeId === descriptor.runtimeId);
+        let persisted: UserSystemdTerminalDescriptor;
+        if (recovery.replaceInactiveWorkspace && existing) {
+          if (existing.scope !== "workspace" || descriptor.scope !== "workspace"
+            || existing.displayName !== descriptor.displayName || existing.cwd !== descriptor.cwd
+            || existing.kind !== descriptor.kind || !await isSettledInactive(descriptor.runtimeId)) {
+            throw new TerminalRuntimeUnavailableError();
+          }
+          await deleteExactZellijSession(existing);
+          await writeDescriptorAtomic(path, descriptor);
+          // Superseded OS-generated launch files are no longer referenced by the durable descriptor.
+          // Never remove user layouts, shared environment files, or any conversation/workspace data.
+          for (const [oldPath, nextPath, root, extension] of [
+            [existing.layoutPath, descriptor.layoutPath, join(homePath, "system", "zellij", "runtime-layouts"), ".kdl"],
+            [existing.environmentPath, descriptor.environmentPath, join(descriptorRoot, "env"), ".json"],
+          ]) {
+            if (!oldPath || oldPath === nextPath || dirname(oldPath) !== root
+              || !basename(oldPath).startsWith(`${descriptor.runtimeId}-`) || !oldPath.endsWith(extension!)) continue;
+            try { await removePath(oldPath); }
+            catch (cleanupError: unknown) {
+              console.warn("[terminal-runtime] superseded launch cleanup deferred", {
+                errorType: cleanupError instanceof Error ? cleanupError.name : "UnknownError",
+              });
+            }
+          }
+          persisted = descriptor;
+        } else {
+          persisted = await writeDescriptorExclusive(path, descriptor);
+        }
         await startInterruptedRuntime(persisted);
         return { ...persisted, lifecycle: "running" };
       });
@@ -664,6 +706,7 @@ export function createUserSystemdTerminalRuntime(options: {
       return withMutationLock(async () => {
         const descriptor = await readDescriptor(runtimeId);
         if (!descriptor) throw new InvalidTerminalRuntimeRequestError();
+        if (descriptor.hibernatedAt) throw new TerminalRuntimeUnavailableError();
         await startInterruptedRuntime(descriptor);
         return { ...descriptor, lifecycle: "running" };
       });
@@ -709,6 +752,27 @@ export function createUserSystemdTerminalRuntime(options: {
     },
 
     isRunning,
+
+    // Hibernation is not session deletion: keep the descriptor, owner files and worktree leases.
+    async hibernateWorkspace(runtimeId: string, expected?: Pick<UserSystemdTerminalDescriptor, "createdAt" | "layoutPath">): Promise<{ ok: true }> {
+      return withMutationLock(async () => {
+        const descriptor = await readDescriptor(runtimeId);
+        if (!descriptor || descriptor.scope !== "workspace" || !/^sess_[A-Za-z0-9_-]+$/.test(descriptor.displayName)) {
+          throw new InvalidTerminalRuntimeRequestError();
+        }
+        if (expected && (descriptor.createdAt !== expected.createdAt || descriptor.layoutPath !== expected.layoutPath)) {
+          throw new TerminalRuntimeUnavailableError();
+        }
+        if (!descriptor.hibernatedAt) {
+          await writeDescriptorAtomic(join(descriptorRoot, `${descriptor.runtimeId}.json`), { ...descriptor, hibernatedAt: now() });
+        }
+        await runSystemctl(["stop", unitName(descriptor.runtimeId)]);
+        if (!await isSettledInactive(descriptor.runtimeId)) throw new TerminalRuntimeUnavailableError();
+        // Remove only Zellij's exited runtime snapshot, preventing resurrection of the old prompt.
+        await deleteExactZellijSession(descriptor);
+        return { ok: true };
+      });
+    },
 
     async renameDisplayName(runtimeId: string, displayName: string): Promise<UserSystemdTerminalDescriptor> {
       const parsedName = DisplayNameSchema.safeParse(displayName);

--- a/packages/gateway/src/user-systemd-zellij-runtime.ts
+++ b/packages/gateway/src/user-systemd-zellij-runtime.ts
@@ -148,15 +148,21 @@ export function createUserSystemdZellijRuntime(options: {
       await writeImmutableFileExclusive(environmentPath, environmentContent, 64 * 1024);
       let descriptor;
       try {
-        descriptor = await options.controller.create({
+        const createInput = {
           runtimeId,
-          scope: "workspace",
-          kind: input.launch.command === "bash" ? "shell" : "agent",
+          scope: "workspace" as const,
+          kind: input.launch.command === "bash" ? "shell" as const : "agent" as const,
           displayName: input.sessionId,
           cwd: input.launch.cwd,
           layoutPath,
           environmentPath,
-        });
+        };
+        const existing = await options.controller.get(runtimeId);
+        // A repeated start is a new prompt, not proof it was delivered to an existing live runner.
+        // The controller verifies settled inactivity again while holding its mutation lock.
+        descriptor = existing
+          ? await options.controller.create(createInput, { replaceInactiveWorkspace: true })
+          : await options.controller.create(createInput);
       } catch (err: unknown) {
         let persisted: UserSystemdTerminalDescriptor | null;
         try {

--- a/packages/gateway/src/workspace-session-orchestrator.ts
+++ b/packages/gateway/src/workspace-session-orchestrator.ts
@@ -172,7 +172,7 @@ function errnoIs(error: unknown, code: string): boolean {
     && (error as NodeJS.ErrnoException).code === code;
 }
 
-async function prepareRootChatWorkspace(homePath: string, sessionId: string): Promise<string> {
+async function prepareRootChatWorkspace(homePath: string, sessionId: string): Promise<{ path: string; created: boolean }> {
   const canonicalHome = await realpath(resolve(homePath));
   const root = join(canonicalHome, "temporary", "root-chat-workspaces");
   await mkdir(root, { recursive: true, mode: 0o700 });
@@ -181,12 +181,18 @@ async function prepareRootChatWorkspace(homePath: string, sessionId: string): Pr
     throw new Error("Root Chat workspace root is invalid");
   }
   const workspace = join(root, sessionId);
-  await mkdir(workspace, { mode: 0o700 });
+  let created = false;
+  try {
+    await mkdir(workspace, { mode: 0o700 });
+    created = true;
+  } catch (error: unknown) {
+    if (!errnoIs(error, "EEXIST")) throw error;
+  }
   const workspaceStats = await lstat(workspace);
   if (!workspaceStats.isDirectory() || workspaceStats.isSymbolicLink() || await realpath(workspace) !== workspace) {
     throw new Error("Root Chat workspace is invalid");
   }
-  return workspace;
+  return { path: workspace, created };
 }
 
 async function cleanupRootChatWorkspace(homePath: string, sessionId: string): Promise<void> {
@@ -258,7 +264,8 @@ export function createWorkspaceSessionOrchestrator(options: {
 }) {
   const idGenerator = options.idGenerator ?? (() => `sess_${randomUUID()}`);
   const prepareRootWorkspace = options.prepareRootChatWorkspace
-    ?? (options.homePath ? (sessionId: string) => prepareRootChatWorkspace(options.homePath!, sessionId) : undefined);
+    ? async (sessionId: string) => ({ path: await options.prepareRootChatWorkspace!(sessionId), created: true })
+    : (options.homePath ? (sessionId: string) => prepareRootChatWorkspace(options.homePath!, sessionId) : undefined);
   const cleanupRootWorkspace = options.cleanupRootChatWorkspace
     ?? (options.homePath ? (sessionId: string) => cleanupRootChatWorkspace(options.homePath!, sessionId) : undefined);
   const sweepRootWorkspaces = options.sweepRootChatWorkspaces
@@ -368,7 +375,9 @@ export function createWorkspaceSessionOrchestrator(options: {
             return failure(503, "sandbox_unavailable", "Agent sandbox is unavailable");
           }
           try {
-            workspacePath = await prepareRootWorkspace(sessionId);
+            const prepared = await prepareRootWorkspace(sessionId);
+            workspacePath = prepared.path;
+            ownsRootWorkspace = prepared.created;
           } catch (error: unknown) {
             console.warn(
               "[workspace-session-orchestrator] Root Chat workspace setup failed:",
@@ -377,7 +386,6 @@ export function createWorkspaceSessionOrchestrator(options: {
             return failure(503, "sandbox_unavailable", "Agent sandbox is unavailable");
           }
         }
-        ownsRootWorkspace = !request.projectSlug;
         effectiveRequest = {
           ...request,
           ...(resolvedWorktreeId ? { worktreeId: resolvedWorktreeId } : {}),

--- a/packages/gateway/src/workspace-session-orchestrator.ts
+++ b/packages/gateway/src/workspace-session-orchestrator.ts
@@ -69,6 +69,8 @@ export interface StartWorkspaceSessionRequest {
 export interface StartWorkspaceSessionInput {
   ownerScope: OwnerScope;
   request: StartWorkspaceSessionRequest;
+  /** Internal only: authenticated provider-thread recovery, never request-body data. */
+  recoveryThreadId?: string;
 }
 
 function failure(status: number, code: string, message: string): Failure {
@@ -172,7 +174,7 @@ function errnoIs(error: unknown, code: string): boolean {
     && (error as NodeJS.ErrnoException).code === code;
 }
 
-async function prepareRootChatWorkspace(homePath: string, sessionId: string): Promise<{ path: string; created: boolean }> {
+async function prepareRootChatWorkspace(homePath: string, sessionId: string, authorizeReuse: () => Promise<boolean>): Promise<{ path: string; created: boolean }> {
   const canonicalHome = await realpath(resolve(homePath));
   const root = join(canonicalHome, "temporary", "root-chat-workspaces");
   await mkdir(root, { recursive: true, mode: 0o700 });
@@ -187,6 +189,7 @@ async function prepareRootChatWorkspace(homePath: string, sessionId: string): Pr
     created = true;
   } catch (error: unknown) {
     if (!errnoIs(error, "EEXIST")) throw error;
+    if (!await authorizeReuse()) throw new Error("Root Chat workspace recovery is unavailable");
   }
   const workspaceStats = await lstat(workspace);
   if (!workspaceStats.isDirectory() || workspaceStats.isSymbolicLink() || await realpath(workspace) !== workspace) {
@@ -265,7 +268,7 @@ export function createWorkspaceSessionOrchestrator(options: {
   const idGenerator = options.idGenerator ?? (() => `sess_${randomUUID()}`);
   const prepareRootWorkspace = options.prepareRootChatWorkspace
     ? async (sessionId: string) => ({ path: await options.prepareRootChatWorkspace!(sessionId), created: true })
-    : (options.homePath ? (sessionId: string) => prepareRootChatWorkspace(options.homePath!, sessionId) : undefined);
+    : (options.homePath ? (sessionId: string, authorizeReuse: () => Promise<boolean>) => prepareRootChatWorkspace(options.homePath!, sessionId, authorizeReuse) : undefined);
   const cleanupRootWorkspace = options.cleanupRootChatWorkspace
     ?? (options.homePath ? (sessionId: string) => cleanupRootChatWorkspace(options.homePath!, sessionId) : undefined);
   const sweepRootWorkspaces = options.sweepRootChatWorkspaces
@@ -352,6 +355,7 @@ export function createWorkspaceSessionOrchestrator(options: {
         ? { ...input.request, approvalPolicy: input.request.approvalPolicy ?? "on_request" }
         : input.request;
       const sessionId = request.sessionId ?? idGenerator();
+      if (!/^sess_[A-Za-z0-9_-]{1,128}$/.test(sessionId)) return failure(400, "invalid_session_id", "Session identifier is invalid");
       let sandbox: AgentLaunchSandbox | undefined;
       let effectiveRequest = request;
       let ownsRootWorkspace = false;
@@ -375,7 +379,13 @@ export function createWorkspaceSessionOrchestrator(options: {
             return failure(503, "sandbox_unavailable", "Agent sandbox is unavailable");
           }
           try {
-            const prepared = await prepareRootWorkspace(sessionId);
+            const prepared = await prepareRootWorkspace(sessionId, async () => {
+              if (input.ownerScope.type !== "user" || input.recoveryThreadId !== `thread_${sessionId.slice(5)}`) return false;
+              const prior = await options.agentSessionManager.getSession(sessionId);
+              return prior.ok && prior.session.ownerId === input.ownerScope.id
+                && prior.session.kind === "agent" && prior.session.agent === request.agent
+                && !prior.session.projectSlug;
+            });
             workspacePath = prepared.path;
             ownsRootWorkspace = prepared.created;
           } catch (error: unknown) {

--- a/packages/gateway/src/workspace-session-orchestrator.ts
+++ b/packages/gateway/src/workspace-session-orchestrator.ts
@@ -131,6 +131,7 @@ async function resolveAgentSandbox(options: {
   request: StartWorkspaceSessionRequest;
   sessionId: string;
   workspacePath: string;
+  reuseCodexScratch?: boolean;
 }): Promise<{ ok: true; sandbox?: AgentLaunchSandbox } | Failure> {
   const preflight = await options.agentSandbox.preflight({
     agent: options.agent,
@@ -141,7 +142,7 @@ async function resolveAgentSandbox(options: {
     approvalPolicy: toLaunchApprovalPolicy(options.request.approvalPolicy) ??
       (options.agent === "claude" ? "on-request" : "never"),
     sandboxMode: options.request.sandboxMode ?? "workspace_write",
-  });
+  }, ...(options.reuseCodexScratch ? [{ reuseCodexScratch: true as const }] : []));
   if (!preflight.ok) {
     return {
       ok: false,
@@ -359,6 +360,20 @@ export function createWorkspaceSessionOrchestrator(options: {
       let sandbox: AgentLaunchSandbox | undefined;
       let effectiveRequest = request;
       let ownsRootWorkspace = false;
+      let reuseCodexScratch = false;
+
+      // Only the internal, owner-scoped native-thread recovery path may reuse
+      // sandbox files. Ordinary starts retain exclusive-create semantics.
+      if (request.agent === "codex" && request.providerThreadId
+        && input.ownerScope.type === "user"
+        && input.recoveryThreadId === `thread_${sessionId.slice(5)}`) {
+        const previous = await options.agentSessionManager.getSession(sessionId);
+        reuseCodexScratch = previous.ok && previous.session.id === sessionId
+          && previous.session.ownerId === input.ownerScope.id
+          && previous.session.kind === "agent" && previous.session.agent === "codex"
+          && previous.session.projectSlug === request.projectSlug
+          && previous.session.worktreeId === request.worktreeId;
+      }
 
       if (request.agent === "codex" || request.agent === "claude") {
         let workspacePath: string;
@@ -407,6 +422,7 @@ export function createWorkspaceSessionOrchestrator(options: {
           request: effectiveRequest,
           sessionId,
           workspacePath,
+          reuseCodexScratch,
         });
         if (!preflight.ok) {
           if (ownsRootWorkspace) await cleanupRootWorkspace?.(sessionId);
@@ -422,7 +438,7 @@ export function createWorkspaceSessionOrchestrator(options: {
         sandbox,
       });
       if (!result.ok) {
-        if (sandbox) await cleanupSessionScratch(sessionId);
+        if (sandbox && !reuseCodexScratch) await cleanupSessionScratch(sessionId);
         if (ownsRootWorkspace) await cleanupRootWorkspace?.(sessionId);
         return result;
       }

--- a/packages/platform/src/runtime-proxy-fetch.ts
+++ b/packages/platform/src/runtime-proxy-fetch.ts
@@ -1,0 +1,22 @@
+/** Keep header waits bounded without timing out a healthy streaming body. */
+export async function fetchRuntimeProxy(
+  targetUrl: string,
+  init: RequestInit,
+  timeoutMs: number,
+  releaseTimeoutAfterHeaders: boolean,
+): Promise<Response> {
+  if (!releaseTimeoutAfterHeaders) {
+    return fetch(targetUrl, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(targetUrl, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function shouldReleaseRuntimeProxyTimeout(method: string, path: string): boolean {
+  return method === "GET" && (path === "/api/files/media" || path === "/api/chats/events");
+}

--- a/packages/platform/src/session-routing-middleware.ts
+++ b/packages/platform/src/session-routing-middleware.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from 'node:crypto';
 import { proxyChatShare } from './chat-share-proxy.js';
+import { fetchRuntimeProxy, shouldReleaseRuntimeProxyTimeout } from "./runtime-proxy-fetch.js";
+export { fetchRuntimeProxy } from "./runtime-proxy-fetch.js";
 import type { Context, MiddlewareHandler } from 'hono';
 import type Dockerode from 'dockerode';
 import type { Agent } from 'undici';
@@ -149,39 +151,6 @@ interface CreateSessionRoutingMiddlewareOpts {
   logRouteError: (context: string, err: unknown) => void;
 }
 
-/**
- * Fetch a runtime response with a bounded header wait. Streaming responses can
- * release that timer once the upstream headers arrive so the signal does not
- * terminate a healthy, long-lived response body.
- */
-export async function fetchRuntimeProxy(
-  targetUrl: string,
-  init: RequestInit,
-  timeoutMs: number,
-  releaseTimeoutAfterHeaders: boolean,
-): Promise<Response> {
-  if (!releaseTimeoutAfterHeaders) {
-    return fetch(targetUrl, {
-      ...init,
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-  }
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(targetUrl, {
-      ...init,
-      signal: controller.signal,
-    });
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-function shouldReleaseRuntimeProxyTimeout(method: string, path: string): boolean {
-  return method === 'GET' && path === '/api/files/media';
-}
 
 function logCodeDomainUpstreamFailure(opts: {
   handle: string;

--- a/shell/src/hooks/useCanonicalChatState.ts
+++ b/shell/src/hooks/useCanonicalChatState.ts
@@ -62,6 +62,8 @@ export function useCanonicalChatState(): ChatState {
   } | null>(null);
   const detailRef = useRef(detail);
   const activeChatIdRef = useRef(activeChatId);
+  // An empty selection after New chat is intentional, not an initial restore.
+  const autoRestoreChatRef = useRef(true);
   detailRef.current = detail;
   activeChatIdRef.current = activeChatId;
 
@@ -69,7 +71,9 @@ export function useCanonicalChatState(): ChatState {
     try {
       const page = await client.list();
       setRecords(page.items);
-      setActiveChatId((current) => current ?? page.items[0]?.chat.id);
+      if (autoRestoreChatRef.current) {
+        setActiveChatId((current) => current ?? page.items[0]?.chat.id);
+      }
     } catch (error: unknown) {
       console.warn("[canonical-chat] Shell list unavailable:", error instanceof Error ? error.name : "UnknownError");
       setSafeError("Chats could not be loaded. Try again.");
@@ -309,6 +313,9 @@ export function useCanonicalChatState(): ChatState {
   }, [activeChatId, client, loadDetail, loadList, submitting]);
 
   const newChat = useCallback(async () => {
+    autoRestoreChatRef.current = false;
+    activeChatIdRef.current = undefined;
+    detailRef.current = null;
     detailRequestGeneration.current += 1;
     setActiveChatId(undefined);
     setDetail(null);

--- a/shell/src/hooks/useCanonicalChatState.ts
+++ b/shell/src/hooks/useCanonicalChatState.ts
@@ -18,8 +18,8 @@ import { getGatewayUrl } from "@/lib/gateway";
 import {
   createCanonicalShellChatClient,
   isDefinitiveCanonicalChatRejection,
-  projectCanonicalMessages,
 } from "@/lib/canonical-chat-client";
+import { projectCanonicalTranscript } from "@/lib/canonical-chat-terminal-notices";
 
 const ACTIVE_RUN_FALLBACK_POLL_MS = 2_000;
 const EVENT_INVALIDATION_COALESCE_MS = 200;
@@ -408,7 +408,7 @@ export function useCanonicalChatState(): ChatState {
     }
   }, [client, records]);
 
-  const messages = detail ? projectCanonicalMessages(detail.messages) : [];
+  const messages = detail ? projectCanonicalTranscript(detail) : [];
   if (safeError) {
     messages.push({ id: "canonical-safe-error", role: "system", content: safeError, timestamp: Date.now() });
   }

--- a/shell/src/lib/canonical-chat-terminal-notices.ts
+++ b/shell/src/lib/canonical-chat-terminal-notices.ts
@@ -1,28 +1,15 @@
-import type { CanonicalChatDetailResponse } from "@matrix-os/contracts";
+import { canonicalChatTerminalNotices, type CanonicalChatDetailResponse } from "@matrix-os/contracts";
 import type { ChatMessage } from "./chat";
 import { projectCanonicalMessages } from "./canonical-chat-client";
 
 /** Keep terminal outcomes attached to their turn, using only safe fixed copy. */
 export function projectCanonicalTranscript(detail: CanonicalChatDetailResponse): ChatMessage[] {
   const messages = projectCanonicalMessages(detail.messages);
-  const inputs = detail.turns.map((turn) => ({
-    turn,
-    message: detail.messages.find((message) => message.id === turn.inputMessageId),
-  })).filter((input) => input.message !== undefined)
-    .sort((a, b) => a.message!.seq - b.message!.seq);
-  // Insert backwards so earlier notices cannot change later insertion positions.
-  for (let index = inputs.length - 1; index >= 0; index -= 1) {
-    const { turn } = inputs[index];
-    const run = detail.runs.filter((candidate) => candidate.turnId === turn.id)
-      .reduce<(typeof detail.runs)[number] | undefined>((latest, candidate) =>
-        !latest || candidate.attempt > latest.attempt ? candidate : latest, undefined);
-    if (!run || (run.status !== "failed" && run.status !== "aborted")) continue;
-    const nextInput = inputs[index + 1]?.turn.inputMessageId;
-    const nextIndex = nextInput ? messages.findIndex((message) => message.id === nextInput) : -1;
+  for (const notice of canonicalChatTerminalNotices(detail)) {
+    const nextIndex = notice.beforeMessageId ? messages.findIndex((message) => message.id === notice.beforeMessageId) : -1;
     messages.splice(nextIndex < 0 ? messages.length : nextIndex, 0, {
-      id: `${run.id}:terminal`, role: "system", requestId: run.id,
-      content: run.status === "failed" ? "Agent work failed. Please try again." : "Agent work stopped.",
-      timestamp: Date.parse(run.completedAt ?? run.updatedAt),
+      id: notice.id, role: "system", requestId: notice.runId,
+      content: notice.text, timestamp: notice.timestamp,
     });
   }
   return messages;

--- a/shell/src/lib/canonical-chat-terminal-notices.ts
+++ b/shell/src/lib/canonical-chat-terminal-notices.ts
@@ -1,10 +1,23 @@
-import { canonicalChatTerminalNotices, type CanonicalChatDetailResponse } from "@matrix-os/contracts";
+import { canonicalChatApprovals, canonicalChatTerminalNotices, type CanonicalChatDetailResponse } from "@matrix-os/contracts";
 import type { ChatMessage } from "./chat";
 import { projectCanonicalMessages } from "./canonical-chat-client";
 
 /** Keep terminal outcomes attached to their turn, using only safe fixed copy. */
 export function projectCanonicalTranscript(detail: CanonicalChatDetailResponse): ChatMessage[] {
   const messages = projectCanonicalMessages(detail.messages);
+  for (const approval of canonicalChatApprovals(detail)) {
+    const existing = messages.find(message => message.id === approval.id);
+    if (existing) {
+      existing.metadata = { ...existing.metadata, canonicalApproval: approval };
+      continue;
+    }
+    const index = approval.beforeMessageId ? messages.findIndex(message => message.id === approval.beforeMessageId) : -1;
+    messages.splice(index < 0 ? messages.length : index, 0, {
+      id: approval.id, role: "system", requestId: approval.runId,
+      content: approval.title, timestamp: approval.timestamp,
+      metadata: { canonicalApproval: approval },
+    });
+  }
   for (const notice of canonicalChatTerminalNotices(detail)) {
     const nextIndex = notice.beforeMessageId ? messages.findIndex((message) => message.id === notice.beforeMessageId) : -1;
     messages.splice(nextIndex < 0 ? messages.length : nextIndex, 0, {

--- a/shell/src/lib/canonical-chat-terminal-notices.ts
+++ b/shell/src/lib/canonical-chat-terminal-notices.ts
@@ -1,0 +1,29 @@
+import type { CanonicalChatDetailResponse } from "@matrix-os/contracts";
+import type { ChatMessage } from "./chat";
+import { projectCanonicalMessages } from "./canonical-chat-client";
+
+/** Keep terminal outcomes attached to their turn, using only safe fixed copy. */
+export function projectCanonicalTranscript(detail: CanonicalChatDetailResponse): ChatMessage[] {
+  const messages = projectCanonicalMessages(detail.messages);
+  const inputs = detail.turns.map((turn) => ({
+    turn,
+    message: detail.messages.find((message) => message.id === turn.inputMessageId),
+  })).filter((input) => input.message !== undefined)
+    .sort((a, b) => a.message!.seq - b.message!.seq);
+  // Insert backwards so earlier notices cannot change later insertion positions.
+  for (let index = inputs.length - 1; index >= 0; index -= 1) {
+    const { turn } = inputs[index];
+    const run = detail.runs.filter((candidate) => candidate.turnId === turn.id)
+      .reduce<(typeof detail.runs)[number] | undefined>((latest, candidate) =>
+        !latest || candidate.attempt > latest.attempt ? candidate : latest, undefined);
+    if (!run || (run.status !== "failed" && run.status !== "aborted")) continue;
+    const nextInput = inputs[index + 1]?.turn.inputMessageId;
+    const nextIndex = nextInput ? messages.findIndex((message) => message.id === nextInput) : -1;
+    messages.splice(nextIndex < 0 ? messages.length : nextIndex, 0, {
+      id: `${run.id}:terminal`, role: "system", requestId: run.id,
+      content: run.status === "failed" ? "Agent work failed. Please try again." : "Agent work stopped.",
+      timestamp: Date.parse(run.completedAt ?? run.updatedAt),
+    });
+  }
+  return messages;
+}

--- a/tests/desktop/canonical-chat-presentation.test.ts
+++ b/tests/desktop/canonical-chat-presentation.test.ts
@@ -463,7 +463,8 @@ describe("canonical Chat presentation adapter", () => {
         kind: "activity-group",
         activities: [expect.objectContaining({ label: "Run tests", state: "failed", detail: "Focused suite\n\nOne test failed." })],
       }),
-      expect.objectContaining({ kind: "request", requestKind: "approval", state: "waiting", label: "Retry the command" }),
+      // A terminal run cannot execute an old approval, even if older history omitted its resolution.
+      expect.objectContaining({ kind: "request", requestKind: "approval", state: "resolved", actions: undefined, label: "Retry the command" }),
       expect.objectContaining({ kind: "notice", tone: "warning", label: "Partial result" }),
     ]));
     expect(presented?.final).toMatchObject({ markdown: "Finished summary", copyText: "Finished summary" });

--- a/tests/desktop/chat-file-navigation.test.tsx
+++ b/tests/desktop/chat-file-navigation.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { ChatFileNavigationProvider, useChatFileNavigation } from "@desktop/renderer/src/features/work/ChatFileNavigation";
+
+afterEach(cleanup);
+
+it("clears inspector requests on navigation without remounting children or accepting stale opens", () => {
+  const reveal = vi.fn();
+  let delayedOpen: (() => void) | undefined;
+  function Consumer({ chatId }: { chatId: string }) {
+    const navigation = useChatFileNavigation();
+    const [text, setText] = React.useState("");
+    const open = () => navigation?.open({ chatId, target: {
+      kind: "project", projectId: "project", path: "README.md", label: "README.md",
+    } });
+    return <>
+      <input aria-label="Draft" value={text} onChange={(event) => setText(event.target.value)} />
+      <button onClick={() => { delayedOpen = open; open(); }}>Open file</button>
+      <output>{navigation?.request?.chatId ?? "no file"}</output>
+    </>;
+  }
+  const tree = (scope: string) => <ChatFileNavigationProvider scopeKey={scope} reveal={reveal}>
+    <Consumer chatId={scope} />
+  </ChatFileNavigationProvider>;
+  const view = render(tree("a"));
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: "retained" } });
+  fireEvent.click(screen.getByRole("button"));
+  expect(screen.getByRole("status").textContent).toBe("a");
+  const oldOpen = delayedOpen;
+  view.rerender(tree("b"));
+  expect(screen.getByRole("status").textContent).toBe("no file");
+  view.rerender(tree("a"));
+  act(() => oldOpen?.());
+  expect(screen.getByRole("status").textContent).toBe("no file");
+  expect(reveal).toHaveBeenCalledTimes(1);
+  expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("retained");
+  fireEvent.click(screen.getByRole("button"));
+  expect(screen.getByRole("status").textContent).toBe("a");
+  view.unmount();
+  act(() => delayedOpen?.());
+  expect(reveal).toHaveBeenCalledTimes(2);
+});

--- a/tests/desktop/chat-steer-http-stream.test.tsx
+++ b/tests/desktop/chat-steer-http-stream.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { KyselyPGlite } from "kysely-pglite";
+import { createCanonicalChatFixture } from "../contracts/fixtures/canonical-chat";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository";
+import { createCanonicalChatEventStream } from "../../packages/gateway/src/chat/event-stream";
+import { registerCanonicalChatEventHttpRoute } from "../../packages/gateway/src/chat/event-http-route";
+import { createCanonicalChatEventSource } from "../../packages/ui/src/canonical-chat-event-source";
+import type { CanonicalChatClient } from "@desktop/renderer/src/lib/canonical-chat-client";
+import { useCanonicalChatRouteController } from "@desktop/renderer/src/features/chat/use-canonical-chat-route-controller";
+
+it.each([
+  { mode: "direct", repeat: "already_accepted", reconnect: false },
+  { mode: "queued", repeat: "already_accepted", reconnect: false },
+  { mode: "direct", repeat: "already_accepted", reconnect: true },
+  { mode: "queued", repeat: "already_accepted", reconnect: true },
+  { mode: "direct", repeat: "accepted", reconnect: false },
+  { mode: "direct", repeat: "accepted", reconnect: true },
+] as const)("keeps $mode steering live with $repeat responses (reconnect=$reconnect)", async ({ mode, repeat, reconnect }) => {
+  const db = await KyselyPGlite.create();
+  const repository = new ChatRepository(db.dialect);
+  await repository.bootstrap();
+  const owner = { type: "personal" as const, ownerId: "owner_stream" };
+  const { snapshot } = createCanonicalChatFixture("running");
+  const chatId = snapshot.chat.id;
+  const run = snapshot.runs[0]!;
+  const turn = snapshot.turns[0]!;
+  await repository.create(owner, { id: chatId, clientRequestId: "req_stream", title: "Stream" });
+  await repository.admitTurn(owner, {
+    chatId, baseRevision: 0, message: snapshot.messages[0]!, turn: { ...turn, status: "accepted" },
+    run: { ...run, status: "accepted", capabilitySnapshot: { ...run.capabilitySnapshot, steering: "same_run" } },
+  });
+  await repository.markRunRunning(owner, { chatId, runId: run.id, startedAt: snapshot.chat.createdAt });
+  if (mode === "queued") await repository.enqueueQueuedTurn(owner, {
+    chatId, baseRevision: (await repository.get(owner, chatId))!.chat.revision,
+    queuedTurnId: "qturn_stream", clientRequestId: "req_queue_stream",
+    parts: [{ type: "text", text: "continue" }], driverKind: run.driverKind,
+    selection: run.selection, interactionMode: run.interactionMode, permissionMode: run.permissionMode,
+    capabilitySnapshot: run.capabilitySnapshot, createdAt: snapshot.chat.createdAt,
+  });
+  const initial = (await repository.getDetailPage(owner, chatId, { limit: 200 }))!;
+  const stream = createCanonicalChatEventStream({ repository });
+  const app = new Hono();
+  registerCanonicalChatEventHttpRoute({ app, stream, getPrincipal: () => ({ userId: owner.ownerId, source: "jwt" }) });
+  let release: (() => void) | undefined;
+  let deliveryGate: Promise<void> | undefined;
+  let disconnect: (() => void) | undefined;
+  const openStream = vi.fn(async ({ signal, cursor }: { signal: AbortSignal; cursor?: number }) => {
+    const response = await app.request(`/api/chats/events${cursor === undefined ? "" : `?cursor=${cursor}`}`, {
+      signal, headers: { accept: "text/event-stream", "x-matrix-chat-protocol": "2" },
+    });
+    return new Response(response.body!.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+      start(controller) { disconnect = () => controller.terminate(); },
+      async transform(chunk, controller) { await deliveryGate; controller.enqueue(chunk); },
+    })), { headers: response.headers });
+  });
+  const source = createCanonicalChatEventSource({ openStream });
+  const getDetail = vi.fn(async () => initial);
+  let firstRequest = true;
+  const steer = async () => {
+      const suffix = !firstRequest && repeat === "accepted" ? "_second" : "";
+      const requestId = `req_steer_stream${suffix}`;
+      // Provider output can commit after the UI captures its request revision,
+      // while the independent HTTP response arrives before these SSE bytes.
+      if (firstRequest) await repository.appendAssistantDelta(owner, { chatId, runId: run.id,
+        messageId: "msg_streaming", delta: "hello", createdAt: snapshot.chat.createdAt });
+      firstRequest = false;
+      const input = { chatId, runId: run.id, expectedTurnId: turn.id,
+        steerId: `steer_stream${suffix}`, messageId: `msg_steer_stream${suffix}`, clientRequestId: requestId,
+        parts: [{ type: "text" as const, text: "continue" }], createdAt: snapshot.chat.createdAt };
+      const begun = mode === "queued" ? await repository.beginQueuedTurnSteer(owner, {
+        ...input, queuedTurnId: "qturn_stream", baseRevision: initial.record.chat.revision,
+      }) : await repository.beginSteer(owner, input);
+      if (begun.status === "accepted") return { message: begun.message, runId: run.id, turnId: turn.id, steering: "already_accepted" as const };
+      const accepted = { chatId, runId: run.id, clientRequestId: requestId, acceptedAt: snapshot.chat.createdAt };
+      const message = mode === "queued" ? await repository.acceptQueuedTurnSteer(owner, {
+        ...accepted, queuedTurnId: "qturn_stream",
+      }) : await repository.acceptSteer(owner, accepted);
+      return { message, runId: run.id, turnId: turn.id, steering: "accepted" as const };
+  };
+  const client = {
+    list: async () => ({ items: [initial.record] }),
+    getDetail,
+    acknowledgeCompletion: async () => (await repository.get(owner, chatId))!,
+    steerRun: steer,
+    steerQueuedTurn: steer,
+  } as CanonicalChatClient;
+  const hook = renderHook(() => useCanonicalChatRouteController({ client, projectId: null,
+    active: true, initialChatId: chatId, eventSource: source }));
+  try {
+    await act(async () => { await source.start(); });
+    await waitFor(() => expect(hook.result.current.detail?.record.chat.revision).toBe(initial.record.chat.revision));
+    deliveryGate = new Promise<void>((resolve) => { release = resolve; });
+    await act(async () => {
+      expect(await (mode === "queued" ? hook.result.current.steerQueuedTurn("qturn_stream")
+        : hook.result.current.steerActiveRun([{ type: "text", text: "continue" }]))).not.toBeNull();
+    });
+    expect(hook.result.current.detail?.messages.some((message) => message.id === "msg_streaming")).toBe(false);
+    await act(async () => { release?.(); });
+    await waitFor(() => expect(hook.result.current.detail?.messages.find((message) => message.id === "msg_streaming")?.parts)
+      .toEqual([{ type: "text", text: "hello" }]));
+    await act(async () => {
+      await repository.appendAssistantDelta(owner, { chatId, runId: run.id,
+        messageId: "msg_streaming", delta: " world", createdAt: snapshot.chat.createdAt });
+    });
+    await waitFor(() => expect(hook.result.current.detail?.messages.find((message) => message.id === "msg_streaming")?.parts)
+      .toEqual([{ type: "text", text: "hello world" }]));
+    deliveryGate = new Promise<void>((resolve) => { release = resolve; });
+    await act(async () => {
+      const response = mode === "queued" ? await hook.result.current.steerQueuedTurn("qturn_stream")
+        : await hook.result.current.steerActiveRun([{ type: "text", text: "continue" }]);
+      expect(response?.steering).toBe(repeat);
+      release?.();
+      await repository.appendRunActivities(owner, chatId, run.id, [{ id: "activity_stream", chatId,
+        runId: run.id, type: "run.status", status: "running", occurredAt: snapshot.chat.createdAt }]);
+    });
+    await waitFor(() => expect(hook.result.current.detail?.activities.some((activity) => activity.id === "activity_stream")).toBe(true));
+    expect(hook.result.current.detail?.messages.filter((message) => message.id === "msg_steer_stream")).toHaveLength(1);
+    await act(async () => {
+      await repository.appendAssistantDelta(owner, { chatId, runId: run.id,
+        messageId: "msg_streaming", delta: " live", createdAt: snapshot.chat.createdAt });
+    });
+    await waitFor(() => expect(hook.result.current.detail?.messages.find((message) => message.id === "msg_streaming")?.parts)
+      .toEqual([{ type: "text", text: "hello world live" }]));
+    if (reconnect) {
+      await act(async () => { disconnect?.(); });
+      await act(async () => {
+        await repository.appendAssistantDelta(owner, { chatId, runId: run.id,
+          messageId: "msg_streaming", delta: " replay", createdAt: snapshot.chat.createdAt });
+      });
+      await waitFor(() => expect(hook.result.current.detail?.messages.find((message) => message.id === "msg_streaming")?.parts)
+        .toEqual([{ type: "text", text: "hello world live replay" }]));
+      expect(openStream).toHaveBeenCalledTimes(2);
+      expect(openStream.mock.calls[1]?.[0].cursor).toBeGreaterThan(0);
+    }
+    await act(async () => {
+      await repository.finishRun(owner, { chatId, runId: run.id, outcome: "completed", completedAt: snapshot.chat.createdAt });
+    });
+    await waitFor(() => expect(hook.result.current.detail?.record.activeRun).toBeUndefined());
+    expect(hook.result.current.detail?.runs.find((candidate) => candidate.id === run.id)?.status).toBe("completed");
+    // One initial snapshot; reconnection deliberately reconciles once. Healthy
+    // steering/content delivery never uses per-event polling or reload.
+    expect(getDetail).toHaveBeenCalledTimes(reconnect ? 2 : 1);
+  } finally {
+    release?.(); hook.unmount(); source.dispose(); stream.shutdown(); await repository.kysely.destroy();
+  }
+});

--- a/tests/desktop/work-tab.test.tsx
+++ b/tests/desktop/work-tab.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { CanonicalChatRecord } from "@matrix-os/contracts";
 import WorkTab from "@desktop/renderer/src/features/work/WorkTab";
+import { useChatComposerDrafts } from "@desktop/renderer/src/features/chat/use-chat-composer-drafts";
 import { SurfaceChromeContext, type SurfaceChromeSpec } from "@desktop/renderer/src/features/desktop-shell/SurfaceChrome";
 import { useBoard, type Project } from "@desktop/renderer/src/stores/board";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
@@ -17,6 +18,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const inspectorProps = vi.hoisted(() => ({
   active: [] as boolean[],
 }));
+const stableDraftClient = {};
+function DraftHarness({ chatId }: { chatId?: string }) {
+  const draft = useChatComposerDrafts({ clientIdentity: stableDraftClient, chatId, projectId: null, conversation: Boolean(chatId) });
+  return <>
+    <input aria-label="Chat draft" value={draft.text} onChange={(event) => draft.setText(event.target.value)} />
+    <button onClick={() => draft.setReferenceTokens([{ type: "resource", resource: {
+      kind: "file", id: "readme", label: "README.md",
+    } }])}>Attach draft reference</button>
+    <output aria-label="Draft references">{draft.referenceTokens.length}</output>
+  </>;
+}
 const chatTabProps = vi.hoisted(() => ({
   tabIds: [] as Array<string | undefined>,
 }));
@@ -63,11 +75,13 @@ vi.mock("@desktop/renderer/src/features/work/WorkRail", async (importOriginal) =
 vi.mock("@desktop/renderer/src/features/chat/ChatTab", () => ({
   default: ({
     tabId,
+    initialChatId,
     eventSource,
     renderInspector,
     inspectorExclusive,
   }: {
     tabId?: string;
+    initialChatId?: string;
     eventSource?: unknown;
     renderInspector?: (detail: unknown) => React.ReactNode;
     inspectorExclusive?: boolean;
@@ -76,7 +90,9 @@ vi.mock("@desktop/renderer/src/features/chat/ChatTab", () => ({
     eventSourceProps.chat.push(eventSource);
     return (
       <>
-        <main aria-hidden={inspectorExclusive || undefined}>Chat center</main>
+        <main aria-hidden={inspectorExclusive || undefined}>Chat center
+          <DraftHarness chatId={initialChatId} />
+        </main>
         {renderInspector?.({ record: { chat: { id: "chat_global" } }, activities: [] })}
       </>
     );
@@ -84,10 +100,12 @@ vi.mock("@desktop/renderer/src/features/chat/ChatTab", () => ({
 }));
 vi.mock("@desktop/renderer/src/features/project/ProjectChatsView", () => ({
   default: ({
+    initialChatId,
     eventSource,
     renderInspector,
     inspectorExclusive,
   }: {
+    initialChatId?: string;
     eventSource?: unknown;
     renderInspector?: (detail: unknown) => React.ReactNode;
     inspectorExclusive?: boolean;
@@ -95,7 +113,7 @@ vi.mock("@desktop/renderer/src/features/project/ProjectChatsView", () => ({
     eventSourceProps.project.push(eventSource);
     return (
       <>
-        <main aria-hidden={inspectorExclusive || undefined}>Project center</main>
+        <main aria-hidden={inspectorExclusive || undefined}>Project center<DraftHarness chatId={initialChatId} /></main>
         {renderInspector?.({ record: { chat: { id: "chat_alpha" } }, activities: [] })}
       </>
     );
@@ -288,6 +306,36 @@ describe("WorkTab rail integration", () => {
     render(<WorkTab tabId="chat-tab-2" route="chat" active />);
 
     expect(chatTabProps.tabIds).toContain("chat-tab-2");
+  });
+
+  it.each(["chat", "project"] as const)("preserves drafts across Chat A, Chat B, and New Chat in the %s route", async (route) => {
+    const surface = (chatId?: string) => <WorkTab route={route} projectSlug={route === "project" ? "alpha" : undefined}
+      active initialChatId={chatId} initialChatView={chatId ? "conversation" : "draft"} />;
+    const view = render(surface("chat_global"));
+    const input = () => screen.getByRole("textbox", { name: "Chat draft" }) as HTMLInputElement;
+    fireEvent.change(input(), { target: { value: "unsent draft a" } });
+    fireEvent.click(screen.getByRole("button", { name: "Attach draft reference" }));
+    view.rerender(surface("chat_other"));
+    expect(input().value).toBe("");
+    expect(screen.getByLabelText("Draft references").textContent).toBe("0");
+    fireEvent.change(input(), { target: { value: "unsent draft b" } });
+    view.rerender(surface());
+    expect(input().value).toBe("");
+    fireEvent.change(input(), { target: { value: "new chat draft" } });
+    view.rerender(surface("chat_global"));
+    expect(input().value).toBe("unsent draft a");
+    expect(screen.getByLabelText("Draft references").textContent).toBe("1");
+    view.rerender(surface("chat_other"));
+    expect(input().value).toBe("unsent draft b");
+    view.rerender(surface());
+    expect(input().value).toBe("new chat draft");
+    act(() => useConnection.setState({ authGeneration: 2 }));
+    expect(input().value).toBe("");
+    expect(screen.getByLabelText("Draft references").textContent).toBe("0");
+    fireEvent.change(input(), { target: { value: "different account draft" } });
+    act(() => useConnection.setState({ runtimeSlot: "secondary" }));
+    expect(input().value).toBe("");
+    await act(async () => undefined);
   });
 
   it("owns one shared Chat event source across rail and content and replaces it on runtime identity changes", async () => {

--- a/tests/fixtures/codex-idle-provider.mjs
+++ b/tests/fixtures/codex-idle-provider.mjs
@@ -1,0 +1,16 @@
+import { createInterface } from "node:readline";
+const send = (value) => process.stdout.write(`${JSON.stringify(value)}\n`);
+for await (const line of createInterface({ input: process.stdin })) {
+  const request = JSON.parse(line);
+  if (request.method === "initialize") send({ id: request.id, result: {} });
+  if (request.method === "thread/start" || request.method === "thread/resume") {
+    send({ id: request.id, result: { thread: { id: "native_idle_test" } } });
+  }
+  if (request.method === "turn/start") {
+    send({ id: request.id, result: { turn: { id: "native_turn_test" } } });
+    send({ method: "item/agentMessage/delta", params: { turnId: "native_turn_test", itemId: "message_test", delta: "Task started and remains active." } });
+    if (!process.env.MATRIX_TEST_KEEP_ACTIVE) {
+      send({ method: "turn/completed", params: { turn: { id: "native_turn_test", status: "completed", items: [] } } });
+    }
+  }
+}

--- a/tests/fixtures/codex-launch-failure.mjs
+++ b/tests/fixtures/codex-launch-failure.mjs
@@ -1,0 +1,22 @@
+import { createInterface } from "node:readline";
+const mode = process.env.MATRIX_TEST_LAUNCH_FAILURE;
+const send = (value) => process.stdout.write(`${JSON.stringify(value)}\n`);
+for await (const line of createInterface({ input: process.stdin })) {
+  const request = JSON.parse(line);
+  if (request.method === "initialize") {
+    if (mode === "handshake-exit") process.exit(7);
+    if (mode !== "handshake-timeout") send({ id: request.id, result: {} });
+  }
+  if (request.method === "thread/start" || request.method === "thread/resume") send({ id: request.id, result: { thread: { id: "native_failure_test" } } });
+  if (request.method === "turn/start") {
+    send({ id: request.id, result: { turn: { id: "native_failure_turn" } } });
+    send({ method: "item/started", params: { turnId: "native_failure_turn", item: {
+      id: "failed-mcp", type: "mcpToolCall", server: "fixture", tool: "read_only_probe", status: "inProgress",
+    } } });
+    // Let stdio flush; the real runner must settle this tool when the provider dies.
+    setTimeout(() => {
+      if (mode === "mcp-runner-exit") process.kill(process.ppid, "SIGKILL");
+      process.exit(7);
+    }, 50);
+  }
+}

--- a/tests/fixtures/codex-spawn-eagain.mjs
+++ b/tests/fixtures/codex-spawn-eagain.mjs
@@ -1,0 +1,11 @@
+import { createRequire, syncBuiltinESMExports } from "node:module";
+const processModule = createRequire(import.meta.url)("node:child_process");
+const original = processModule.spawn;
+processModule.spawn = (command, args, options) => {
+  if (args.includes("app-server")) {
+    process.stderr.write("Injected spawn EAGAIN\n");
+    throw Object.assign(new Error("spawn EAGAIN"), { code: "EAGAIN" });
+  }
+  return original(command, args, options);
+};
+syncBuiltinESMExports();

--- a/tests/gateway/chat-idle-admission.test.ts
+++ b/tests/gateway/chat-idle-admission.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KyselyPGlite } from "kysely-pglite";
+import { CanonicalChatRunSchema } from "@matrix-os/contracts";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository.js";
+import { withCanonicalIdleChat } from "../../packages/gateway/src/chat/idle-runtime-admission.js";
+
+const owner = { type: "personal" as const, ownerId: "owner" };
+const at = "2026-09-08T00:00:00.000Z";
+const identity = { ownerId: "owner", threadId: "thread_idle", sessionId: "sess_idle", providerThreadId: "native_idle" };
+describe("canonical idle runtime admission", () => {
+  let database: Awaited<ReturnType<typeof KyselyPGlite.create>>;
+  let repository: ChatRepository;
+  beforeEach(async () => { database = await KyselyPGlite.create(); repository = new ChatRepository(database.dialect); await repository.bootstrap(); });
+  afterEach(async () => { await repository.release(); await repository.kysely.destroy(); });
+  async function admitted() {
+    const created = await repository.create(owner, { id: "chat_idle", clientRequestId: "req_create", title: "Idle" });
+    const message = { id: "msg_idle", chatId: "chat_idle", seq: 1, role: "user" as const, state: "committed" as const,
+      turnId: "cturn_idle", parts: [{ type: "text" as const, text: "Task" }], createdAt: at };
+    const turn = { id: "cturn_idle", chatId: "chat_idle", clientRequestId: "req_turn", baseMessageSeq: 0,
+      inputMessageId: message.id, status: "accepted" as const, createdAt: at, updatedAt: at };
+    const run = CanonicalChatRunSchema.parse({ id: "run_idle", chatId: "chat_idle", turnId: turn.id, attempt: 1,
+      driverKind: "codex", instanceId: "codex_default", selection: { instanceId: "codex_default", model: "model" },
+      interactionMode: "default", permissionMode: "supervised", status: "accepted", historyBoundarySeq: 0,
+      capabilitySnapshot: { revision: "catalog_1", rootChat: true, attachments: [], resources: [], tools: [],
+        approvals: true, userInput: true, resume: true, cancellation: true, steering: "same_run", worktrees: "optional",
+        interactionModes: ["default"], permissionModes: ["supervised"] }, createdAt: at, updatedAt: at });
+    await repository.admitTurn(owner, { chatId: "chat_idle", baseRevision: created.chat.revision, message, turn, run,
+      adapterState: { schemaVersion: 1, state: { conversationId: identity.threadId } } });
+    return run;
+  }
+  it("requires matching durable ownership and excludes active runs", async () => {
+    await admitted();
+    const reclaim = vi.fn(async () => true);
+    expect(await withCanonicalIdleChat(repository.kysely, identity, reclaim)).toBe(false);
+    await repository.finishRun(owner, { chatId: "chat_idle", runId: "run_idle", outcome: "completed", completedAt: at });
+    expect(await withCanonicalIdleChat(repository.kysely, { ...identity, ownerId: "other" }, reclaim)).toBe(false);
+    expect(await withCanonicalIdleChat(repository.kysely, identity, reclaim)).toBe(true);
+    expect(reclaim).toHaveBeenCalledTimes(1);
+  });
+  it("does not reclaim a completed chat with a durable queued prompt", async () => {
+    const run = await admitted();
+    const chat = await repository.get(owner, "chat_idle");
+    await repository.enqueueQueuedTurn(owner, { chatId: "chat_idle", baseRevision: chat!.chat.revision,
+      queuedTurnId: "qturn_idle", clientRequestId: "req_queue", parts: [{ type: "text", text: "Next" }],
+      driverKind: "codex", selection: run.selection, interactionMode: "default", permissionMode: "supervised",
+      capabilitySnapshot: run.capabilitySnapshot, createdAt: at });
+    await repository.finishRun(owner, { chatId: "chat_idle", runId: "run_idle", outcome: "completed", completedAt: at });
+    const reclaim = vi.fn(async () => true);
+    expect(await withCanonicalIdleChat(repository.kysely, identity, reclaim)).toBe(false);
+    expect(reclaim).not.toHaveBeenCalled();
+  });
+});

--- a/tests/gateway/chat-idle-reaper.test.ts
+++ b/tests/gateway/chat-idle-reaper.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChatIdleReaper } from "../../packages/gateway/src/coding-agents/chat-idle-reaper.js";
+import { workspaceRuntimeId } from "../../packages/gateway/src/user-systemd-zellij-runtime.js";
+
+describe("Chat idle reaper", () => {
+  it("reclaims bounded proven idle runtimes, preserves unrelated sessions, and recovers a recorded stop intent", async () => {
+    const runtimes = ["sess_old", "sess_busy", "sess_unknown", "sess_stopping"].map((displayName) => ({
+      runtimeId: workspaceRuntimeId(displayName), displayName, scope: "workspace", createdAt: "2026-09-08T00:00:00Z",
+      layoutPath: "/owned/runtime.kdl", ...(displayName === "sess_stopping" ? { hibernatedAt: "2026-09-08T00:01:00Z" } : {}),
+    }));
+    const alive = new Set(runtimes.map((runtime) => runtime.runtimeId));
+    const hibernate = vi.fn(async () => {});
+    const controller = { list: async () => runtimes, isRunning: async (id: string) => alive.has(id),
+      hibernateWorkspace: vi.fn(async (id: string) => { alive.delete(id); return { ok: true }; }) };
+    const threads = { withIdleWorkspace: async (id: string, _cutoff: number, action: (identity: unknown) => Promise<boolean>) => {
+      if (["sess_busy", "sess_unknown"].includes(id)) return false;
+      return action({ ownerId: "owner", sessionId: id, threadId: `thread_${id.slice(5)}`, providerThreadId: "native_saved" });
+    } };
+    const reaper = createChatIdleReaper({ controller, threads, control: { hibernate },
+      sessions: { getSession: async (id: string) => ({ ok: true, session: { id, ownerId: "owner", kind: "agent", agent: "codex", attachedClients: 0, lastActivityAt: "2026-09-08T00:00:00Z" } }) },
+      admitCanonical: async (_identity: unknown, action: () => Promise<boolean>) => action(),
+      unwatch: vi.fn(), underPressure: async () => true, now: () => Date.parse("2026-09-08T01:00:00Z"),
+    } as never);
+    try {
+      expect((await reaper.sweep()).reclaimed).toBe(2);
+      expect(hibernate).toHaveBeenCalledTimes(1);
+      expect(alive.has(workspaceRuntimeId("sess_busy"))).toBe(true);
+      expect(alive.has(workspaceRuntimeId("sess_unknown"))).toBe(true);
+      expect((await reaper.sweep()).reclaimed).toBe(0);
+    } finally { await reaper.close(); }
+  });
+
+  it("never force-stops an unsupported runner or an attached owner terminal", async () => {
+    const stop = vi.fn();
+    const control = vi.fn(async () => { throw new Error("old runner does not support idle admission"); });
+    const reaper = createChatIdleReaper({
+      controller: { list: async () => ["sess_old", "sess_attached"].map((displayName) => ({ runtimeId: workspaceRuntimeId(displayName), displayName,
+        scope: "workspace", createdAt: "2026-09-08T00:00:00Z", layoutPath: "/owned/runtime.kdl" })), isRunning: async () => true, hibernateWorkspace: stop },
+      threads: { withIdleWorkspace: async (id: string, _cutoff: number, action: (identity: unknown) => Promise<boolean>) => action({ ownerId: "owner", sessionId: id, providerThreadId: "native_saved" }) },
+      sessions: { getSession: async (id: string) => ({ ok: true, session: { id, ownerId: "owner", kind: "agent", agent: "codex", attachedClients: id === "sess_attached" ? 1 : 0, lastActivityAt: "2026-09-08T00:00:00Z" } }) },
+      control: { hibernate: control }, admitCanonical: async (_identity: unknown, action: () => Promise<boolean>) => action(),
+      unwatch: vi.fn(), underPressure: async () => false, now: () => Date.parse("2026-09-08T01:00:00Z"),
+    } as never);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try { await reaper.sweep(); expect(stop).not.toHaveBeenCalled(); expect(control).toHaveBeenCalledTimes(1); }
+    finally { await reaper.close(); warn.mockRestore(); }
+  });
+});

--- a/tests/gateway/codex-idle-runtime.test.ts
+++ b/tests/gateway/codex-idle-runtime.test.ts
@@ -1,0 +1,59 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createConnection } from "node:net";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createCodexControlClient } from "../../packages/gateway/src/coding-agents/codex-control-client.js";
+import { codexProviderEventPath } from "../../packages/gateway/src/coding-agents/codex-event-bridge.js";
+
+async function waitFor(path: string, text: string) {
+  for (let attempt = 0; attempt < 250; attempt++) {
+    try { if ((await readFile(path, "utf8")).includes(text)) return; }
+    catch (error: unknown) { if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error; }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("Timed out waiting for runner output");
+}
+
+function control(path: string, providerThreadId: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ path });
+    let output = "";
+    socket.setEncoding("utf8");
+    socket.setTimeout(2_000, () => socket.destroy(new Error("control timeout")));
+    socket.once("error", reject);
+    socket.once("connect", () => socket.end(`${JSON.stringify({ type: "hibernate", providerThreadId, clientRequestId: "req_hibernate_test" })}\n`));
+    socket.on("data", (chunk) => { output += chunk; });
+    socket.once("end", () => { try { resolve(JSON.parse(output)); } catch (error) { reject(error); } });
+  });
+}
+
+describe("Codex idle runtime handshake", () => {
+  it.each([false, true])("hibernates only after work has completed (active=%s)", async (active) => {
+    const home = await mkdtemp("/tmp/codex-idle-");
+    const eventPath = codexProviderEventPath(home, "sess_idle");
+    const config = Buffer.from(JSON.stringify({ prompt: "Small task", approvalPolicy: "never", sandbox: "read-only", writableRoots: [home] })).toString("base64");
+    const child = spawn(process.execPath, [join(process.cwd(), "packages/gateway/src/coding-agents/codex-app-server-runner.mjs"),
+      eventPath, process.version.slice(1), process.execPath, join(process.cwd(), "tests/fixtures/codex-idle-provider.mjs"), config], {
+      cwd: home, stdio: ["pipe", "ignore", "pipe"], env: { ...process.env, ...(active ? { MATRIX_TEST_KEEP_ACTIVE: "1" } : {}) },
+    });
+    const exited = once(child, "close");
+    try {
+      await waitFor(eventPath, active ? "Task started" : "turn.completed");
+      expect(await readFile(eventPath, "utf8")).toContain('"type":"thread.started","thread_id":"native_idle_test"');
+      await expect(control(eventPath.replace(/\.jsonl$/, ".sock"), "wrong_native_id")).resolves.toEqual({ ok: false });
+      const hibernate = () => createCodexControlClient({ homePath: home }).hibernate({
+        sessionId: "sess_idle", providerThreadId: "native_idle_test", clientRequestId: "req_hibernate_client",
+      });
+      if (active) await expect(hibernate()).rejects.toThrow();
+      else await expect(hibernate()).resolves.toBeUndefined();
+      if (!active) expect((await exited)[0]).toBe(0);
+      else expect(child.exitCode).toBeNull();
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+      await exited;
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gateway/codex-launch-failure.test.ts
+++ b/tests/gateway/codex-launch-failure.test.ts
@@ -1,0 +1,80 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CODEX_VERIFIED_VERSION } from "@matrix-os/contracts";
+import { createCodingAgentThreadStore } from "../../packages/gateway/src/coding-agents/thread-store.js";
+import { createCodexEventBridge, codexProviderEventPath } from "../../packages/gateway/src/coding-agents/codex-event-bridge.js";
+import { createCanonicalCodingChatProviderAdapter } from "../../packages/gateway/src/chat/coding-provider-adapter.js";
+import type { CanonicalProviderRunEvent } from "../../packages/gateway/src/chat/provider-adapter.js";
+
+describe("provider launch failure reaches canonical Chat", () => {
+  it.each(["spawn-eagain", "handshake-exit", "handshake-timeout", "mcp-early-exit", "mcp-runner-exit", "resume-identity-mismatch"])("settles the run and in-flight tool for %s", async (mode) => {
+    const homePath = await mkdtemp("/tmp/cf-");
+    let child: ChildProcess | undefined;
+    let ended: Promise<unknown> | undefined;
+    let now = 0;
+    let transcriptPath = "";
+    let stderr = "";
+    const bridge = createCodexEventBridge({ homePath, pollIntervalMs: 60_000, nowMs: () => now,
+      runVersionCommand: async () => ({ stdout: `codex-cli ${CODEX_VERIFIED_VERSION}`, stderr: "" }),
+      isRuntimeAlive: async () => child?.exitCode === null && child?.signalCode === null });
+    const threads = createCodingAgentThreadStore({ homePath, providers: [{ providerId: "codex",
+      startThread: async ({ thread, principal, nextEventId, now: clock }) => {
+        const sessionId = `sess_${thread.id.slice(7)}`;
+        transcriptPath = codexProviderEventPath(homePath, sessionId);
+        await bridge.watch({ threadId: thread.id, principal, sessionId });
+        const config = Buffer.from(JSON.stringify({ prompt: "Read only", approvalPolicy: "never", sandbox: "read-only", writableRoots: [homePath],
+          ...(mode === "resume-identity-mismatch" ? { providerThreadId: "native_expected" } : {}),
+        })).toString("base64");
+        child = spawn(process.execPath, [join(process.cwd(), "packages/gateway/src/coding-agents/codex-app-server-runner.mjs"),
+          codexProviderEventPath(homePath, sessionId), process.version.slice(1), process.execPath,
+          join(process.cwd(), "tests/fixtures/codex-launch-failure.mjs"), config], {
+          cwd: homePath, stdio: ["ignore", "ignore", "pipe"], env: { ...process.env, MATRIX_TEST_LAUNCH_FAILURE: mode,
+            ...(mode === "spawn-eagain" ? { NODE_OPTIONS: `--import=${join(process.cwd(), "tests/fixtures/codex-spawn-eagain.mjs")}` } : {}) },
+        });
+        ended = once(child, "close");
+        child.stderr?.on("data", (chunk) => { stderr += chunk; });
+        return { events: [{ type: "thread.status", eventId: nextEventId(), threadId: thread.id,
+          occurredAt: clock().toISOString(), status: "running" }], resumeState: { conversationId: sessionId } };
+      },
+    }] });
+    bridge.attachThreadStore(threads);
+    const adapter = createCanonicalCodingChatProviderAdapter({ providerId: "codex", threads });
+    const events: CanonicalProviderRunEvent[] = [];
+    const abort = new AbortController();
+    const collecting = (async () => {
+      for await (const event of adapter.start({ owner: { type: "personal", ownerId: "owner" }, chatId: "chat_launch",
+        turnId: "cturn_launch", runId: "run_launch", prompt: "Read only", parts: [{ type: "text", text: "Read only" }],
+        selection: { instanceId: "codex_default", model: "model" }, interactionMode: "default", permissionMode: "supervised",
+        signal: abort.signal })) events.push(event);
+    })();
+    try {
+      for (let i = 0; !ended && i < 100; i++) await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(ended).toBeDefined();
+      await ended;
+      if (mode === "spawn-eagain") expect(stderr).toContain("Injected spawn EAGAIN");
+      if (mode === "resume-identity-mismatch") expect(await readFile(transcriptPath, "utf8")).not.toContain("native_failure_test");
+      now = 61_000;
+      await bridge.drain();
+      await collecting;
+      expect(events.filter((event) => event.type === "run.completed")).toEqual([
+        expect.objectContaining({ outcome: "failed" }),
+      ]);
+      if (mode === "mcp-early-exit" || mode === "mcp-runner-exit") {
+        expect(events.filter((event) => event.type === "tool.progress" || event.type === "agent.activity").map((event) => event.status), JSON.stringify({ events, stderr, transcript: await readFile(transcriptPath, "utf8") })).toEqual(["running", "failed"]);
+      }
+      await bridge.drain();
+      expect(events.filter((event) => event.type === "run.completed")).toHaveLength(1);
+    } finally {
+      abort.abort();
+      if (child?.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      await ended;
+      await collecting.catch(() => undefined);
+      await bridge.shutdown();
+      await threads.shutdownTurns();
+      await rm(homePath, { recursive: true, force: true });
+    }
+  }, 40_000);
+});

--- a/tests/gateway/codex-mcp-elicitation-limits.test.ts
+++ b/tests/gateway/codex-mcp-elicitation-limits.test.ts
@@ -1,0 +1,52 @@
+import { expect, it } from "vitest";
+import { createCodexMcpElicitations } from "../../packages/gateway/src/coding-agents/codex-mcp-elicitations.mjs";
+
+const request = (id: number) => ({ id, method: "mcpServer/elicitation/request", params: {
+  threadId: "thread", turnId: "turn", serverName: "integration", mode: "form",
+  message: "Allow operation?", requestedSchema: { type: "object", properties: {} },
+} });
+
+function harness() {
+  let time = 0;
+  const responses: unknown[] = [];
+  const events: { approvalId: string }[] = [];
+  const bridge = createCodexMcpElicitations({
+    send: (value: unknown) => responses.push(value),
+    persist: async (event: { approvalId: string }) => { events.push(event); },
+    safeText: (text: string) => text,
+    now: () => time,
+  });
+  return { bridge, responses, events, advance: () => { time += 300_001; } };
+}
+
+it("expires unanswered confirmation and fences a late approval", async () => {
+  const h = harness();
+  await h.bridge.handle(request(42), "thread");
+  h.advance();
+  expect(h.bridge.decide(h.events[0].approvalId, "approve")).toBe(false);
+  expect(h.responses).toEqual([{ id: 42, result: { action: "cancel", content: null } }]);
+  expect(h.bridge.size).toBe(0);
+});
+
+it("sweeps unattended confirmations once without extending their deadlines", async () => {
+  const h = harness();
+  await h.bridge.handle(request(42), "thread");
+  h.advance();
+  await h.bridge.handle(request(42), "thread");
+  h.bridge.sweep();
+  h.bridge.sweep();
+  expect(h.responses).toEqual([{ id: 42, result: { action: "cancel", content: null } }]);
+  expect(h.events).toHaveLength(1);
+});
+
+it("caps pending confirmations and drains only the outstanding requests", async () => {
+  const h = harness();
+  for (let id = 1; id <= 21; id++) await h.bridge.handle(request(id), "thread");
+  expect(h.bridge.size).toBe(20);
+  expect(h.events).toHaveLength(20);
+  expect(h.responses).toEqual([{ id: 21, result: { action: "cancel", content: null } }]);
+  h.bridge.drain();
+  h.bridge.drain();
+  expect(h.responses).toHaveLength(21);
+  expect(h.bridge.decide(h.events[0].approvalId, "approve")).toBe(false);
+});

--- a/tests/gateway/codex-mcp-elicitation-limits.test.ts
+++ b/tests/gateway/codex-mcp-elicitation-limits.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import { createCodexMcpElicitations } from "../../packages/gateway/src/coding-agents/codex-mcp-elicitations.mjs";
+import { parseCodexExecJsonLine } from "../../packages/gateway/src/coding-agents/codex-events.js";
 
 const request = (id: number) => ({ id, method: "mcpServer/elicitation/request", params: {
   threadId: "thread", turnId: "turn", serverName: "integration", mode: "form",
@@ -23,7 +24,7 @@ it("expires unanswered confirmation and fences a late approval", async () => {
   const h = harness();
   await h.bridge.handle(request(42), "thread");
   h.advance();
-  expect(h.bridge.decide(h.events[0].approvalId, "approve")).toBe(false);
+  expect(await h.bridge.decide(h.events[0].approvalId, "approve")).toBe(false);
   expect(h.responses).toEqual([{ id: 42, result: { action: "cancel", content: null } }]);
   expect(h.bridge.size).toBe(0);
 });
@@ -33,10 +34,15 @@ it("sweeps unattended confirmations once without extending their deadlines", asy
   await h.bridge.handle(request(42), "thread");
   h.advance();
   await h.bridge.handle(request(42), "thread");
-  h.bridge.sweep();
-  h.bridge.sweep();
+  await h.bridge.sweep();
+  await h.bridge.sweep();
   expect(h.responses).toEqual([{ id: 42, result: { action: "cancel", content: null } }]);
-  expect(h.events).toHaveLength(1);
+  expect(h.events).toHaveLength(2);
+  expect(parseCodexExecJsonLine(JSON.stringify(h.events[1]), {
+    threadId: "thread_test", now: () => new Date("2026-09-08T00:00:00Z"), nextEventId: () => "evt_test",
+  }).events).toEqual([expect.objectContaining({
+    type: "approval.resolved", approvalId: h.events[0].approvalId, decision: "cancel",
+  })]);
 });
 
 it("caps pending confirmations and drains only the outstanding requests", async () => {
@@ -45,8 +51,9 @@ it("caps pending confirmations and drains only the outstanding requests", async 
   expect(h.bridge.size).toBe(20);
   expect(h.events).toHaveLength(20);
   expect(h.responses).toEqual([{ id: 21, result: { action: "cancel", content: null } }]);
-  h.bridge.drain();
-  h.bridge.drain();
+  await h.bridge.drain();
+  await h.bridge.drain();
   expect(h.responses).toHaveLength(21);
-  expect(h.bridge.decide(h.events[0].approvalId, "approve")).toBe(false);
+  expect(h.events).toHaveLength(40);
+  expect(await h.bridge.decide(h.events[0].approvalId, "approve")).toBe(false);
 });

--- a/tests/gateway/codex-mcp-elicitation-limits.test.ts
+++ b/tests/gateway/codex-mcp-elicitation-limits.test.ts
@@ -57,3 +57,69 @@ it("caps pending confirmations and drains only the outstanding requests", async 
   expect(h.events).toHaveLength(40);
   expect(await h.bridge.decide(h.events[0].approvalId, "approve")).toBe(false);
 });
+
+it("waits for in-flight expiry persistence before terminal drain can complete", async () => {
+  let time = 0;
+  let release!: () => void;
+  const gate = new Promise<void>(resolve => { release = resolve; });
+  const events: { type: string; approvalId: string }[] = [];
+  const responses: unknown[] = [];
+  const bridge = createCodexMcpElicitations({
+    send: (value: unknown) => responses.push(value),
+    persist: async (event: { type: string; approvalId: string }) => {
+      if (event.type === "matrix.codex.approval.resolved") await gate;
+      events.push(event);
+    },
+    safeText: (text: string) => text,
+    now: () => time,
+  });
+  await bridge.handle(request(42), "thread");
+  time = 300_001;
+  const expiry = bridge.sweep();
+  let drained = false;
+  const drain = bridge.drain().then(() => { drained = true; });
+  try {
+    await new Promise(resolve => setImmediate(resolve));
+    expect(drained).toBe(false);
+    expect(await bridge.decide(events[0].approvalId, "approve")).toBe(false);
+    await bridge.handle(request(42), "thread");
+    expect(events).toHaveLength(1);
+    expect(responses).toEqual([]);
+  } finally {
+    release();
+    await Promise.all([expiry, drain]);
+  }
+  expect(drained).toBe(true);
+  expect(events.map(event => event.type)).toEqual([
+    "matrix.codex.approval.requested", "matrix.codex.approval.resolved",
+  ]);
+  expect(responses).toEqual([{ id: 42, result: { action: "cancel", content: null } }]);
+  expect(bridge.size).toBe(0);
+});
+
+it("does not report a successful drain when expiry persistence failed", async () => {
+  let time = 0;
+  let resolutionWrites = 0;
+  const failure = new Error("storage unavailable");
+  const responses: unknown[] = [];
+  const events: { approvalId: string }[] = [];
+  const bridge = createCodexMcpElicitations({
+    send: (value: unknown) => responses.push(value),
+    persist: async (event: { type: string; approvalId: string }) => {
+      if (event.type === "matrix.codex.approval.resolved") {
+        resolutionWrites++;
+        throw failure;
+      }
+      events.push(event);
+    },
+    safeText: (text: string) => text,
+    now: () => time,
+  });
+  await bridge.handle(request(42), "thread");
+  time = 300_001;
+  await expect(bridge.sweep()).rejects.toBe(failure);
+  await expect(bridge.drain()).rejects.toBe(failure);
+  expect(await bridge.decide(events[0].approvalId, "approve")).toBe(false);
+  expect(resolutionWrites).toBe(1);
+  expect(responses).toEqual([{ id: 42, result: { action: "cancel", content: null } }]);
+});

--- a/tests/gateway/codex-mcp-elicitation-runtime.test.ts
+++ b/tests/gateway/codex-mcp-elicitation-runtime.test.ts
@@ -131,6 +131,9 @@ it("cancels outstanding MCP confirmation on interruption and rejects a late deci
     await expect.poll(() => lines(runtime.responses)).toEqual([{ id: 42, result: { action: "cancel", content: null } }]);
     const approval = (await lines(runtime.events)).find(e => e.type === "matrix.codex.approval.requested");
     expect(await runtime.control({ type: "approval", approvalId: approval.approvalId, decision: "approve", clientRequestId: "req_late" })).toEqual({ ok: false });
+    const events = await lines(runtime.events);
+    expect(events.find(e => e.type === "matrix.codex.approval.resolved")).toMatchObject({ approvalId: approval.approvalId, decision: "cancel" });
+    expect(events.findIndex(e => e.type === "matrix.codex.approval.resolved")).toBeLessThan(events.findIndex(e => e.type === "turn.aborted"));
   } finally { await runtime.close(); }
 });
 

--- a/tests/gateway/codex-mcp-elicitation-runtime.test.ts
+++ b/tests/gateway/codex-mcp-elicitation-runtime.test.ts
@@ -1,0 +1,159 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createConnection } from "node:net";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+import { codexProviderEventPath } from "../../packages/gateway/src/coding-agents/codex-event-bridge.js";
+import { parseCodexExecJsonLine } from "../../packages/gateway/src/coding-agents/codex-events.js";
+
+const elicitation = {
+  id: 42, method: "mcpServer/elicitation/request",
+  params: {
+    threadId: "thread-mcp", turnId: "turn-mcp", serverName: "matrix-integrations",
+    mode: "form", message: "Allow this integration operation?",
+    requestedSchema: { type: "object", properties: {} },
+    _meta: { codex_approval_kind: "tool", tool_params: { token: "sk-never-display-this" } },
+  },
+};
+
+async function start(requests: unknown[], env: Record<string, string> = {}) {
+  const dir = await mkdtemp("/tmp/mx-mcp-");
+  const fake = join(dir, "provider.mjs");
+  const events = codexProviderEventPath(dir, "sess_mcp");
+  const responses = join(dir, "responses.jsonl");
+  await writeFile(fake, `
+    import {createInterface} from 'node:readline';
+    import {appendFile} from 'node:fs/promises';
+    let remaining=${requests.length};
+    for await(const line of createInterface({input:process.stdin})) {
+      const m=JSON.parse(line);
+      if(m.method==='initialize') console.log(JSON.stringify({id:m.id,result:{}}));
+      else if(m.method==='thread/start') console.log(JSON.stringify({id:m.id,result:{thread:{id:'thread-mcp'}}}));
+      else if(m.method==='turn/start') {
+        console.log(JSON.stringify({id:m.id,result:{turn:{id:'turn-mcp'}}}));
+        console.log(JSON.stringify({method:'item/started',params:{turnId:'turn-mcp',item:{id:'tool-1',type:'mcpToolCall',status:'inProgress'}}}));
+        for(const r of ${JSON.stringify(requests)}) console.log(JSON.stringify(r));
+      } else if(m.id!==undefined && !m.method) {
+        await appendFile(${JSON.stringify(responses)}, JSON.stringify(m)+'\\n');
+        if(--remaining===0) {
+          console.log(JSON.stringify({method:'item/completed',params:{turnId:'turn-mcp',item:{id:'tool-1',type:'mcpToolCall',status:'completed'}}}));
+          console.log(JSON.stringify({method:'turn/completed',params:{turn:{id:'turn-mcp',status:'completed'}}}));
+        }
+      }
+    }
+  `);
+  const config = Buffer.from(JSON.stringify({ prompt: "Check inventory", approvalPolicy: "on-request", sandbox: "workspace-write", writableRoots: [dir] })).toString("base64");
+  const child = spawn(process.execPath, [join(process.cwd(), "packages/gateway/src/coding-agents/codex-app-server-runner.mjs"), events, process.version.slice(1), process.execPath, fake, config], {
+    cwd: dir, env: { ...process.env, ...env }, stdio: ["pipe", "ignore", "pipe"],
+  });
+  child.stderr.resume();
+  return {
+    events, responses,
+    async control(payload: unknown) {
+      return new Promise<unknown>((resolve, reject) => {
+        const socket = createConnection(events.replace(/\.jsonl$/, ".sock"));
+        let data = "";
+        socket.setEncoding("utf8");
+        socket.setTimeout(2000, () => socket.destroy(new Error("control timeout")));
+        socket.once("connect", () => socket.end(JSON.stringify(payload) + "\n"));
+        socket.on("data", chunk => { data += chunk; });
+        socket.once("error", reject);
+        socket.once("close", () => { if (data) resolve(JSON.parse(data)); });
+      });
+    },
+    async close() {
+      const closed = new Promise(resolve => child.once("close", resolve));
+      child.kill("SIGTERM");
+      if (child.exitCode === null && child.signalCode === null) await closed;
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function lines(path: string): Promise<any[]> {
+  try { return (await readFile(path, "utf8")).trim().split("\n").filter(Boolean).map(line => JSON.parse(line)); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return []; throw error; }
+}
+
+it("surfaces native MCP confirmation and returns one correlated approval before continuing", async () => {
+  const runtime = await start([elicitation]);
+  try {
+    await expect.poll(async () => (await lines(runtime.events)).find(e => e.type === "matrix.codex.approval.requested"), { timeout: 2000 }).toBeDefined();
+    const approval = (await lines(runtime.events)).find(e => e.type === "matrix.codex.approval.requested");
+    expect(approval.allowedDecisions).toEqual(["approve", "decline", "cancel"]);
+    expect(parseCodexExecJsonLine(JSON.stringify(approval), {
+      threadId: "thread_mcp", now: () => new Date("2026-09-08T00:00:00.000Z"), nextEventId: () => "evt_mcp",
+    }).events.some(e => e.type === "approval.requested")).toBe(true);
+    expect(JSON.stringify(approval)).not.toContain("sk-never");
+    expect(await lines(runtime.responses)).toEqual([]);
+    const control = { type: "approval", approvalId: approval.approvalId, decision: "approve", clientRequestId: "req_mcp_1" };
+    expect(await runtime.control(control)).toEqual({ ok: true });
+    expect(await runtime.control(control)).toEqual({ ok: true, replayed: true });
+    await expect.poll(() => lines(runtime.responses)).toEqual([{ id: 42, result: { action: "accept", content: {} } }]);
+    await expect.poll(async () => (await lines(runtime.events)).some(e => e.type === "turn.completed")).toBe(true);
+  } finally { await runtime.close(); }
+});
+
+it("does not publish credentials embedded in an elicitation message", async () => {
+  const runtime = await start([{ ...elicitation, params: { ...elicitation.params, message: "authorization: private-value-123" } }]);
+  try {
+    await expect.poll(async () => (await lines(runtime.events)).find(e => e.type === "matrix.codex.approval.requested")).toBeDefined();
+    expect(await readFile(runtime.events, "utf8")).not.toContain("private-value-123");
+  } finally { await runtime.close(); }
+});
+
+it.each(["decline", "cancel"])("settles an MCP confirmation with %s without granting access", async decision => {
+  const runtime = await start([elicitation]);
+  try {
+    await expect.poll(async () => (await lines(runtime.events)).find(e => e.type === "matrix.codex.approval.requested")).toBeDefined();
+    const approval = (await lines(runtime.events)).find(e => e.type === "matrix.codex.approval.requested");
+    expect(await runtime.control({ type: "approval", approvalId: approval.approvalId, decision: "approve_for_session", clientRequestId: "req_bad_grant" })).toEqual({ ok: false });
+    expect(await runtime.control({ type: "approval", approvalId: approval.approvalId, decision, clientRequestId: "req_decline" })).toEqual({ ok: true });
+    await expect.poll(() => lines(runtime.responses)).toEqual([{ id: 42, result: { action: decision, content: null } }]);
+  } finally { await runtime.close(); }
+});
+
+it("does not charge an MCP approval wait against the tool deadline", async () => {
+  const runtime = await start([elicitation], { MATRIX_CODEX_TOOL_DEADLINE_MS: "150" });
+  try {
+    await expect.poll(async () => (await lines(runtime.events)).find(e => e.type === "matrix.codex.approval.requested")).toBeDefined();
+    const approval = (await lines(runtime.events)).find(e => e.type === "matrix.codex.approval.requested");
+    await new Promise(resolve => setTimeout(resolve, 300));
+    expect((await lines(runtime.events)).some(e => e.type === "turn.failed")).toBe(false);
+    expect(await runtime.control({ type: "approval", approvalId: approval.approvalId, decision: "approve", clientRequestId: "req_waited" })).toEqual({ ok: true });
+    await expect.poll(async () => (await lines(runtime.events)).some(e => e.type === "turn.completed")).toBe(true);
+  } finally { await runtime.close(); }
+});
+
+it("cancels outstanding MCP confirmation on interruption and rejects a late decision", async () => {
+  const runtime = await start([elicitation, { method: "turn/completed", params: { turn: { id: "turn-mcp", status: "interrupted" } } }]);
+  try {
+    await expect.poll(() => lines(runtime.responses)).toEqual([{ id: 42, result: { action: "cancel", content: null } }]);
+    const approval = (await lines(runtime.events)).find(e => e.type === "matrix.codex.approval.requested");
+    expect(await runtime.control({ type: "approval", approvalId: approval.approvalId, decision: "approve", clientRequestId: "req_late" })).toEqual({ ok: false });
+  } finally { await runtime.close(); }
+});
+
+it.each([
+  { ...elicitation.params, mode: "url", url: "https://example.com/authorize", elicitationId: "auth-1" },
+  { ...elicitation.params, requestedSchema: { type: "object", properties: { password: { type: "string" } }, required: ["password"] } },
+])("cancels unsupported MCP forms instead of granting empty consent or hanging", async params => {
+  const runtime = await start([{ ...elicitation, params }]);
+  try {
+    await expect.poll(() => lines(runtime.responses)).toEqual([{ id: 42, result: { action: "cancel", content: null } }]);
+    expect((await lines(runtime.events)).some(e => e.type === "matrix.codex.approval.requested")).toBe(false);
+  } finally { await runtime.close(); }
+});
+
+it.each([
+  [{ ...elicitation, params: { ...elicitation.params, turnId: "old-turn" } }, -32000],
+  [{ ...elicitation, params: { ...elicitation.params, threadId: "foreign-thread" } }, -32000],
+  [{ ...elicitation, method: "item/unknown/request" }, -32601],
+  [{ ...elicitation, params: { ...elicitation.params, message: null } }, -32601],
+] as const)("answers stale and unsupported server requests with a correlated error", async (request, code) => {
+  const runtime = await start([request]);
+  try {
+    await expect.poll(() => lines(runtime.responses)).toEqual([{ id: 42, error: { code, message: "This request is unavailable." } }]);
+    expect((await lines(runtime.events)).some(e => e.type === "matrix.codex.approval.requested")).toBe(false);
+  } finally { await runtime.close(); }
+});

--- a/tests/gateway/codex-mcp-expiry-ingestion.test.ts
+++ b/tests/gateway/codex-mcp-expiry-ingestion.test.ts
@@ -1,0 +1,59 @@
+import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+import { AgentThreadEventSchema, CODEX_VERIFIED_VERSION } from "../../packages/contracts/src/index.js";
+import { createCodexEventBridge } from "../../packages/gateway/src/coding-agents/codex-event-bridge.js";
+import { createCodingAgentThreadStore } from "../../packages/gateway/src/coding-agents/thread-store.js";
+
+it("ingests MCP expiry and completion without granting provider-authored approvals", async () => {
+  const homePath = await mkdtemp(join(tmpdir(), "matrix-mcp-expiry-"));
+  const principal = { userId: "owner_expiry", source: "jwt" as const };
+  const store = createCodingAgentThreadStore({ homePath, providers: [{
+    providerId: "codex",
+    startThread: () => ({ events: [], resumeState: { conversationId: "sess_expiry" } }),
+  }] });
+  const bridge = createCodexEventBridge({ homePath, pollIntervalMs: 60_000,
+    runVersionCommand: async () => ({ stdout: `codex-cli ${CODEX_VERIFIED_VERSION}`, stderr: "" }),
+  });
+  bridge.attachThreadStore(store);
+  try {
+    const created = await store.createThread(principal, {
+      providerId: "codex", prompt: "Check inventory once", mode: "default",
+      approvalPolicy: "on_request", sandboxMode: "workspace_write", clientRequestId: "req_expiry",
+    });
+    const threadId = created.snapshot.thread.id;
+    const { path } = await bridge.watch({ principal, threadId, sessionId: "sess_expiry" });
+    await writeFile(path, JSON.stringify({
+      type: "matrix.codex.approval.requested", approvalId: "appr_expiry",
+      correlationId: "corr_expiry", title: "Use integration", safeDescription: "Confirm this operation",
+      actionKind: "provider", risk: "high", allowedDecisions: ["approve", "decline", "cancel"],
+    }) + "\n");
+    await bridge.drain();
+    expect((await store.getThread(principal, threadId)).thread.status).toBe("waiting_for_approval");
+
+    for (const decision of ["approve", "approve_for_session", "decline"] as const) {
+      await expect(store.ingestProviderEvents(principal, threadId, { events: [AgentThreadEventSchema.parse({
+        type: "approval.resolved", eventId: `evt_${decision}`, threadId,
+        occurredAt: new Date().toISOString(), approvalId: "appr_expiry", decision,
+      })] })).rejects.toThrow("Provider emitted reserved lifecycle event");
+    }
+
+    await appendFile(path, [
+      JSON.stringify({ type: "matrix.codex.approval.resolved", approvalId: "appr_expiry", decision: "cancel" }),
+      JSON.stringify({ type: "turn.completed" }), "",
+    ].join("\n"));
+    await bridge.drain();
+    await bridge.drain();
+    const result = await store.getThread(principal, threadId);
+    expect(result.thread.status).toBe("completed");
+    expect(result.thread.attention).toBe("none");
+    expect(result.events.items.filter(event => event.type === "approval.resolved"))
+      .toEqual([expect.objectContaining({ approvalId: "appr_expiry", decision: "cancel" })]);
+    expect(result.events.items.at(-1)).toMatchObject({ type: "thread.completed", outcome: "completed" });
+  } finally {
+    await bridge.shutdown();
+    await store.shutdownTurns();
+    await rm(homePath, { recursive: true, force: true });
+  }
+});

--- a/tests/gateway/codex-runtime-supervision.test.ts
+++ b/tests/gateway/codex-runtime-supervision.test.ts
@@ -1,0 +1,144 @@
+import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createCodexEventBridge, codexProviderEventPath } from "../../packages/gateway/src/coding-agents/codex-event-bridge.js";
+import { CODEX_VERIFIED_VERSION } from "@matrix-os/contracts";
+
+describe("Codex runtime supervision", () => {
+  async function fixture(probe: () => Promise<boolean>) {
+    const homePath = await mkdtemp(join(tmpdir(), "codex-supervision-"));
+    let now = 0;
+    const ingestProviderEvents = vi.fn(async (..._args: unknown[]) => ({}));
+    const bridge = createCodexEventBridge({ homePath, nowMs: () => now, pollIntervalMs: 60_000,
+      runVersionCommand: async () => ({ stdout: `codex-cli ${CODEX_VERIFIED_VERSION}`, stderr: "" }),
+      isRuntimeAlive: probe,
+    });
+    bridge.attachThreadStore({ ingestProviderEvents });
+    const watch = (startAtEnd = false) => bridge.watch({ principal: { userId: "owner", source: "jwt" },
+      threadId: "thread_test", sessionId: "sess_test", startAtEnd });
+    await watch();
+    return { bridge, ingestProviderEvents, watch, path: codexProviderEventPath(homePath, "sess_test"),
+      tick: async (time: number) => { now = time; await bridge.drain(); },
+      close: async () => { await bridge.shutdown(); await rm(homePath, { recursive: true, force: true }); },
+    };
+  }
+
+  it.each(["not json\n", '{"type":']) ("does not let malformed or partial output hide startup failure: %s", async (bytes) => {
+    const f = await fixture(async () => true);
+    try {
+      await writeFile(f.path, bytes);
+      await f.tick(61_000);
+      expect(f.ingestProviderEvents).toHaveBeenCalledWith(expect.anything(), "thread_test", expect.objectContaining({
+        events: expect.arrayContaining([expect.objectContaining({ outcome: "failed" })]),
+      }));
+    } finally { await f.close(); }
+  });
+
+  it("allows startup grace, then long silent tool execution, but detects later runtime exit", async () => {
+    let alive = false;
+    const f = await fixture(async () => alive);
+    try {
+      await f.tick(10_000);
+      expect(f.ingestProviderEvents).not.toHaveBeenCalled();
+      alive = true;
+      await writeFile(f.path, '{"type":"turn.started"}\n');
+      await f.tick(20_000);
+      f.ingestProviderEvents.mockClear();
+      await f.tick(600_000);
+      expect(f.ingestProviderEvents).not.toHaveBeenCalled();
+      alive = false;
+      await appendFile(f.path, '{"type":');
+      await f.tick(610_000);
+      expect(f.ingestProviderEvents).toHaveBeenCalledWith(expect.anything(), "thread_test", expect.objectContaining({
+        events: expect.arrayContaining([expect.objectContaining({ outcome: "failed" })]),
+      }));
+    } finally { await f.close(); }
+  });
+
+  it("tolerates transient probe errors and persists terminal failure idempotently on repeated errors", async () => {
+    const f = await fixture(async () => { throw new Error("unavailable"); });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await f.tick(10_000);
+      await f.tick(20_000);
+      expect(f.ingestProviderEvents).not.toHaveBeenCalled();
+      f.ingestProviderEvents.mockRejectedValueOnce(new Error("temporary store outage"));
+      await f.tick(30_000);
+      await f.tick(31_000);
+      expect(f.ingestProviderEvents).toHaveBeenCalledTimes(2);
+      expect(f.ingestProviderEvents.mock.calls[0]).toEqual(f.ingestProviderEvents.mock.calls[1]);
+      expect(f.bridge.watcherCount()).toBe(0);
+    } finally { await f.close(); warn.mockRestore(); }
+  });
+
+  it("fences a stale liveness probe after the watcher is replaced for a new turn", async () => {
+    let resolveProbe!: (alive: boolean) => void;
+    let entered!: () => void;
+    const started = new Promise<void>((resolve) => { entered = resolve; });
+    const f = await fixture(() => { entered(); return new Promise<boolean>((resolve) => { resolveProbe = resolve; }); });
+    try {
+      const draining = f.tick(61_000);
+      await started;
+      await f.watch(true);
+      resolveProbe(false);
+      await draining;
+      expect(f.ingestProviderEvents).not.toHaveBeenCalled();
+      expect(f.bridge.watcherCount()).toBe(1);
+      f.bridge.unwatch("sess_test");
+    } finally { await f.close(); }
+  });
+
+  it("retains undrained provider bytes when renewing an existing watcher", async () => {
+    const f = await fixture(async () => true);
+    try {
+      await writeFile(f.path, '{"type":"item.completed","item":{"id":"msg_1","type":"agent_message","text":"Still deliver this"}}\n');
+      await f.watch(true);
+      await f.tick(1_000);
+      expect(f.ingestProviderEvents).toHaveBeenCalledWith(expect.anything(), "thread_test", expect.objectContaining({
+        events: expect.arrayContaining([expect.objectContaining({ type: "assistant.text.delta", delta: "Still deliver this" })]),
+      }));
+    } finally { await f.close(); }
+  });
+
+  it.each(["dead", "never-ready"])("finishes %s runtime without waiting for provider bytes", async (mode) => {
+    const homePath = await mkdtemp(join(tmpdir(), "codex-supervision-"));
+    let now = 0;
+    const ingestProviderEvents = vi.fn(async () => ({}));
+    const bridge = createCodexEventBridge({ homePath, nowMs: () => now, pollIntervalMs: 60_000,
+      runVersionCommand: async () => ({ stdout: `codex-cli ${CODEX_VERIFIED_VERSION}`, stderr: "" }),
+      isRuntimeAlive: async () => mode !== "dead",
+    });
+    bridge.attachThreadStore({ ingestProviderEvents });
+    try {
+      await bridge.watch({ principal: { userId: "owner", source: "jwt" }, threadId: "thread_test", sessionId: "sess_test" });
+      now = 61_000;
+      await bridge.drain();
+      expect(ingestProviderEvents).toHaveBeenCalledWith(expect.anything(), "thread_test", expect.objectContaining({
+        events: expect.arrayContaining([expect.objectContaining({ type: "thread.completed", outcome: "failed" })]),
+      }));
+      await bridge.drain();
+      expect(ingestProviderEvents).toHaveBeenCalledTimes(1);
+    } finally { await bridge.shutdown(); await rm(homePath, { recursive: true, force: true }); }
+  });
+
+  it("drains successful completion before declaring a dead runtime failed", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "codex-supervision-"));
+    let now = 0;
+    const ingestProviderEvents = vi.fn(async () => ({}));
+    const bridge = createCodexEventBridge({ homePath, nowMs: () => now, pollIntervalMs: 60_000,
+      runVersionCommand: async () => ({ stdout: `codex-cli ${CODEX_VERIFIED_VERSION}`, stderr: "" }),
+      isRuntimeAlive: async () => false,
+    });
+    bridge.attachThreadStore({ ingestProviderEvents });
+    try {
+      await bridge.watch({ principal: { userId: "owner", source: "jwt" }, threadId: "thread_test", sessionId: "sess_test" });
+      await writeFile(codexProviderEventPath(homePath, "sess_test"), '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n');
+      now = 61_000;
+      await bridge.drain();
+      const events = ingestProviderEvents.mock.calls.flatMap((call) => (call as unknown as [unknown, unknown, {events: Array<{outcome?: string}>}])[2].events);
+      expect(events.some((event) => event.outcome === "completed")).toBe(true);
+      expect(events.some((event) => event.outcome === "failed")).toBe(false);
+    } finally { await bridge.shutdown(); await rm(homePath, { recursive: true, force: true }); }
+  });
+});

--- a/tests/gateway/coding-agents-codex-app-server-contract.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-contract.test.ts
@@ -66,6 +66,7 @@ describe("Codex app-server contract", () => {
         "item/fileChange/requestApproval",
         "item/tool/requestUserInput",
         "item/permissions/requestApproval",
+        "mcpServer/elicitation/request",
       ],
       requiredServerNotifications: [
         "item/started",
@@ -85,6 +86,7 @@ describe("Codex app-server contract", () => {
         "item/fileChange/requestApproval": expect.stringMatching(/^[a-f0-9]{64}$/),
         "item/tool/requestUserInput": expect.stringMatching(/^[a-f0-9]{64}$/),
         "item/permissions/requestApproval": expect.stringMatching(/^[a-f0-9]{64}$/),
+        "mcpServer/elicitation/request": expect.stringMatching(/^[a-f0-9]{64}$/),
         "item/started": expect.stringMatching(/^[a-f0-9]{64}$/),
         "item/completed": expect.stringMatching(/^[a-f0-9]{64}$/),
         "item/agentMessage/delta": expect.stringMatching(/^[a-f0-9]{64}$/),

--- a/tests/gateway/coding-agents-codex-app-server-reliability.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-reliability.test.ts
@@ -388,7 +388,7 @@ describe("Codex app-server runner reliability", () => {
       expect(events.filter((event) => event.type === "tool.completed")).toEqual([
         expect.objectContaining({
           toolCallId: toolStarted && "toolCallId" in toolStarted ? toolStarted.toolCallId : undefined,
-          outcome: "cancelled",
+          outcome: "failed",
         }),
       ]);
       expect(outcomes).toEqual(["failed"]);
@@ -467,7 +467,7 @@ describe("Codex app-server runner reliability", () => {
       const completed = events.filter((event) => event.type === "tool.completed");
       expect(startedIds).toHaveLength(1);
       expect(completed).toEqual([
-        expect.objectContaining({ toolCallId: startedIds[0], outcome: "cancelled" }),
+        expect.objectContaining({ toolCallId: startedIds[0], outcome: "failed" }),
       ]);
       expect(outcomes).toEqual(["failed"]);
       expect(exitCode).toBe(1);
@@ -512,7 +512,7 @@ describe("Codex app-server runner reliability", () => {
 
     try {
       const transcript = await waitForTranscript(runtime.eventPath, /approval\.requested/);
-      const approval = transcript.trim().split("\n").map((line) => JSON.parse(line))[0];
+      const approval = transcript.trim().split("\n").map((line) => JSON.parse(line)).find((item) => item.type === "matrix.codex.approval.requested");
       expect(approval.allowedDecisions).toEqual(["decline"]);
       await expect(sendControl(runtime.controlPath, {
         type: "approval",
@@ -541,7 +541,7 @@ describe("Codex app-server runner reliability", () => {
 
     try {
       const transcript = await waitForTranscript(runtime.eventPath, /approval\.requested/);
-      const approval = transcript.trim().split("\n").map((line) => JSON.parse(line))[0];
+      const approval = transcript.trim().split("\n").map((line) => JSON.parse(line)).find((item) => item.type === "matrix.codex.approval.requested");
       expect(approval.allowedDecisions).toEqual(["decline", "cancel"]);
       await expect(sendControl(runtime.controlPath, {
         type: "approval",

--- a/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
@@ -6,6 +6,11 @@ import { describe, expect, it } from "vitest";
 import { codexProviderEventPath } from "../../packages/gateway/src/coding-agents/codex-event-bridge.js";
 import { parseCodexExecJsonLine } from "../../packages/gateway/src/coding-agents/codex-events.js";
 
+// Native resume identity is owner-only bridge metadata, never a rendered event.
+function visibleTranscript(transcript: string): string {
+  return transcript.trim().split("\n").filter((line) => JSON.parse(line).type !== "thread.started").join("\n");
+}
+
 async function waitForTranscript(path: string, pattern: RegExp): Promise<string> {
   const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
@@ -221,7 +226,7 @@ describe("Codex app-server control runtime", () => {
       const approval = beforeDecision.trim().split("\n").map((line) => JSON.parse(line))
         .find((event) => event.type === "matrix.codex.approval.requested");
       expect(approval.approvalId).toMatch(/^appr_codex_[a-f0-9]{32}$/);
-      expect(beforeDecision).not.toMatch(/auth\.json|private\/project|private\.internal|native-|"42"|:42/);
+      expect(visibleTranscript(beforeDecision)).not.toMatch(/auth\.json|private\/project|private\.internal|native-|"42"|:42/);
 
       const control = {
         type: "approval",
@@ -255,7 +260,7 @@ describe("Codex app-server control runtime", () => {
       const transcript = await readFile(eventPath, "utf8");
       expect(transcript).toContain('"type":"matrix.codex.assistant.delta"');
       expect(transcript).toContain('"type":"turn.completed"');
-      expect(transcript).not.toMatch(/auth\.json|private\/project|native-/);
+      expect(visibleTranscript(transcript)).not.toMatch(/auth\.json|private\/project|native-/);
     } finally {
       child.kill("SIGTERM");
       await rm(homePath, { recursive: true, force: true });
@@ -319,7 +324,7 @@ describe("Codex app-server control runtime", () => {
         question: "The coding agent needs an answer.",
         options: [{ label: "Minimal", description: "Choose this option." }],
       });
-      expect(beforeAnswer).not.toMatch(/native-|rpc-input-secret|private\/project|private-question/);
+      expect(visibleTranscript(beforeAnswer)).not.toMatch(/native-|rpc-input-secret|private\/project|private-question/);
 
       const [approach, secret] = request.questions;
       await expect(sendControl(controlPath, {
@@ -345,7 +350,7 @@ describe("Codex app-server control runtime", () => {
       });
       const transcript = await readFile(eventPath, "utf8");
       expect(transcript).not.toContain("temporary-secret-value");
-      expect(transcript).not.toMatch(/native-|rpc-input-secret|private\/project/);
+      expect(visibleTranscript(transcript)).not.toMatch(/native-|rpc-input-secret|private\/project/);
     } finally {
       child.kill("SIGTERM");
       await rm(homePath, { recursive: true, force: true });
@@ -406,7 +411,7 @@ describe("Codex app-server control runtime", () => {
       const transcript = (await readFile(eventPath, "utf8")).trim().split("\n");
       expect(transcript.filter((line) => JSON.parse(line).type === "matrix.codex.approval.requested"))
         .toHaveLength(20);
-      expect(transcript.join("\n")).not.toContain("native-");
+      expect(visibleTranscript(transcript.join("\n"))).not.toContain("native-");
     } finally {
       child.kill("SIGTERM");
       await rm(homePath, { recursive: true, force: true });
@@ -467,7 +472,7 @@ describe("Codex app-server control runtime", () => {
     ], { cwd: homePath, stdio: ["ignore", "pipe", "pipe"] });
     try {
       const transcript = await waitForTranscript(eventPath, /"type":"turn.completed"/);
-      expect(transcript).not.toMatch(/native-|auth\.json|private\/project|secret-token-output|secret-mcp-token|private result/);
+      expect(visibleTranscript(transcript)).not.toMatch(/native-|auth\.json|private\/project|secret-token-output|secret-mcp-token|private result/);
 
       let sequence = 0;
       const parsedTranscript = transcript.trim().split("\n").map((line) => parseCodexExecJsonLine(line, {

--- a/tests/gateway/coding-agents-codex-control-client.test.ts
+++ b/tests/gateway/coding-agents-codex-control-client.test.ts
@@ -48,6 +48,21 @@ async function listen(homePath: string, sessionId: string, reply?: string, reply
 }
 
 describe("Codex control client", () => {
+  it("distinguishes a request that was never sent from an ambiguous lost acknowledgement", async () => {
+    const absentHome = await mkdtemp(join(socketTempRoot, "mx-unsent-"));
+    cleanup.push(() => rm(absentHome, { recursive: true, force: true }));
+    const input = { sessionId: "sess_delivery", turnId: "turn_delivery", prompt: "Read only", modelOptions: [] };
+    await expect(createCodexControlClient({ homePath: absentHome }).submitTurn(input)).rejects.toMatchObject({
+      name: "CodexControlUnavailableError",
+    });
+    const stalledHome = await mkdtemp(join(socketTempRoot, "mx-ack-"));
+    const received = await listen(stalledHome, input.sessionId);
+    await expect(createCodexControlClient({ homePath: stalledHome, timeoutMs: 25 }).submitTurn(input)).rejects.toMatchObject({
+      name: "CodexControlTransportError",
+    });
+    expect(received).toHaveLength(1);
+  });
+
   it("allows a loaded Codex app-server more than ten seconds to acknowledge steer", async () => {
     const homePath = await mkdtemp(join(socketTempRoot, "mx-control-delayed-steer-"));
     const sessionId = "sess_delayed_steer";

--- a/tests/gateway/coding-agents-delivered-steering.test.ts
+++ b/tests/gateway/coding-agents-delivered-steering.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTurnHarness, ownerPrincipal, otherPrincipal, turnNow } from "./coding-agent-turn-harness.js";
+
+describe("steering a delivered background provider turn", () => {
+  it("retains the exact steering target after dispatch settles and fences older turns", async () => {
+    const steerTurn = vi.fn(async () => undefined);
+    const harness = await createTurnHarness({
+      provider: {
+        providerId: "codex",
+        startThread: ({ thread, nextEventId }) => ({
+          events: [{ type: "thread.completed", eventId: nextEventId(), threadId: thread.id,
+            occurredAt: turnNow.toISOString(), outcome: "completed" }],
+          resumeState: { conversationId: "conversation_delivered" },
+        }),
+        resumeTurn: ({ resumeState }) => ({ events: [], outcome: "delivered", resumeState }),
+        steerTurn,
+      },
+    });
+    try {
+      const accept = async (clientRequestId: string) => {
+        const turn = await harness.threads.acceptTurn(ownerPrincipal, harness.threadId, {
+          message: "Run a long read-only task", clientRequestId,
+        });
+        await vi.waitFor(async () => {
+          const snapshot = await harness.threads.getThread(ownerPrincipal, harness.threadId);
+          expect(snapshot.events.items).toContainEqual(expect.objectContaining({
+            type: "turn.status", turnId: turn.turnId, status: "completed",
+          }));
+          expect(snapshot.thread.status).toBe("running");
+        });
+        return turn;
+      };
+      const first = await accept("req_delivered_first");
+      const steer = (turnId: string) => ({ expectedTurnId: turnId, message: "Continue with checkpoints", clientRequestId: "req_delivered_steer" });
+      await expect(harness.threads.steerTurn(ownerPrincipal, harness.threadId, steer(first.turnId))).resolves.toBeUndefined();
+      expect(steerTurn).toHaveBeenCalledOnce();
+      await expect(harness.threads.steerTurn(otherPrincipal, harness.threadId, steer(first.turnId))).rejects.toThrow("thread_not_found");
+      await harness.threads.ingestProviderEvents(ownerPrincipal, harness.threadId, {
+        events: [{ type: "thread.completed", eventId: "evt_delivered_done", threadId: harness.threadId,
+          occurredAt: turnNow.toISOString(), outcome: "completed" }],
+      });
+      await expect(harness.threads.steerTurn(ownerPrincipal, harness.threadId, steer(first.turnId))).rejects.toThrow("thread_busy");
+      const second = await accept("req_delivered_second");
+      await expect(harness.threads.steerTurn(ownerPrincipal, harness.threadId, steer(first.turnId))).rejects.toThrow("thread_busy");
+      await expect(harness.threads.steerTurn(ownerPrincipal, harness.threadId, steer(second.turnId))).resolves.toBeUndefined();
+      expect(steerTurn).toHaveBeenCalledTimes(2);
+      expect(JSON.stringify(await harness.threads.getThread(ownerPrincipal, harness.threadId))).not.toContain("deliveredTurnId");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -720,6 +720,7 @@ exec /bin/sh "$@"
       runtime: {
         startSession,
         stopSession: vi.fn(),
+        getSession: vi.fn(async () => ({ ok: true as const, session: workspaceSession({ id: "sess_workspace_dead_1" }) })),
       },
       codexEvents: {
         healthCheck: vi.fn(async () => ({ ok: true })),
@@ -764,6 +765,10 @@ exec /bin/sh "$@"
       nextEventId: () => "evt_workspace_recovered_1",
     } as never)).resolves.toMatchObject({
       outcome: "delivered",
+      events: [expect.objectContaining({
+        type: "terminal.bound",
+        terminalSessionCreatedAt: workspaceSession().runtime.createdAt,
+      })],
       resumeState: {
         conversationId: "sess_workspace_dead_1",
         providerThreadId: "native_thread_dead_1",
@@ -779,6 +784,7 @@ exec /bin/sh "$@"
         agent: "codex",
         prompt: "Continue after cancellation.",
         projectSlug: "repo-main",
+        worktreeId: "wt_abc123def456",
         model: "gpt-5.6-sol",
         modelOptions: [{ id: "effort", value: "high" }],
         approvalPolicy: "never",
@@ -791,6 +797,36 @@ exec /bin/sh "$@"
       { errorName: "CodexControlUnavailableError" },
     );
     expect(JSON.stringify(warn.mock.calls)).not.toContain("private socket path");
+  });
+
+  it.each(["missing-native", "missing-session", "foreign-owner", "lookup-error", "launch-error", "ambiguous-ack"])("fails cold recovery closed and releases ingestion on %s", async (mode) => {
+    const unwatch = vi.fn();
+    const startSession = vi.fn(async () => { throw new Error("launch failed"); });
+    const provider = createWorkspaceCodingAgentProvider({
+      providerId: "codex", agent: "codex",
+      runtime: { startSession, stopSession: vi.fn(), getSession: async () => {
+        if (mode === "lookup-error") throw new Error("lookup failed");
+        return mode === "missing-session" ? { ok: false } : { ok: true, session: workspaceSession({
+          id: "sess_cold", ...(mode === "foreign-owner" ? { ownerId: "someone-else" } : {}),
+        }) };
+      } } as never,
+      codexEvents: { watch: async () => ({ path: "/tmp/events" }), unwatch, markStopped: vi.fn(), healthCheck: async () => ({ ok: true }) },
+      codexControl: { submitTurn: async () => { throw Object.assign(new Error("offline"), {
+        name: mode === "ambiguous-ack" ? "CodexControlTransportError" : "CodexControlUnavailableError",
+      }); } } as never,
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await expect(provider.resumeTurn!({
+        principal: ownerPrincipal,
+        thread: { id: "thread_cold", projectId: "repo-main" },
+        turn: { turnId: "turn_cold", message: "continue" },
+        resumeState: { conversationId: "sess_cold", ...(mode === "missing-native" ? {} : { providerThreadId: "native_cold" }) },
+        signal: AbortSignal.timeout(1_000), now: () => baseNow, nextEventId: () => "evt_cold",
+      } as never)).rejects.toThrow();
+      expect(unwatch).toHaveBeenCalledWith("sess_cold");
+      expect(startSession).toHaveBeenCalledTimes(mode === "launch-error" ? 1 : 0);
+    } finally { warn.mockRestore(); }
   });
 
   it("restores Codex event ingestion before resuming a persisted workspace thread", async () => {

--- a/tests/gateway/coding-agents-workspace-provider.test.ts
+++ b/tests/gateway/coding-agents-workspace-provider.test.ts
@@ -772,6 +772,7 @@ exec /bin/sh "$@"
 
     expect(startSession).toHaveBeenCalledWith({
       ownerScope: { type: "user", id: "owner_user" },
+      recoveryThreadId: "thread_workspace_dead_1",
       request: expect.objectContaining({
         sessionId: "sess_workspace_dead_1",
         providerThreadId: "native_thread_dead_1",

--- a/tests/gateway/coding-idle-workspace.test.ts
+++ b/tests/gateway/coding-idle-workspace.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import { createCodingAgentThreadStore, type CodingAgentProviderAdapter } from "../../packages/gateway/src/coding-agents/thread-store.js";
+
+const owner = { userId: "owner", source: "jwt" as const };
+const timestamp = "2026-09-08T00:00:00.000Z";
+describe("managed idle Chat ownership", () => {
+  it("holds new turn admission behind the idle boundary and retains native history across reload", async () => {
+    const homePath = await mkdtemp("/tmp/chat-idle-race-");
+    const provider: CodingAgentProviderAdapter = { providerId: "codex", startThread: ({ thread, nextEventId }) => ({
+      events: [{ type: "thread.status", eventId: nextEventId(), threadId: thread.id, occurredAt: timestamp, status: "completed" }],
+      resumeState: { conversationId: `sess_${thread.id.slice(7)}`, providerThreadId: "native_history" },
+    }), resumeTurn: async ({ resumeState }) => ({ events: [], resumeState, outcome: "delivered" }) };
+    const options = { homePath, providers: [provider], now: () => new Date(timestamp) };
+    const store = createCodingAgentThreadStore(options);
+    const barrier = Promise.withResolvers<void>();
+    const entered = Promise.withResolvers<void>();
+    try {
+      const { snapshot } = await store.createThread(owner, { providerId: "codex", prompt: "Task", mode: "default", approvalPolicy: "never", sandboxMode: "read_only", clientRequestId: "req_create" });
+      const sessionId = `sess_${snapshot.thread.id.slice(7)}`;
+      const reloaded = createCodingAgentThreadStore(options);
+      await expect(reloaded.withIdleWorkspace(sessionId, Date.parse(timestamp) + 1, async (identity) => {
+        expect(identity.providerThreadId).toBe("native_history"); return true;
+      })).resolves.toBe(true);
+      await reloaded.shutdownTurns();
+      const idle = store.withIdleWorkspace(sessionId, Date.parse(timestamp) + 1, async () => {
+        entered.resolve(); await barrier.promise; return true;
+      });
+      await entered.promise;
+      let accepted = false;
+      const next = store.acceptTurn(owner, snapshot.thread.id, { message: "Continue", clientRequestId: "req_next" }).then((result) => { accepted = true; return result; });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(accepted).toBe(false);
+      barrier.resolve();
+      await expect(idle).resolves.toBe(true);
+      await expect(next).resolves.toMatchObject({ status: "accepted" });
+      await expect(store.withIdleWorkspace(sessionId, Date.parse(timestamp) + 1, async () => true)).resolves.toBe(false);
+    } finally { barrier.resolve(); await store.shutdownTurns(); await rm(homePath, { recursive: true, force: true }); }
+  });
+
+  it.each(["completed", "running", "waiting_for_approval", "waiting_for_input", "missing-native-id"])("admits only proven recoverable idle work (%s)", async (mode) => {
+    const homePath = await mkdtemp("/tmp/chat-idle-state-");
+    const provider: CodingAgentProviderAdapter = { providerId: "codex", startThread: ({ thread, nextEventId }) => ({
+      events: [{ type: "thread.status", eventId: nextEventId(), threadId: thread.id, occurredAt: timestamp,
+        status: mode === "missing-native-id" ? "completed" : mode } as never],
+      resumeState: { conversationId: `sess_${thread.id.slice(7)}`, ...(mode === "missing-native-id" ? {} : { providerThreadId: "native_history" }) },
+    }) };
+    const store = createCodingAgentThreadStore({ homePath, providers: [provider], now: () => new Date(timestamp) });
+    try {
+      const { snapshot } = await store.createThread(owner, { providerId: "codex", prompt: "Task", mode: "default", approvalPolicy: "never", sandboxMode: "read_only", clientRequestId: "req_test" });
+      const sessionId = `sess_${snapshot.thread.id.slice(7)}`;
+      const action = vi.fn(async () => true);
+      const cutoff = Date.parse(timestamp) + 1;
+      expect(await store.withIdleWorkspace(sessionId, cutoff, action)).toBe(mode === "completed");
+      expect(action.mock.calls.length).toBe(mode === "completed" ? 1 : 0);
+      expect(await store.withIdleWorkspace("sess_unowned", cutoff, action)).toBe(false);
+      expect(await store.withIdleWorkspace(sessionId, Date.parse(timestamp) - 1, action)).toBe(false);
+    } finally { await store.shutdownTurns(); await rm(homePath, { recursive: true, force: true }); }
+  });
+});

--- a/tests/gateway/terminal-readiness-signal.test.ts
+++ b/tests/gateway/terminal-readiness-signal.test.ts
@@ -1,0 +1,92 @@
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { createUserSystemdTerminalRuntime } from "../../packages/gateway/src/shell/user-systemd-terminal-runtime.js";
+
+const runtimeId = `rt_${"a".repeat(32)}`;
+const generation = `gen_${"b".repeat(64)}`;
+const invocationId = "c".repeat(32);
+const paths: string[] = [];
+afterEach(async () => { await Promise.all(paths.splice(0).map(path => rm(path, { recursive: true, force: true }))); });
+
+it.each([0, 1])("publishes readiness only after a successful background launch (exit %i)", async (exitCode) => {
+  const homePath = await mkdtemp(join(tmpdir(), "matrix-keeper-ready-"));
+  paths.push(homePath);
+  const terminalRuntimeRoot = join(homePath, "installed");
+  const generationPath = join(terminalRuntimeRoot, "generations", generation);
+  await mkdir(generationPath, { recursive: true });
+  const keeperPath = join(generationPath, "matrix-terminal-user-keeper.mjs");
+  await writeFile(keeperPath, await readFile("distro/customer-vps/host-bin/matrix-terminal-user-keeper.mjs"));
+  await writeFile(join(generationPath, "zellij"), "fixture binary\n");
+  await chmod(join(generationPath, "zellij"), 0o755);
+  const layoutPath = join(homePath, "layout.kdl");
+  await writeFile(layoutPath, "layout { pane }\n");
+  const preloadPath = join(homePath, "external-command-fixture.mjs");
+  await writeFile(preloadPath, `
+    import cp from 'node:child_process';
+    import {EventEmitter} from 'node:events';
+    import {syncBuiltinESMExports} from 'node:module';
+    cp.spawn = (command, args) => {
+      if(command !== '/usr/bin/script') throw new Error('Unexpected external command');
+      const child = new EventEmitter(); child.exitCode = null; child.signalCode = null;
+      child.kill = () => true;
+      if(args[1].includes('--create-background')) queueMicrotask(() => {child.exitCode=${exitCode};child.emit('exit',${exitCode},null);});
+      return child;
+    };
+    syncBuiltinESMExports();
+  `);
+  const runtime = createUserSystemdTerminalRuntime({ homePath, uid: 1001, generation, terminalRuntimeRoot,
+    readinessTimeoutMs: 50, readinessStabilityMs: 0, capacityAdmission: async () => undefined,
+    runCommand: async (command, args) => {
+      if (command !== "systemctl") throw new Error("Unexpected IPC probe");
+      if (args.includes("start")) await promisify(execFile)(process.execPath, ["--import", preloadPath, keeperPath, runtimeId],
+        { timeout: 3_000, env: { ...process.env, MATRIX_HOME: homePath, MATRIX_TERMINAL_RUNTIME_ROOT: terminalRuntimeRoot, INVOCATION_ID: invocationId } });
+      return { stdout: `ActiveState=active\nInvocationID=${invocationId}\n`, stderr: "" };
+    },
+  });
+  const result = runtime.create({ runtimeId, scope: "workspace", kind: "agent", displayName: "Chat", cwd: homePath, layoutPath });
+  if (exitCode === 0) await expect(result).resolves.toMatchObject({ lifecycle: "running" });
+  else await expect(result).rejects.toThrow("Terminal runtime unavailable");
+});
+
+it.each(["old invocation", "old generation", "old descriptor", "partial write", "oversized", "missing"])(
+  "waits for a current keeper signal without probing Zellij (%s)", async (initialSignal) => {
+  const homePath = await mkdtemp(join(tmpdir(), "matrix-ready-"));
+  paths.push(homePath);
+  const terminalRuntimeRoot = join(homePath, "installed");
+  const generationPath = join(terminalRuntimeRoot, "generations", generation);
+  await mkdir(generationPath, { recursive: true });
+  await writeFile(join(generationPath, "matrix-terminal-user-keeper.mjs"),
+    "// matrix-terminal-readiness: invocation-v1\n");
+  const layoutPath = join(homePath, "layout.kdl");
+  await writeFile(layoutPath, "layout { pane }\n");
+  let showCount = 0;
+  const runtime = createUserSystemdTerminalRuntime({ homePath, uid: 1001, generation, terminalRuntimeRoot,
+    readinessTimeoutMs: 1_000, readinessStabilityMs: 0, capacityAdmission: async () => undefined,
+    runCommand: async (command, args) => {
+      if (command !== "systemctl") throw new Error("readiness probe crashed uninitialized Zellij");
+      if (args.includes("show")) {
+        showCount += 1;
+        const descriptor = JSON.parse(await readFile(join(homePath, "system/terminal-runtimes", `${runtimeId}.json`), "utf8"));
+        const first = showCount === 1;
+        const signal = JSON.stringify({ version: 1,
+          generation: first && initialSignal === "old generation" ? `gen_${"e".repeat(64)}` : generation,
+          createdAt: first && initialSignal === "old descriptor" ? "2020-01-01T00:00:00.000Z" : descriptor.createdAt,
+          invocationId: first && initialSignal === "old invocation" ? "d".repeat(32) : invocationId,
+        });
+        if (!first || initialSignal !== "missing") {
+          await writeFile(join(homePath, "system/terminal-runtimes", `${runtimeId}.ready.json`),
+            first && initialSignal === "partial write" ? "{" : signal + (first && initialSignal === "oversized" ? " ".repeat(2_000) : ""));
+        }
+        return { stdout: `ActiveState=active\nInvocationID=${invocationId}\n`, stderr: "" };
+      }
+      return { stdout: "active\n", stderr: "" };
+    },
+  });
+  await expect(runtime.create({ runtimeId, scope: "workspace", kind: "agent", displayName: "Chat", cwd: homePath, layoutPath }))
+    .resolves.toMatchObject({ lifecycle: "running" });
+  expect(showCount).toBeGreaterThanOrEqual(2);
+});

--- a/tests/gateway/terminal-runtime-capacity.test.ts
+++ b/tests/gateway/terminal-runtime-capacity.test.ts
@@ -2,9 +2,19 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { createTerminalCapacityAdmission } from "../../packages/gateway/src/shell/terminal-runtime-capacity.js";
+import { createTerminalCapacityAdmission, terminalTasksUnderPressure } from "../../packages/gateway/src/shell/terminal-runtime-capacity.js";
 
 describe("terminal runtime capacity admission", () => {
+  it("uses aggregate task pressure rather than process age to shorten the idle grace", async () => {
+    const root = await mkdtemp(join(tmpdir(), "terminal-pressure-"));
+    try {
+      await writeFile(join(root, "pids.max"), "4096");
+      await writeFile(join(root, "pids.current"), "3837");
+      expect(await terminalTasksUnderPressure(root)).toBe(true);
+      await writeFile(join(root, "pids.current"), "1071");
+      expect(await terminalTasksUnderPressure(root)).toBe(false);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
   it("preserves existing active units at capacity and supports the first aggregate launch", async () => {
     const root = await mkdtemp(join(tmpdir(), "terminal-capacity-"));
     const admission = createTerminalCapacityAdmission({ root });

--- a/tests/gateway/terminal-runtime-capacity.test.ts
+++ b/tests/gateway/terminal-runtime-capacity.test.ts
@@ -1,0 +1,48 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createTerminalCapacityAdmission } from "../../packages/gateway/src/shell/terminal-runtime-capacity.js";
+
+describe("terminal runtime capacity admission", () => {
+  it("preserves existing active units at capacity and supports the first aggregate launch", async () => {
+    const root = await mkdtemp(join(tmpdir(), "terminal-capacity-"));
+    const admission = createTerminalCapacityAdmission({ root });
+    try {
+      await expect(admission("rt_first")).resolves.toBeUndefined();
+      await writeFile(join(root, "pids.max"), "4096\n");
+      await writeFile(join(root, "pids.current"), "4096\n");
+      const unit = join(root, "matrix-zellij@rt_existing.service");
+      await mkdir(unit);
+      await writeFile(join(unit, "pids.current"), "81\n");
+      await expect(admission("rt_existing")).resolves.toBeUndefined();
+      expect(await readFile(join(unit, "pids.current"), "utf8")).toBe("81\n");
+      expect(await readFile(join(root, "pids.max"), "utf8")).toBe("4096\n");
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it.each(["", "garbage", "-1", "9007199254740992"])("fails closed on invalid capacity: %s", async (value) => {
+    const root = await mkdtemp(join(tmpdir(), "terminal-capacity-"));
+    try {
+      await writeFile(join(root, "pids.max"), value);
+      await writeFile(join(root, "pids.current"), "0");
+      await expect(createTerminalCapacityAdmission({ root })("rt_first")).rejects.toThrow("Terminal runtime capacity unavailable");
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it("rejects exhausted and burst launches without deleting existing runtimes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "terminal-capacity-"));
+    let now = 0;
+    const admission = createTerminalCapacityAdmission({ root, now: () => now });
+    try {
+      await writeFile(join(root, "pids.max"), "4096\n");
+      await writeFile(join(root, "pids.current"), "4075\n");
+      await expect(admission("rt_first")).rejects.toThrow("Terminal runtime capacity unavailable");
+      await writeFile(join(root, "pids.current"), "3900\n");
+      await expect(admission("rt_first")).resolves.toBeUndefined();
+      await expect(admission("rt_second")).rejects.toThrow("Terminal runtime capacity unavailable");
+      now = 31_000;
+      await expect(admission("rt_second")).resolves.toBeUndefined();
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+});

--- a/tests/gateway/user-systemd-terminal-runtime.test.ts
+++ b/tests/gateway/user-systemd-terminal-runtime.test.ts
@@ -148,6 +148,18 @@ describe("user-systemd terminal runtime", () => {
     await expect(runtime.assertInstallationReady()).rejects.toThrow("Terminal runtime unavailable");
   });
 
+  it("refuses a new runtime before systemd start when aggregate capacity is exhausted", async () => {
+    const runCommand = vi.fn<UserSystemdCommandRunner>(async () => ({ stdout: "", stderr: "" }));
+    const capacityAdmission = vi.fn(async () => { throw new Error("capacity exhausted"); });
+    const runtime = createUserSystemdTerminalRuntime({ homePath, uid: 1001, generation: GENERATION,
+      runCommand, readinessProbe: async () => true, capacityAdmission });
+    await expect(runtime.create({ runtimeId: RUNTIME_ID, scope: "workspace", kind: "agent",
+      displayName: "Chat", cwd, layoutPath })).rejects.toThrow("Terminal runtime unavailable");
+    expect(capacityAdmission).toHaveBeenCalledWith(RUNTIME_ID);
+    expect(runCommand.mock.calls.some(([, args]) => args.includes("start"))).toBe(false);
+    expect(runCommand.mock.calls.some(([, args]) => args.includes("stop"))).toBe(false);
+  });
+
   it("creates an owner descriptor atomically and starts only the derived user unit", async () => {
     const runCommand = vi.fn<UserSystemdCommandRunner>(async () => ({ stdout: "", stderr: "" }));
     const runtime = createUserSystemdTerminalRuntime({

--- a/tests/gateway/user-systemd-terminal-runtime.test.ts
+++ b/tests/gateway/user-systemd-terminal-runtime.test.ts
@@ -160,6 +160,106 @@ describe("user-systemd terminal runtime", () => {
     expect(runCommand.mock.calls.some(([, args]) => args.includes("stop"))).toBe(false);
   });
 
+  it("hibernates only a managed workspace runtime while retaining its files and descriptor", async () => {
+    const runCommand = vi.fn<UserSystemdCommandRunner>(async (_command, args) => ({ stdout: args.includes("is-active") ? "inactive\n" : "", stderr: "" }));
+    const runtime = createUserSystemdTerminalRuntime({ homePath, uid: 1001, generation: GENERATION,
+      runCommand, readinessProbe: async () => true });
+    await runtime.create({ runtimeId: RUNTIME_ID, scope: "workspace", kind: "agent", displayName: "sess_test", cwd, layoutPath });
+    const ownerFile = join(cwd, "user.txt");
+    await writeFile(ownerFile, "keep my work");
+    runCommand.mockClear();
+    await expect(runtime.hibernateWorkspace(RUNTIME_ID)).resolves.toEqual({ ok: true });
+    expect(await readFile(ownerFile, "utf8")).toBe("keep my work");
+    expect(await runtime.get(RUNTIME_ID)).toMatchObject({ scope: "workspace", cwd, layoutPath, hibernatedAt: expect.any(String) });
+    await expect(runtime.start(RUNTIME_ID)).rejects.toThrow("Terminal runtime unavailable");
+    expect(runCommand.mock.calls.some(([, args]) => args.includes("stop") && args.includes(`matrix-zellij@${RUNTIME_ID}.service`))).toBe(true);
+    await expect(runtime.hibernateWorkspace(RUNTIME_ID)).resolves.toEqual({ ok: true });
+  });
+
+  it("refuses to hibernate independent Terminal sessions", async () => {
+    const runCommand = vi.fn<UserSystemdCommandRunner>(async () => ({ stdout: "", stderr: "" }));
+    const runtime = createUserSystemdTerminalRuntime({ homePath, uid: 1001, generation: GENERATION,
+      runCommand, readinessProbe: async () => true });
+    await runtime.create({ runtimeId: RUNTIME_ID, scope: "terminal", kind: "shell", displayName: "My terminal", cwd, layoutPath });
+    runCommand.mockClear();
+    await expect(runtime.hibernateWorkspace(RUNTIME_ID)).rejects.toThrow();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("reconciles a failed stop after restart without replaying the original prompt", async () => {
+    let failStop = true;
+    const runCommand = vi.fn<UserSystemdCommandRunner>(async (_command, args) => {
+      if (args.includes("stop") && failStop) throw new Error("temporary systemd outage");
+      return { stdout: args.includes("is-active") ? "inactive\n" : "", stderr: "" };
+    });
+    const options = { homePath, uid: 1001, generation: GENERATION, runCommand, readinessProbe: async () => true };
+    const runtime = createUserSystemdTerminalRuntime(options);
+    await runtime.create({ runtimeId: RUNTIME_ID, scope: "workspace", kind: "agent", displayName: "sess_test", cwd, layoutPath });
+    await expect(runtime.hibernateWorkspace(RUNTIME_ID)).rejects.toThrow();
+    const restarted = createUserSystemdTerminalRuntime(options);
+    expect((await restarted.get(RUNTIME_ID))?.hibernatedAt).toBeDefined();
+    await expect(restarted.start(RUNTIME_ID)).rejects.toThrow();
+    failStop = false;
+    await expect(restarted.hibernateWorkspace(RUNTIME_ID)).resolves.toEqual({ ok: true });
+    expect(await readFile(layoutPath, "utf8")).toBeTruthy();
+  });
+
+  it("rejects a stale idle admission after the same runtime ID was rebound", async () => {
+    const runCommand = vi.fn<UserSystemdCommandRunner>(async (_command, args) => ({ stdout: args.includes("is-active") ? "inactive\n" : "", stderr: "" }));
+    let createdAt = "2026-09-08T00:00:00.000Z";
+    const runtime = createUserSystemdTerminalRuntime({ homePath, uid: 1001, generation: GENERATION,
+      runCommand, readinessProbe: async () => true, now: () => createdAt });
+    const input = { runtimeId: RUNTIME_ID, scope: "workspace" as const, kind: "agent" as const, displayName: "sess_test", cwd, layoutPath };
+    const old = await runtime.create(input);
+    createdAt = "2026-09-08T00:01:00.000Z";
+    await runtime.create(input, { replaceInactiveWorkspace: true });
+    runCommand.mockClear();
+    await expect(runtime.hibernateWorkspace(RUNTIME_ID, old)).rejects.toThrow();
+    expect(runCommand).not.toHaveBeenCalled();
+    expect((await runtime.get(RUNTIME_ID))?.hibernatedAt).toBeUndefined();
+  });
+
+  it("rebinds an explicitly recovered inactive workspace to the new launch without replaying its old layout", async () => {
+    let state = "inactive";
+    const runCommand = vi.fn<UserSystemdCommandRunner>(async (_command, args) => ({ stdout: args.includes("is-active") ? `${state}\n` : "", stderr: "" }));
+    const runtime = createUserSystemdTerminalRuntime({ homePath, uid: 1001, generation: GENERATION,
+      runCommand, readinessProbe: async () => true });
+    const input = { runtimeId: RUNTIME_ID, scope: "workspace" as const, kind: "agent" as const, displayName: "sess_test", cwd, layoutPath };
+    await runtime.create(input);
+    const newLayoutPath = join(homePath, "system", "zellij", "layouts", "resume.kdl");
+    await writeFile(newLayoutPath, "layout { pane }\n");
+    await runtime.create({ ...input, layoutPath: newLayoutPath }, { replaceInactiveWorkspace: true });
+    expect(await runtime.get(RUNTIME_ID)).toMatchObject({ layoutPath: newLayoutPath });
+    for (state of ["active", "activating", "deactivating"]) {
+      await expect(runtime.create(input, { replaceInactiveWorkspace: true })).rejects.toThrow();
+    }
+    expect(await runtime.get(RUNTIME_ID)).toMatchObject({ layoutPath: newLayoutPath });
+  });
+
+  it("reclaims only superseded generated launch artifacts during cold recovery", async () => {
+    const runtime = createUserSystemdTerminalRuntime({ homePath, uid: 1001, generation: GENERATION,
+      runCommand: async (_command, args) => ({ stdout: args.includes("is-active") ? "inactive\n" : "", stderr: "" }),
+      readinessProbe: async () => true });
+    const generatedRoot = join(homePath, "system", "zellij", "runtime-layouts");
+    const environmentRoot = join(homePath, "system", "terminal-runtimes", "env");
+    await mkdir(generatedRoot, { recursive: true });
+    await mkdir(environmentRoot, { recursive: true });
+    const oldLayout = join(generatedRoot, `${RUNTIME_ID}-0123456789abcdef.kdl`);
+    const oldEnvironment = join(environmentRoot, `${RUNTIME_ID}-0123456789abcdef.json`);
+    const nextLayout = join(generatedRoot, `${RUNTIME_ID}-fedcba9876543210.kdl`);
+    await writeFile(oldLayout, "old prompt");
+    await writeFile(nextLayout, "new prompt");
+    await writeFile(oldEnvironment, "{}");
+    const input = { runtimeId: RUNTIME_ID, scope: "workspace" as const, kind: "agent" as const, displayName: "sess_test", cwd,
+      layoutPath: oldLayout, environmentPath: oldEnvironment };
+    await runtime.create(input);
+    await runtime.create({ ...input, layoutPath: nextLayout }, { replaceInactiveWorkspace: true });
+    await expect(readFile(oldLayout)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(oldEnvironment, "utf8")).toBe("{}");
+    expect(await readFile(nextLayout, "utf8")).toBe("new prompt");
+    expect(await readFile(layoutPath, "utf8")).toBeTruthy();
+  });
+
   it("creates an owner descriptor atomically and starts only the derived user unit", async () => {
     const runCommand = vi.fn<UserSystemdCommandRunner>(async () => ({ stdout: "", stderr: "" }));
     const runtime = createUserSystemdTerminalRuntime({

--- a/tests/gateway/user-systemd-terminal-runtime.test.ts
+++ b/tests/gateway/user-systemd-terminal-runtime.test.ts
@@ -186,6 +186,20 @@ describe("user-systemd terminal runtime", () => {
     expect(runCommand).not.toHaveBeenCalled();
   });
 
+  it.each(["inactive", "failed"])("cold-recovers when real systemctl reports %s with exit code 3", async (state) => {
+    const runtime = createUserSystemdTerminalRuntime({ homePath, generation: GENERATION,
+      readinessProbe: async () => true,
+      runCommand: async (_command, args) => {
+        if (args.includes("is-active")) throw Object.assign(new Error("systemctl exited"), { code: 3, stdout: `${state}\n` });
+        return { stdout: "", stderr: "" };
+      },
+    });
+    const input = { runtimeId: RUNTIME_ID, scope: "workspace" as const, kind: "agent" as const, displayName: "sess_test", cwd, layoutPath };
+    await runtime.create(input);
+    await expect(runtime.hibernateWorkspace(RUNTIME_ID)).resolves.toEqual({ ok: true });
+    await expect(runtime.create(input, { replaceInactiveWorkspace: true })).resolves.toMatchObject({ lifecycle: "running" });
+  });
+
   it("reconciles a failed stop after restart without replaying the original prompt", async () => {
     let failStop = true;
     const runCommand = vi.fn<UserSystemdCommandRunner>(async (_command, args) => {

--- a/tests/gateway/user-systemd-zellij-runtime.test.ts
+++ b/tests/gateway/user-systemd-zellij-runtime.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createUserSystemdZellijRuntime, workspaceRuntimeId } from "../../packages/gateway/src/user-systemd-zellij-runtime.js";
 import type { ZellijAdapter } from "../../packages/gateway/src/shell/zellij.js";
+import { createUserSystemdTerminalRuntime } from "../../packages/gateway/src/shell/user-systemd-terminal-runtime.js";
 
 const GENERATION = "gen_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const SESSION_ID = "sess_demo";
@@ -40,6 +41,22 @@ describe("user-systemd workspace Zellij runtime", () => {
     expect(workspaceRuntimeId(SESSION_ID)).toBe(workspaceRuntimeId(SESSION_ID));
     expect(workspaceRuntimeId(SESSION_ID)).toMatch(/^rt_[0-9a-f]{32}$/);
     expect(workspaceRuntimeId("sess_other")).not.toBe(workspaceRuntimeId(SESSION_ID));
+  });
+
+  it("cold-recovers a retained inactive descriptor using the next prompt's fresh layout", async () => {
+    const controller = createUserSystemdTerminalRuntime({ homePath, generation: GENERATION,
+      runCommand: async (_command, args) => ({ stdout: args.includes("is-active") ? "inactive\n" : "", stderr: "" }),
+      readinessProbe: async () => true });
+    const layoutPath = join(homePath, "system", "zellij", "layouts", `${SESSION_ID}.kdl`);
+    const runtime = createUserSystemdZellijRuntime({ homePath, generation: GENERATION, controller,
+      layoutRuntime: { generateLayout: async () => ({ sessionName: SESSION_ID, layoutPath }) }, baseAdapter: fakeAdapter() });
+    const launch = { command: "codex", args: [], cwd: homePath, env: {} };
+    const first = await runtime.start({ sessionId: SESSION_ID, launch });
+    await controller.hibernateWorkspace(workspaceRuntimeId(SESSION_ID));
+    await writeFile(layoutPath, "layout { pane name=\"cold resume\" }\n");
+    const second = await runtime.start({ sessionId: SESSION_ID, launch });
+    expect(second.layoutPath).not.toBe(first.layoutPath);
+    expect(await controller.get(workspaceRuntimeId(SESSION_ID))).toMatchObject({ layoutPath: second.layoutPath });
   });
 
   it("starts the generated agent layout in the typed user-systemd runtime", async () => {
@@ -91,6 +108,21 @@ describe("user-systemd workspace Zellij runtime", () => {
       publicSessionName: SESSION_ID,
       createdAt: "2026-07-31T12:00:00.000Z",
     });
+  });
+
+  it("does not claim a new prompt was delivered by returning an already-running workspace", async () => {
+    let active = false;
+    const controller = createUserSystemdTerminalRuntime({ homePath, generation: GENERATION,
+      runCommand: async (_command, args) => ({ stdout: args.includes("is-active") ? `${active ? "active" : "inactive"}\n` : "", stderr: "" }),
+      readinessProbe: async () => true });
+    const runtime = createUserSystemdZellijRuntime({ homePath, generation: GENERATION, controller,
+      layoutRuntime: { generateLayout: async () => ({ sessionName: SESSION_ID, layoutPath: join(homePath, "system", "zellij", "layouts", `${SESSION_ID}.kdl`) }) },
+      baseAdapter: fakeAdapter() });
+    const input = { sessionId: SESSION_ID, launch: { command: "codex", args: [], cwd: homePath, env: {} } };
+    await runtime.start(input);
+    active = true;
+    await expect(runtime.start(input)).rejects.toThrow();
+    expect(await runtime.isAlive(SESSION_ID)).toBe(true);
   });
 
   it("rejects launch environment keys outside the fixed runtime allowlist", async () => {

--- a/tests/gateway/workspace-cold-resume-sandbox.test.ts
+++ b/tests/gateway/workspace-cold-resume-sandbox.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, readFile, realpath, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createAgentSandbox } from "../../packages/gateway/src/agent-sandbox.js";
+import { createAgentLauncher } from "../../packages/gateway/src/agent-launcher.js";
+import { createAgentSessionManager } from "../../packages/gateway/src/agent-session-manager.js";
+import { createWorkspaceSessionOrchestrator } from "../../packages/gateway/src/workspace-session-orchestrator.js";
+import { createWorktreeManager } from "../../packages/gateway/src/worktree-manager.js";
+import type { AgentLaunchSpec } from "../../packages/gateway/src/agent-launcher.js";
+
+describe("cold resume with retained workspace sandbox", () => {
+  const homes: string[] = [];
+  afterEach(async () => { await Promise.all(homes.splice(0).map((path) => rm(path, { recursive: true, force: true }))); });
+
+  it.each(["resume", "launch-failure", "public", "foreign-owner", "wrong-thread", "missing-native", "scratch-symlink"])(
+    "preserves sandbox ownership during %s", async (scenario) => {
+    const homePath = await realpath(await mkdtemp(join(tmpdir(), "matrix-cold-sandbox-")));
+    homes.push(homePath);
+    const launches: string[][] = [];
+    const agentSessionManager = createAgentSessionManager({
+      homePath,
+      worktreeManager: createWorktreeManager({ homePath }),
+      agentLauncher: createAgentLauncher({ runtimeHome: homePath }),
+      zellijRuntime: {
+        start: async ({ sessionId, launch }: { sessionId: string; launch: AgentLaunchSpec }) => {
+          if (launches.length && scenario === "launch-failure") throw new Error("runtime unavailable");
+          launches.push(launch.args);
+          return { ok: true, status: "running", sessionName: sessionId, layoutPath: join(homePath, "layout.kdl") };
+        },
+        attachCommand: () => [], observeCommand: () => [],
+        isAlive: async () => false, kill: async () => ({ ok: true }),
+      } as never,
+    });
+    const orchestrator = createWorkspaceSessionOrchestrator({
+      homePath, agentSessionManager,
+      agentSandbox: createAgentSandbox({ homePath, getUid: () => 1000 }),
+      projectManager: {} as never, worktreeManager: createWorktreeManager({ homePath }),
+      sessionRuntimeBridge: {} as never,
+    });
+    try {
+      const request = { sessionId: "sess_resume", kind: "agent" as const, agent: "codex" as const, prompt: "first" };
+      expect(await orchestrator.startSession({ ownerScope: { type: "user", id: "owner" }, request })).toMatchObject({ ok: true });
+      const retained = join(homePath, "system", "agent-scratch", "sess_resume", "keep.txt");
+      await writeFile(retained, "owner scratch content");
+      if (scenario === "scratch-symlink") {
+        const scratch = join(homePath, "system", "agent-scratch", "sess_resume");
+        await rename(scratch, `${scratch}-original`);
+        await symlink(`${scratch}-original`, scratch);
+      }
+      const result = await orchestrator.startSession({
+        ownerScope: { type: "user", id: scenario === "foreign-owner" ? "other" : "owner" },
+        ...(scenario === "public" ? {} : { recoveryThreadId: scenario === "wrong-thread" ? "thread_other" : "thread_resume" }),
+        request: { ...request, prompt: "continue", ...(scenario === "missing-native" ? {} : { providerThreadId: "native_resume" }) },
+      });
+      expect(result.ok).toBe(scenario === "resume");
+      expect(launches).toHaveLength(scenario === "resume" ? 2 : 1);
+      if (scenario === "resume") {
+        expect(JSON.parse(Buffer.from(launches[1]!.at(-1)!, "base64").toString("utf8")))
+          .toMatchObject({ providerThreadId: "native_resume", prompt: "continue" });
+      }
+      expect(await readFile(retained, "utf8")).toBe("owner scratch content");
+    } finally { await orchestrator.close(); }
+  });
+});

--- a/tests/gateway/workspace-session-orchestrator.test.ts
+++ b/tests/gateway/workspace-session-orchestrator.test.ts
@@ -187,12 +187,38 @@ describe("workspace session orchestrator", () => {
     }));
   });
 
+  it.each(["public", "foreign-owner", "unrelated-thread", "missing-session"])("rejects root workspace reuse with %s provenance", async (scenario) => {
+    const home = await mkdtemp(join(tmpdir(), "matrix-root-provenance-"));
+    tempHomes.push(home);
+    const workspace = join(home, "temporary", "root-chat-workspaces", "sess_fixed");
+    await mkdir(workspace, { recursive: true });
+    const d = deps();
+    d.agentSessionManager.getSession.mockResolvedValue({ ok: true, session: {
+      ...session, projectSlug: undefined, ownerId: scenario === "foreign-owner" ? "other" : "user_workspace",
+    } } as never);
+    if (scenario === "missing-session") d.agentSessionManager.getSession.mockResolvedValue({ ok: false, status: 404 } as never);
+    const orchestrator = createWorkspaceSessionOrchestrator({ ...d, homePath: home });
+    try {
+      const result = await orchestrator.startSession({
+        ownerScope: { type: "user", id: "user_workspace" },
+        ...(scenario === "public" ? {} : { recoveryThreadId: scenario === "unrelated-thread" ? "thread_other" : "thread_fixed" }),
+        request: { sessionId: "sess_fixed", kind: "agent", agent: "codex" },
+      });
+      expect(result.ok).toBe(false);
+      expect(d.agentSandbox.preflight).not.toHaveBeenCalled();
+      await expect(access(workspace)).resolves.toBeUndefined();
+    } finally { await orchestrator.close(); }
+  });
+
   it.each([true, false])("reuses a root workspace without deleting it when launch succeeds=%s", async (succeeds) => {
     const home = await mkdtemp(join(tmpdir(), "matrix-root-recovery-"));
     tempHomes.push(home);
     const workspace = join(home, "temporary", "root-chat-workspaces", "sess_fixed");
     await mkdir(workspace, { recursive: true });
     const d = deps();
+    d.agentSessionManager.getSession.mockResolvedValue({ ok: true, session: {
+      ...session, projectSlug: undefined, ownerId: "user_workspace",
+    } } as never);
     if (!succeeds) d.agentSandbox.preflight.mockResolvedValueOnce({
       ok: false, status: 503, error: { code: "sandbox_unavailable", message: "Unavailable" },
     } as never);
@@ -200,6 +226,7 @@ describe("workspace session orchestrator", () => {
     try {
       const result = await orchestrator.startSession({
         ownerScope: { type: "user", id: "user_workspace" },
+        recoveryThreadId: "thread_fixed",
         request: { sessionId: "sess_fixed", kind: "agent", agent: "codex" },
       });
       expect(d.agentSandbox.preflight).toHaveBeenCalled();

--- a/tests/gateway/workspace-session-orchestrator.test.ts
+++ b/tests/gateway/workspace-session-orchestrator.test.ts
@@ -187,6 +187,48 @@ describe("workspace session orchestrator", () => {
     }));
   });
 
+  it.each([true, false])("reuses a root workspace without deleting it when launch succeeds=%s", async (succeeds) => {
+    const home = await mkdtemp(join(tmpdir(), "matrix-root-recovery-"));
+    tempHomes.push(home);
+    const workspace = join(home, "temporary", "root-chat-workspaces", "sess_fixed");
+    await mkdir(workspace, { recursive: true });
+    const d = deps();
+    if (!succeeds) d.agentSandbox.preflight.mockResolvedValueOnce({
+      ok: false, status: 503, error: { code: "sandbox_unavailable", message: "Unavailable" },
+    } as never);
+    const orchestrator = createWorkspaceSessionOrchestrator({ ...d, homePath: home });
+    try {
+      const result = await orchestrator.startSession({
+        ownerScope: { type: "user", id: "user_workspace" },
+        request: { sessionId: "sess_fixed", kind: "agent", agent: "codex" },
+      });
+      expect(d.agentSandbox.preflight).toHaveBeenCalled();
+      expect(result.ok).toBe(succeeds);
+      await expect(access(workspace)).resolves.toBeUndefined();
+    } finally { await orchestrator.close(); }
+  });
+
+  it("rejects an existing root workspace symlink without touching its target", async () => {
+    const home = await mkdtemp(join(tmpdir(), "matrix-root-symlink-"));
+    tempHomes.push(home);
+    const root = join(home, "temporary", "root-chat-workspaces");
+    const target = join(home, "external");
+    await mkdir(root, { recursive: true });
+    await mkdir(target);
+    await symlink(target, join(root, "sess_fixed"));
+    const d = deps();
+    const orchestrator = createWorkspaceSessionOrchestrator({ ...d, homePath: home });
+    try {
+      const result = await orchestrator.startSession({
+        ownerScope: { type: "user", id: "user_workspace" },
+        request: { sessionId: "sess_fixed", kind: "agent", agent: "codex" },
+      });
+      expect(result.ok).toBe(false);
+      expect(d.agentSandbox.preflight).not.toHaveBeenCalled();
+      await expect(access(target)).resolves.toBeUndefined();
+    } finally { await orchestrator.close(); }
+  });
+
   it("periodically protects every active root Chat status and stops the timer on close", async () => {
     vi.useFakeTimers();
     const d = deps();

--- a/tests/platform/chat-stream-proxy-timeout.test.ts
+++ b/tests/platform/chat-stream-proxy-timeout.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createClerkAuth } from "../../packages/platform/src/clerk-auth.js";
+import { type PlatformDB, insertUserMachine } from "../../packages/platform/src/db.js";
+import { createApp } from "../../packages/platform/src/main.js";
+import { cleanupProxyRoutingTest, setupProxyRoutingTest, stubOrchestrator } from "./proxy-routing-test-utils.js";
+
+describe("Chat SSE through authenticated platform routing", () => {
+  let db: PlatformDB;
+  beforeEach(async () => {
+    db = await setupProxyRoutingTest();
+    await insertUserMachine(db, {
+      machineId: "machine-chat-stream", clerkUserId: "user_alice", handle: "alice-review",
+      runtimeSlot: "review", status: "running", hetznerServerId: 100,
+      publicIPv4: "203.0.113.21", imageVersion: "dev", serverType: "cpx22",
+      provisionedAt: "2026-07-16T00:00:00.000Z",
+    });
+  });
+  afterEach(async () => {
+    vi.useRealTimers();
+    await cleanupProxyRoutingTest(db);
+  });
+
+  it.each([
+    ["/api/chats/events?runtime=review", "GET", true],
+    ["/vm/alice-review/api/chats/events", "GET", true],
+    ["/api/chats?runtime=review", "GET", false],
+    ["/api/chats/events?runtime=review", "POST", false],
+  ] as const)("applies the correct body deadline to %s (%s)", async (path, method, streaming) => {
+    const app = createApp({
+      db, orchestrator: stubOrchestrator(), platformSecret: "platform-secret-123",
+      clerkAuth: createClerkAuth({ verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }) }),
+    });
+    vi.useFakeTimers();
+    // Native AbortSignal.timeout does not use Vitest's clock. Keep its actual
+    // cancellation semantics while making the 30-second boundary deterministic.
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(new DOMException("Timed out", "TimeoutError")), ms);
+      return controller.signal;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => new Response(
+      new ReadableStream({
+        start(controller) {
+          const timer = setTimeout(() => {
+            controller.enqueue(new TextEncoder().encode('data: {"checkpoint":"after-30s"}\n\n'));
+            controller.close();
+          }, 35_000);
+          init?.signal?.addEventListener("abort", () => {
+            clearTimeout(timer);
+            controller.error(init.signal?.reason);
+          }, { once: true });
+        },
+      }), { headers: { "content-type": "text/event-stream" } },
+    ));
+    const response = await app.request(path, {
+      method,
+      headers: { host: "app.matrix-os.com", authorization: "Bearer clerk-session", accept: "text/event-stream", "x-matrix-chat-protocol": "2" },
+    });
+    expect(response.status).toBe(200);
+    const body = response.text().then(text => ({ text }), error => ({ error: String(error) }));
+    await vi.advanceTimersByTimeAsync(35_000);
+    expect(await body).toEqual(streaming
+      ? { text: 'data: {"checkpoint":"after-30s"}\n\n' }
+      : { error: "TimeoutError: Timed out" });
+  });
+});

--- a/tests/platform/runtime-proxy-stream.test.ts
+++ b/tests/platform/runtime-proxy-stream.test.ts
@@ -34,4 +34,16 @@ describe("runtime proxy response streaming", () => {
     expect(requestSignal?.aborted).toBe(false);
     expect(await response.text()).toBe("complete media");
   });
+
+  it("still aborts a streaming route if upstream headers never arrive", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => new Promise((_, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+    }));
+    const result = fetchRuntimeProxy(
+      "https://runtime.invalid/api/chats/events", { method: "GET" }, 10, true,
+    ).then(() => "unexpected success", (error: Error) => error.name);
+    await vi.advanceTimersByTimeAsync(11);
+    expect(await result).toBe("AbortError");
+  });
 });

--- a/tests/shell/canonical-chat-approval-parity.test.ts
+++ b/tests/shell/canonical-chat-approval-parity.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from "vitest";
+import { canonicalChatApprovals, type CanonicalChatDetailResponse } from "@matrix-os/contracts";
+import { createCanonicalChatFixture } from "../contracts/fixtures/canonical-chat";
+import { buildTranscript } from "../../apps/mobile/lib/canonical-chat-transcript";
+import { projectCanonicalTranscript } from "../../shell/src/lib/canonical-chat-terminal-notices";
+import { canonicalChatPresentation } from "@desktop/renderer/src/features/chat/canonical-chat-presentation";
+
+function fixture() {
+  const { snapshot } = createCanonicalChatFixture("approval_required");
+  const run = snapshot.runs[0]!;
+  return { ...snapshot, activities: [{
+    id: "activity_confirm", chatId: snapshot.chat.id, runId: run.id,
+    occurredAt: run.updatedAt, type: "approval.requested", approvalId: "approval_confirm",
+    title: "Use integration", risk: "high", allowedDecisions: ["approve", "decline", "cancel"],
+  }] } as unknown as CanonicalChatDetailResponse;
+}
+
+it("renders native approval activities on Web and Native Mobile with the same run-scoped decisions", () => {
+  const detail = fixture();
+  const expected = { runId: detail.runs[0]!.id, approvalId: "approval_confirm", pending: true,
+    title: "Use integration", allowedDecisions: ["approve", "decline", "cancel"] };
+  expect(projectCanonicalTranscript(detail).map(m => m.metadata?.canonicalApproval)).toContainEqual(expect.objectContaining(expected));
+  expect(buildTranscript(detail).map(m => m.approval)).toContainEqual(expect.objectContaining(expected));
+});
+
+it.each(["completed", "failed", "aborted"] as const)("never offers old approval controls after a %s run, even without a resolution event", status => {
+  const detail = fixture();
+  detail.runs[0]!.status = status;
+  expect(projectCanonicalTranscript(detail).find(m => m.metadata?.canonicalApproval)?.metadata?.canonicalApproval).toMatchObject({ pending: false });
+  expect(buildTranscript(detail).find(m => m.approval)?.approval).toMatchObject({ pending: false });
+  const [view] = canonicalChatPresentation(detail);
+  expect(view?.work).toContainEqual(expect.objectContaining({ requestId: "approval_confirm", state: "resolved", actions: undefined }));
+});
+
+it("deduplicates legacy parts and native activities and resolves across their different representations", () => {
+  const detail = fixture();
+  const run = detail.runs[0]!;
+  detail.messages.push({ ...detail.messages[0]!, id: "msg_approval", seq: 2, role: "assistant", runId: run.id,
+    parts: [{ type: "approval_request", approvalId: "approval_confirm", title: "Use integration",
+      description: "Confirm the inventory operation", risk: "high", allowedDecisions: ["approve", "cancel"] }] });
+  detail.activities.push({ id: "evt_resolve", chatId: run.chatId, runId: run.id,
+    occurredAt: run.updatedAt, type: "approval.resolved", approvalId: "approval_confirm", decision: "cancel" });
+  expect(canonicalChatApprovals(detail)).toEqual([expect.objectContaining({ id: "msg_approval", pending: false })]);
+  expect(projectCanonicalTranscript(detail).filter(m => m.metadata?.canonicalApproval)).toHaveLength(1);
+  expect(buildTranscript(detail).filter(m => m.approval)).toHaveLength(1);
+  const requests = canonicalChatPresentation(detail)[0]?.work.filter(item => item.kind === "request");
+  expect(requests).toEqual([expect.objectContaining({ requestId: "approval_confirm", state: "resolved", actions: undefined })]);
+});
+
+it("does not apply another run's decision to the current approval", () => {
+  const detail = fixture();
+  detail.activities.push({ ...detail.activities[0]!, id: "evt_other", runId: "run_other",
+    type: "approval.resolved", approvalId: "approval_confirm", decision: "cancel" });
+  expect(canonicalChatApprovals(detail)[0]?.pending).toBe(true);
+});

--- a/tests/shell/canonical-chat-refresh-recovery.test.tsx
+++ b/tests/shell/canonical-chat-refresh-recovery.test.tsx
@@ -50,6 +50,50 @@ async function tick(ms = 0) {
 afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
 
 describe("Web Desktop and Web Mobile shared Chat refresh", () => {
+  it.each(["focus", "stream"])("keeps an intentional new Chat empty after a %s list refresh", async (trigger) => {
+    vi.useFakeTimers();
+    const h = harness();
+    const hook = renderHook(() => useCanonicalChatState());
+    try {
+      await tick();
+      expect(hook.result.current.sessionId).toBe(record.chat.id);
+      await act(async () => { await hook.result.current.newChat(); });
+      h.list.mockImplementation(async () => Response.json({ items: [{
+        ...record, chat: { ...record.chat, title: "Refreshed list" },
+      }] }));
+      if (trigger === "focus") {
+        act(() => { window.dispatchEvent(new Event("focus")); });
+      } else {
+        h.emit(2, "run.completed");
+      }
+      await tick(250);
+      expect(hook.result.current.conversations[0]?.title).toBe("Refreshed list");
+      expect(hook.result.current.sessionId).toBeUndefined();
+      expect(hook.result.current.messages).toEqual([]);
+      expect(hook.result.current.busy).toBe(false);
+      act(() => { hook.result.current.switchConversation(record.chat.id); });
+      await tick();
+      expect(hook.result.current.messages[0]?.content).toBe("Before");
+    } finally { hook.unmount(); }
+  });
+
+  it("does not restore history when the initial list arrives after New chat", async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    let resolveList!: (response: Response) => void;
+    h.list.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveList = resolve; }));
+    const hook = renderHook(() => useCanonicalChatState());
+    try {
+      await tick();
+      await act(async () => { await hook.result.current.newChat(); });
+      await act(async () => { resolveList(Response.json({ items: [record] })); });
+      await tick();
+      expect(hook.result.current.conversations[0]?.id).toBe(record.chat.id);
+      expect(hook.result.current.sessionId).toBeUndefined();
+      expect(hook.result.current.messages).toEqual([]);
+    } finally { hook.unmount(); }
+  });
+
   it("applies slow snapshots during continuous events without concurrent detail requests", async () => {
     vi.useFakeTimers();
     const h = harness();

--- a/tests/shell/canonical-chat-refresh-recovery.test.tsx
+++ b/tests/shell/canonical-chat-refresh-recovery.test.tsx
@@ -94,6 +94,48 @@ describe("Web Desktop and Web Mobile shared Chat refresh", () => {
     } finally { hook.unmount(); }
   });
 
+  it("shows a failed run before the next user message and hides it after successful retry", async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    let recovered = false;
+    const failedRun = {
+      id: "run_failed", chatId: record.chat.id, turnId: "cturn_failed", attempt: 1,
+      driverKind: "codex", instanceId: "codex_default", selection: { instanceId: "codex_default", model: "test" },
+      interactionMode: "default", permissionMode: "supervised", status: "failed", outcome: "failed",
+      historyBoundarySeq: 0, capabilitySnapshot: { revision: "test", rootChat: true, resume: true,
+        cancellation: true, attachments: [], tools: [], approvals: true, userInput: true,
+        worktrees: "optional", resources: [], interactionModes: ["default"], permissionModes: ["supervised"] },
+      createdAt: record.chat.createdAt, updatedAt: record.chat.updatedAt,
+      startedAt: record.chat.createdAt, completedAt: record.chat.updatedAt,
+    };
+    h.getDetail.mockImplementation(async () => Response.json({
+      record,
+      messages: [1, 2].map((seq) => ({
+        id: `msg_${seq}`, chatId: record.chat.id, seq, role: "user", state: "committed",
+        parts: [{ type: "text", text: `Prompt ${seq}` }], createdAt: record.chat.createdAt,
+      })),
+      turns: [{ id: "cturn_failed", chatId: record.chat.id, inputMessageId: "msg_1", clientRequestId: "req_test",
+        baseMessageSeq: 0, status: "failed", createdAt: record.chat.createdAt, updatedAt: record.chat.updatedAt },
+      { id: "cturn_next", chatId: record.chat.id, inputMessageId: "msg_2", clientRequestId: "req_next",
+        baseMessageSeq: 1, status: "accepted", createdAt: record.chat.createdAt, updatedAt: record.chat.updatedAt }],
+      runs: [failedRun,
+        ...(recovered ? [{ ...failedRun, id: "run_retry", attempt: 2, status: "completed", outcome: "completed" }] : [])],
+      activities: [],
+    }));
+    const hook = renderHook(() => useCanonicalChatState());
+    try {
+      await tick();
+      expect(hook.result.current.messages.map((message) => message.content)).toEqual([
+        "Prompt 1", "Agent work failed. Please try again.", "Prompt 2",
+      ]);
+      expect(hook.result.current.busy).toBe(false);
+      recovered = true;
+      act(() => { window.dispatchEvent(new Event("focus")); });
+      await tick();
+      expect(hook.result.current.messages.map((message) => message.content)).toEqual(["Prompt 1", "Prompt 2"]);
+    } finally { hook.unmount(); }
+  });
+
   it("applies slow snapshots during continuous events without concurrent detail requests", async () => {
     vi.useFakeTimers();
     const h = harness();

--- a/tests/shell/canonical-chat-terminal-parity.test.ts
+++ b/tests/shell/canonical-chat-terminal-parity.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import type { CanonicalChatDetailResponse } from "@matrix-os/contracts";
+import { buildTranscript } from "../../apps/mobile/lib/canonical-chat-transcript.js";
+import { projectCanonicalTranscript } from "../../shell/src/lib/canonical-chat-terminal-notices.js";
+
+function fixture(status: "failed" | "aborted", retry = false): CanonicalChatDetailResponse {
+  const date = "2026-09-08T00:00:00.000Z";
+  return {
+    messages: [1, 2].map((seq) => ({ id: `msg_${seq}`, chatId: "chat_test", seq, role: "user", state: "committed",
+      parts: [{ type: "text", text: `Prompt ${seq}` }], createdAt: date })),
+    turns: [1, 2].map((seq) => ({ id: `cturn_${seq}`, inputMessageId: `msg_${seq}` })),
+    runs: [{ id: "run_first", turnId: "cturn_1", attempt: 1, status, createdAt: date, updatedAt: date,
+      ...(retry ? {} : { completedAt: date }) },
+    ...(retry ? [{ id: "run_retry", turnId: "cturn_1", attempt: 2, status: "completed", createdAt: date, updatedAt: date }] : [])],
+    activities: [],
+  } as unknown as CanonicalChatDetailResponse;
+}
+
+describe("terminal notice parity", () => {
+  it.each(["failed", "aborted"] as const)("shows safe %s outcome in the same turn on Web and Native Mobile", (status) => {
+    const detail = fixture(status);
+    const expected = ["Prompt 1", status === "failed" ? "Agent work failed. Please try again." : "Agent work stopped.", "Prompt 2"];
+    expect(projectCanonicalTranscript(detail).map((message) => message.content)).toEqual(expected);
+    expect(buildTranscript(detail).reverse().map((message) => message.text)).toEqual(expected);
+  });
+  it("removes superseded failed attempts after a successful retry on both surfaces", () => {
+    const detail = fixture("failed", true);
+    expect(buildTranscript(detail).reverse().map((message) => message.text)).toEqual(["Prompt 1", "Prompt 2"]);
+    expect(projectCanonicalTranscript(detail).map((message) => message.content)).toEqual(["Prompt 1", "Prompt 2"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Avoid the Zellij startup panic caused by readiness probes before first-client initialization. Use an invocation-scoped keeper signal for supporting immutable generations, retain the legacy generation path, reject stale/partial signals, and never report background-launch failure as ready.
- Settle native MCP approval expiry and turn-end cancellation durably before native continuation/terminal events. Fence late decisions; do not leave completed runs with actionable stale approvals. Share run-scoped approval derivation across Electron, Web Desktop/Web Mobile and Native Mobile; support both legacy message parts and native activity records, deduplicate mixed history, and wire Native Mobile's canonical approval controls to the selected computer/chat/run.
- Handle native Codex MCP empty-form confirmations through existing Chat approval events and correlated accept/decline/cancel responses. Bound pending confirmations, pause execution budgets during human wait, drain on turn end, reject late decisions, and fail unsupported/stale server requests closed instead of silently dropping them. Preserve supervised permissions; no implicit/session-wide MCP approval. Extract this behavior into a focused runner module and pin the exact native request schema.
- Recover the actual `systemctl is-active` exit-code-3 inactive result through the safe error wrapper's retained cause. Cold-resume/hibernation now distinguish settled inactivity from a command failure without exposing raw errors.
- Keep per-Chat text/reference drafts mounted across Chat A/B/New Chat navigation. Reset only the file inspector scope and fence delayed opens, while retaining account/runtime identity isolation (OM-223).
- Apply mutation acknowledgements synchronously to the SSE checkpoint so React-deferred updater replay cannot regress newer streamed content. Cover direct/queued steering, subsequent deltas/activity/completion and cursor-based reconnect without per-event detail polling (OM-224).
- Keep allowlisted Chat SSE bodies alive through platform routing after response headers arrive, without removing header deadlines or ordinary request timeouts. Extract the shared proxy-fetch helper from the oversized routing module.
- Retain the exact background-provider steering target after dispatch reports `delivered`; reject other owners, terminal threads and stale targets after a newer turn starts. Keep this bounded private bookkeeping out of API responses.
- Preserve intentional New chat drafts across list/focus/stream refreshes; require authenticated same-owner/thread/agent provenance when reusing an existing root workspace.
- Supervise systemd-backed Codex outside its runner: detect exit and missing startup readiness, drain final events first, persist failure idempotently, and fence replaced watchers.
- Add task-capacity admission and conservative idle Chat hibernation. Reconcile owner/thread/run/queue/attention and require the live runner's idle handshake before stopping the exact managed unit. Protect active/queued/human-wait work and independent Terminal sessions.
- Persist native conversation identity and cold-resume matching history, retaining owner files and worktree bindings. Rebind inactive launch descriptors and terminal incarnation; never replay an old launch layout or report a live runtime as proof a new prompt was delivered.
- Reuse retained sandbox scratch only for internal same-owner/session/agent/project/worktree Codex recovery with native thread identity. Ordinary duplicate starts remain rejected; symlinks are refused and failed replacement launches preserve existing scratch files.
- Distinguish unsent controls from ambiguous acknowledgements; do not automatically replay potentially dispatched work. Fail in-flight tools when either provider or runner dies, through the canonical client stream.
- Share latest-attempt failed/stopped notices across applicable Web and Native Mobile surfaces, attached to their original turn.

Tracking: [OM-222](https://linear.app/matrix-os/issue/OM-222/chat-hangs-as-working-after-runtime-exhaustion-repair-startup-recovery), [OM-223](https://linear.app/matrix-os/issue/OM-223/preserve-chat-drafts-across-navigation-after-the-file-inspector), [OM-224](https://linear.app/matrix-os/issue/OM-224/restore-live-http-sse-assistant-updates-after-same-run-chat-steering).

## Owner-approved delivery scope and surface matrix

The owner explicitly requested that the related existing/New Chat, runtime and MCP failures be fixed in this same PR, and later authorized: Electron Desktop acceptance first, then Greptile 5/5 and green CI, then merge without waiting for Mobile results. This is the owner-approved exception to the PR-size/splitting and Native Mobile live-evidence gates. Runtime/protocol, platform transport, and renderer fixes remain separated into focused commits/modules and tracked by OM-222/223/224. No repository/site documentation or speculative visual evidence is added. Native Mobile live/visual acceptance remains a follow-up in [OM-222](https://linear.app/matrix-os/issue/OM-222), not a passed or inapplicable surface. Shared-platform deployment verification also remains a release follow-up there.

| Surface | UI and behavior | State and recovery | Automated coverage | Actual evidence / remaining validation |
| --- | --- | --- | --- | --- |
| Electron Desktop | Existing Chat approval controls consume shared run-scoped approval projection; drafts and live steer preserve Chat identity. | Expired/completed requests lose action buttons; failed/stopped outcomes stay in their turn; queue/steer/reopen retain streamed history. | Desktop presentation/steer HTTP-stream/draft tests and shared approval-parity tests. | Exact `41351608e35` preview: original failed Retry recovered, MCP expiry settled, queued fourteen-step run completed in 7m41s with live steer, and reopened history had no stale actions. Actual Electron screenshots/AX evidence recorded in the owner review task. The subsequent MCP concurrency-only follow-up requires its focused regression verification; do not relabel old live evidence as a newer head. |
| Web Desktop | Shared Chat component renders canonical content and approve/decline/cancel controls. | Shared approval and terminal-notice derivation; deliberate New Chat selection survives refresh. | Shell refresh-recovery and approval/terminal parity tests. | Live supervised MCP controls observed on `238a4f1a25`; that run exposed the subsequently fixed expiry-ingestion bug. Full final-head Web acceptance is not claimed; owner chose Electron-first landing. |
| Web Canvas | `CanvasWindow` routes `__chat__` to the shared Chat component and canonical chat state. | Same shared approval/outcome/draft semantics; only window presentation differs. | Shared shell projection/parity tests and CI OS-view parity. | Routing/source wiring verified; no separate final-head live Canvas visual acceptance claimed. Remaining visual check tracked with OM-222. |
| Web Mobile | Responsive shared Web Chat exposes the same canonical approval actions. | Same run-scoped resolution, safe notices and stale-action fencing as Web Desktop. | Shared approval/terminal parity and shell controller tests. | Live 390px supervised approval rendering observed on `238a4f1a25`; screenshot verified in the owner task. Final-head Mobile acceptance is explicitly deferred by the owner. |
| Native Mobile | `CanonicalApprovalMessage` renders correlated one-time controls and safe error/disabled/resolved states. | Shared contracts derive approvals and terminal notices; selected computer/chat/run scope is passed to the request, with refresh after success and retryable safe failure. | Three native component tests plus shared six-case approval parity and three-case terminal parity tests. | Native-device screenshot/recording is not available and is not fabricated. Live acceptance is the explicit owner-approved follow-up above; unrelated global native type/Jest environment failures remain documented in test history. |

## Tests

- **Final landing gates (`7bcdc4c938f`):** [full CI 34266673306](https://github.com/HamedMP/matrix-os/actions/runs/34266673306), including four unit shards and E2E, succeeded. Docker smoke and [Preview build/deploy/stability 34266583034](https://github.com/HamedMP/matrix-os/actions/runs/34266583034) succeeded. Greptile is 5/5 for the exact head, with zero unresolved review threads. The final installed-preview Electron retest below passed. Previous pending snapshots in the historical record are superseded by these final gates.
- **Final follow-up `7bcdc4c938f` verified:** the delayed-persistence regression reproduced terminal draining finishing before an in-flight MCP expiry resolution. The fix retains a fenced bounded entry and shares its resolution promise across expiry/drain, preventing late grants, duplicate cancellation, and terminal completion before durable resolution. Persistence failures remain failures rather than a successful empty drain. **33 focused MCP/runtime/ingestion/parity tests**, root typecheck and patterns passed. Full local suite: **24 failed / 13,905 passed / 21 skipped**; 23 failures exactly match the prior merge-base baseline, plus one untouched home-mirror file-watcher timeout. That full file passed **34/34** on immediate isolated rerun. Full local validation is not claimed all-green. Exact-head CI has all four unit shards, build/type/parity checks and Docker smoke passing; E2E and Preview stability are pending. **Greptile 5/5** is tied to exact head `7bcdc4c938f0fd6dc171dbd6edd38a9f2ac1492d` by check run 102197692273, with zero unresolved review threads. This follow-up changes only the MCP lifecycle module and its tests, not renderer code.
- **Final installed-preview Electron retest (`7bcdc4c938f`) passed:** version `v2026.09.08-pr1580-34266583034-1-7bcdc4c` independently verified. A fresh supervised Chat bound in 706 ms. Approval requested 19:19:18.589Z, cancelled automatically 19:24:37.984Z (**5m19.395s**), and completed 19:24:41.494Z (**3.510s** after cancellation). Electron showed Worked for 5m34s and the no-retry final reply. Reopening and expanding history showed Approval resolved without action buttons; screenshot recorded in the owner task. Ten bounded legacy detail reads during approval returned HTTP 200 with correct waiting state. No approval or broader permission was granted. The fourteen-checkpoint/steer/draft acceptance below used the same unchanged renderer on the immediately prior backend head and is not misrepresented as a repeated fourteen-step run on this final follow-up.

- **Current exact-head Electron acceptance (`41351608e35`) passed:** installed release metadata verifies `v2026.09.08-pr1580-34262506615-1-4135160`. Retry of the previously failing original Chat bound its runtime in 710 ms and reached MCP approval. Unanswered approval requested 18:37:59.504Z, cancelled automatically 18:43:21.242Z (5m 21.738s), and the final reply arrived 18:43:25.773Z. Electron showed Worked for 5m 35s. The queued read-only 14-checkpoint task started automatically at 18:43:26.324Z and completed at 18:51:08.020Z (**7m 41.696s**). All checkpoints arrived in sequence; a queued prompt was steered into the same run and checkpoints 5–14 used the new prefix. UI showed Worked, API confirmed completed/empty queue, and reopening retained the final reply. Expanding the earlier MCP history showed Approval resolved with no action buttons. New Chat draft isolation also passed while the long run was active; only the agent-created unsent draft was cleared. Preview workflow [34262506615](https://github.com/HamedMP/matrix-os/actions/runs/34262506615) succeeded, including gateway stability. Per owner authorization, fresh Greptile/full CI/merge gates are now proceeding; Native Mobile live acceptance is deferred.
- **Transport evidence boundary:** the still-deployed shared platform reconnects SSE about every 33 seconds. A four-minute passive observation saw eight stream responses, all HTTP 200, and ten detail GETs including intentional Chat navigation. Live checkpoint/completion recovery passed; this is not an uninterrupted long-connection claim or live acceptance of the not-yet-deployed platform proxy change.
- **Current local verification (`41351608e35`):** 52 focused tests, the expanded 8-test readiness suite, and a fresh 35-test ownership/approval/terminal-parity run passed. Root typecheck, Electron build, and patterns (0 violations / 5 warnings) passed. Full suite: **23 failed / 13,904 passed / 21 skipped**, with exactly the same sorted failed test names as the independently reproduced merge-base baseline. This is not a green full suite; exact-head CI remains a landing gate.
- **Confirmed startup root cause:** the old-chat failure in 649 ms correlated with a Zellij pre-initialization `RemoveClient` panic. An isolated disposable Linux server reproduced the same panic when `list-sessions` probed before first-client initialization. The committed repair uses current-systemd-invocation keeper readiness rather than probing an uninitialized Zellij session, rejects stale/partial readiness signals and nonzero background-launch exit, and retains compatibility with older immutable keeper generations. This avoids the Matrix-triggered race; it does not claim an upstream Zellij Rust fix.
- **Full suite at `ea69fa39a37`:** 23 failed / 13,896 passed / 21 skipped. Sorted failed test names exactly match the independently reproduced merge-base baseline; this is not a green full suite.
- **Latest expiry ingestion repair (`ea69fa39a37`):** live testing on `238a4f1a25` found native cancellation and completion persisted in JSONL but rejected by the provider lifecycle allowlist, leaving both legacy and canonical state waiting. Allow provider-authored **cancel only**, never approve/approve-for-session/decline. A real JSONL bridge -> real thread-store regression reproduces the stuck state before this fix and passes afterward, including replay deduplication and forged-consent rejection. **36 focused tests**, root typecheck and patterns (0 violations / 5 warnings) passed; full suite is rerunning. New exact-head preview requested. Electron Desktop acceptance remains pending, so the newly authorized Greptile/CI/merge stage has not started; Mobile acceptance is no longer a merge prerequisite per user direction.
- **Cross-surface evidence on `238a4f1a25`:** live supervised Codex MCP actions render in Web Desktop and Web Mobile (390px, screenshot verified). Electron's old expired history renders Approval resolved without action buttons. The new unanswered run did not settle in Chat despite runner completion, exposing the ingestion defect above; this is NOT a passing timeout test. Native input/click automation is intermittent; no new Electron-send acceptance claimed.

### Earlier validation history (superseded by the latest results above)

- **Latest exact-head validation (`238a4f1a25`):** full suite completed with **23 failed / 13,895 passed / 21 skipped**, across 9 failing files. Sorted failure names exactly match the separately reproduced merge-base baseline; this is not an all-green result. The 77 focused tests, 3 Native Mobile approval component tests, root typecheck and Electron build passed. New Electron live verification of an old completed/expired approval shows **Approval resolved**, with no approval action buttons. Preview workflow [34250289743](https://github.com/HamedMP/matrix-os/actions/runs/34250289743) built successfully and is deploying; post-deploy expiry persistence and Web acceptance are still pending.
- **Startup evidence update:** the original failure and bounded retry correlate with two systemd runtime units that ended roughly 10 seconds after starting with SIGKILL. Neither produced a native event file. The same prompt/model/options in a new Chat reached approval and completed after expiry. Journal access remains denied. The precise launch failure is unresolved; no claim of a root-cause fix, capacity exhaustion, or destructive cleanup.

- **Current approval follow-up (2026-09-08/09):** tests first reproduced missing durable expiry, missing Web/Native approval projection, and duplicate/stale Electron controls. Focused gateway/contracts/Web/Electron validation: **77 tests passed across 8 files**. Native Mobile approval component: **3 passed**, covering correlated one-time submission, settled actions, and safe failure handling. Root typecheck and Electron build passed; patterns: 0 violations / 5 warnings. The new full-suite run is still in progress, not claimed green. Native Mobile full typecheck still reports unrelated Image/WebView/PostHog/theme typing errors; the initial new component color-token error was corrected. Its existing home-screen Jest test also fails on the unrelated micromark ESM barrel import. Native-device acceptance is not claimed.
- **Startup investigation remains open:** two new supervised Codex chats (plain text and MCP) started successfully on the unchanged `5a303d94a` preview; the plain response completed in 6 seconds and MCP reached approval then completed after Cancel. The original failed Chat retried once and failed again in 568 ms before binding. A new Chat with the exact same prompt/model/options reached approval. This narrows the failure but does not prove its underlying cause; no permissions were changed and no session data was deleted.
- **Follow-up verification found remaining defects; this PR is not fully accepted.** Web Desktop and Web Mobile receive content, but neither renders the live Codex MCP approval from run activities. The Web projection uses message parts plus terminal notices; its existing approval component expects message-part metadata. The same pending request exposes Approve/Decline/Cancel in Electron. Native Mobile source inspection likewise found no canonical approval-activity projection/control wiring; native-device acceptance was not run.
- **Unanswered approval deadline:** the request at 15:25:03.669Z was cancelled at 15:30:17.823Z (5m 14s) and the run completed at 15:30:25.842Z (5m 22s). The five-minute TTL is swept every 30 seconds. However, expiry sends the native cancellation without persisting an approval-resolution event. Expanding the completed Electron run still shows actionable approval buttons. A late Cancel fails locally with safe copy and produces no approval HTTP request; terminal run safety holds, but the stale UI is a confirmed defect.
- **New Codex Chat startup remains unresolved:** a fresh supervised Chat failed in 635 ms before terminal binding on the same exact preview. No failed task was blindly retried or deleted. The existing Codex Chat cold-resumed successfully from Web, and a real native Codex probe produced the expected MCP confirmation and completed after the diagnostic rejection. Live gateway/user task counts were far below configured limits. Ordinary runtime journal access is denied, and a scoped centralized-log search found no matching run; the precise startup failure is not yet proven.
- **Hermes + existing Codex Luna login, live Web/Electron:** a new Web Chat ran 14 separate read-only `sleep 30; date -u` commands and completed in **8m 17s**. Web showed progressive checkpoints beyond six minutes; Electron loaded the same active Chat and observed subsequent output/completion. All 14 command activities persisted completed. Both clients and stored text contain **13 numbered checkpoints plus the final summary**, not 14 numbered texts; the final numbered checkpoint criterion is not claimed passed. No new provider authorization was added.
- **Remaining boundaries:** the earlier unexpected approval source and permission-selection change could not be reproduced or attributed. A later untouched approval waited until expiry; restart/New Chat/existing Chat checks retained Supervised. OpenCode and Pi are disabled in Settings, Claude requires authentication, and OpenClaw is not installed, so those live provider tests remain blocked. This follow-up changes test records only, not implementation; no Greptile or merge.
- **Exact-head Electron Desktop acceptance (`5a303d94a`)** against the installed matching preview: Retry recovered the previously hibernated/failed Chat and recalled checkpoint 14 from native history. A visible supervised MCP approval was approved once; the inventory tool completed **386 ms** after the recorded approval. Fourteen separate `sleep 30; date -u` commands completed in **8m 21s** overall. Foreground DOM monitoring observed checkpoints 1–13 arriving during execution; checkpoint 14 was verified by expanding the completed activity. A queued prompt was explicitly steered into the current run, and checkpoints 4–14 used the requested prefix without restarting the sequence. UI changed to Worked, API persisted `completed`, queue was empty, and reopening the Chat retained the result.
- **Desktop rejection and drafts:** an explicit Decline click produced a persisted `decline`, failed the tool within 208 ms, and completed the turn about 2.2 seconds later without retrying or indefinite Working. A prior attempt recorded an approval instead and is not counted as rejection coverage. Existing/New Chat text drafts survived navigation independently using real keyboard input; test drafts were cleared without sending. Prior failed work remained visibly failed after the exact-head client restart.
- **Preview workflow [34239579671](https://github.com/HamedMP/matrix-os/actions/runs/34239579671) succeeded**, including the 15-minute gateway stability check. During the long Desktop run, the public proxy still caused approximately 33-second reconnects (15 observed stream responses, all HTTP 200); the client continued updating and completed. This validates recovery under the currently deployed proxy, **not uninterrupted SSE or the undeployed platform fix**. Exact-head Web, Native Mobile, all-provider acceptance, and historical PostHog switch-project remain unverified.
- Latest MCP investigation: fresh supervised Codex inventory stalled on exact preview bundle `v2026.09.08-pr1580-34219005536-1-d7b90d7`; direct MCP stdio returned in 465 ms. A bounded real Codex 0.153.4 probe confirmed the missing `mcpServer/elicitation/request` response. Returning `{action: "accept", content: {}}` completed the same read-only tool in 291 ms and the turn completed. This is a native protocol probe, not yet the updated Matrix approval UI acceptance test. The stalled pre-fix Chat correctly failed its tool/run after 10 minutes.
- Latest follow-up focused validation: 109 tests across 10 files passed, then the expanded MCP lifecycle suite passed all 12 tests (including the two additional human-wait/interruption cases). Regression tests first exposed ignored MCP confirmations, sensitive message disclosure, missing protocol coverage, and actual systemctl inactive handling. Root typecheck, gateway and Electron builds passed; patterns: 0 violations, 5 warnings. Full suite at `5a303d94a` completed: **23 failed / 13,889 passed / 21 skipped**, with 9 failing files. Sorted failure names exactly match the reproduced merge-base baseline; full suite is not green.
- Latest preview installed release metadata independently verifies `v2026.09.08-pr1580-34239579671-1-5a303d9`, exact commit `5a303d94a630e681b5d0a2d616eb134fd82b1e18`. Electron Desktop live acceptance is in progress; this VPS installation does not deploy the shared platform proxy change.
- Existing d7b90d7 preview workflow is successful; installed release metadata was independently verified. That deployment does not include this newest MCP/systemctl increment and does not release the shared platform proxy change.
- Live-test follow-up: **84 tests passed across 9 files**, including real authenticated platform route/body-deadline tests and real legacy thread-store delivered-turn steering. Both regressions failed before their respective fixes. Root typecheck, gateway/platform builds passed; patterns: 0 violations, 5 warnings.
- The follow-up full suite completed: **23 failed / 13,865 passed / 21 skipped** (9 failing files). Sorted failure names match the already reproduced merge-base baseline exactly. This run preceded the final sandbox-recovery increment; its separate focused validation is listed below. Full suite is not green.
- A third continuation after approximately 16 idle minutes failed before any requested diagnostic command executed. Read-only inspection confirmed a persisted hibernation marker and retained sandbox directory, while the session view still reported running. A real orchestrator -> sandbox -> session manager regression reproduced recovery failing with `409 sandbox_unavailable`. The new sandbox fix passes **112 tests across 6 files**, including native-thread launch configuration, failed-launch preservation, unauthorized reuse and symlink rejection. Live post-fix cold-resume validation remains pending; no gateway PID samples were obtained from the failed task.
- Real Codex preview testing on the earlier `4fbc773` head: first task completed in **3m 3s**, with queued same-run steering and later live checkpoints. An automatically queued follow-up completed in **7m 42s**, with all 14 read-only checkpoints and persisted completion. Final long-run completion was verified through the API after the selected test window changed; this is not an uninterrupted foreground-renderer assertion. The test exposed periodic ~33-second stream reconnects and a second-run direct-steer failure, now covered by the new regressions above. Those newest fixes are **not yet deployed**.
- Preview installation at `4fbc773` succeeded, but the workflow failed stability validation after one gateway PID/NRestarts change. Later HTTP observations do not establish process restart counts. Do not treat the preview workflow as green.
- Latest draft/steering focused run: **133 tests passed across 13 files**. A real repository/outbox -> Hono HTTP stream -> SSE parser -> React controller regression failed before the checkpoint fix and passes after it. Six cases cover accepted/idempotent acknowledgements and reconnect; healthy delivery performs only the initial detail read, reconnect reconciles once. The provider boundary is controlled, not a live multi-provider acceptance test.
- Latest root typecheck and Electron production build passed; patterns: 0 violations, 5 warnings. Final-head interactive Electron/Web acceptance remains pending.
- Previous runtime increment focused run: **172 tests passed across 17 files**, including real Unix sockets/processes and the event bridge -> real thread store -> canonical adapter path. Faults include injected spawn EAGAIN, handshake exit/timeout, provider exit during MCP work, runner SIGKILL, native identity mismatch and ambiguous acknowledgements.
- Guards cover new-message serialization, reload, queued/active/human-wait protection, inactive/activating/deactivating runtimes, persistent stop intent after failure/restart, stale incarnation fencing, owned artifact cleanup and unsupported-runner refusal.
- Real isolated Codex 0.153.4 + bundled zellij passed: complete first turn, acknowledge idle shutdown, stop exact diagnostic runtime, resume the same native conversation in a second runtime and recall prior test content. Owner test file retained; diagnostic runtimes stopped. This validates the lifecycle path, **not production rollout or exact-head Web/Electron acceptance**.
- Root typecheck, gateway build and built-module import smoke passed. Pattern checks: 0 violations, 5 warnings.
- Full local run during this increment: **23 failed / 13,859 passed / 21 skipped tests**, with 9 failing files, matching the earlier failure groups. It began before the final test-case extensions; the final focused 133-test run above covers those extensions. Failures include billing, runtime manager, host-bundle/golden-snapshot workflows, onboarding, timezone-sensitive todo and terminal menu tests. Full suite is not green.
- Baseline comparison: running those nine files in a separate detached worktree at merge-base `919eb2e6d9b3e2d034d2cc0c974336d30e6b1820`, with the same installed dependencies, reproduces **exactly the same 23 failed tests / 181 passed**. Sorted failure names match. These failures are pre-existing, not introduced by this PR.
- Earlier Native Mobile global typecheck failed in unchanged React Native/WebView/theme files; focused parity coverage does not replace a clean mobile check.
- **Draft PR; Greptile paused by user request.** No merge or new Human Review pass claimed.

## Invariants

### Source of truth

- Canonical runs/queued turns/steers and persisted owner-scoped coding threads authorize reclamation; process counts alone do not.
- Native history is retained. Bridge-only resume metadata is not rendered. Missing/inconsistent identity fails closed, never starts an empty replacement conversation.
- Legacy detail endpoints and 200ms polling remain available. No client transport removal or SSE protocol replacement.
- Delivered-turn identity is optional private per-thread metadata (one bounded ID), not a new public field or proof of provider completion. New dispatches fence it; terminal threads cannot be steered.

### Lock/transaction scope

- No database schema changes. Idle admission holds the legacy thread admission queue, then the matching canonical Chat row transaction, then the runtime mutation/generation lock. New admission cannot race the bounded stop.
- Canonical lock/query waits and control/systemd operations are bounded. Runtime incarnation is rechecked before stopping.
- Capacity preflight runs under the runtime mutation lock; reservations have a 30-second TTL/64-entry cap. Kernel limits remain the hard boundary; actual launch failures still propagate.
- Sweeps are coalesced/bounded with capped TTL retries and a shutdown drain before dependent resources close.

### Acceptable orphan states

- Durable hibernation intent prevents old-prompt replay after stop failure/restart. Reconciliation repeats ownership/idle checks; cold recovery explicitly replaces the inactive descriptor.
- If gateway death occurs after idle ACK but before recording stop intent, an unmarked residual runtime may remain. It is not force-killed without proof.
- Unsupported old runners or missing native identity are skipped; they require separately reviewed recovery, not speculative deletion.
- Owner files/history/worktree leases remain intact. Only exact superseded generated launch files and runtime snapshots are cleaned; no bulk production cleanup.

### Auth source of truth

- Authenticated principals and durable same-owner/thread/session/agent provenance authorize recovery. Internal hints are not public request authority; symlinks and mismatched paths are rejected.
- Sandbox reuse is a separate internal preflight argument, never a request-body flag. Recovery also matches project/worktree binding; the runtime controller still checks settled inactivity under its mutation lock before replacement. A failed replacement must not clean scratch owned by the retained session.
- Only the owner-only Codex socket reserves idle shutdown. Independent Terminal/application/VPN services are outside scope.
- User-visible failures use safe fixed copy, not raw system/provider errors.

### Deferred scope

- No fleet cleanup, limit increases, resizing, production restart/deploy or conversion of other providers to zellij.
- The platform timeout fix requires the platform release as well as the runtime preview; updating only a VPS bundle cannot validate the public proxy change. No shared production platform deployment is part of this test run.
- Local pending file-upload objects are currently discarded when changing Chat scope. This is separate from text/structured-reference draft preservation; the live smoke found it and tracking records it, but this PR does not claim to fix that upload lifecycle.
- The steering regression proves a client checkpoint race. Read-only incident outbox validation found no malformed/gapped persisted content, but the original incident has no contemporaneous wire/renderer trace; do not claim this was its sole cause or that production streaming is verified.
- The supervised Matrix inventory stall is now reproduced and isolated to an ignored native MCP confirmation request. Val's historical PostHog switch-project trace has not been retested on the new implementation; revoked Codex authentication remains a separate observation, not proof of that historical call's cause.
- MCP empty-form confirmations are supported. Nonempty forms and URL-based elicitations are explicitly cancelled rather than auto-approved or left hanging; a full form/authentication UI is outside this repair.
- Automatic systemd/canonical reclamation still needs reviewed rollout and Web/Electron acceptance. Older runners missing safe resume metadata are not force-recovered. Unrelated full-suite/mobile errors remain outside this fix.
