### PR TITLE
refactor(terminal): narrow provider login registry contract

### DIFF
--- a/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
+++ b/packages/gateway/src/ai-providers/provider-terminal-login-coordinator.ts
@@ -3,7 +3,8 @@ import { lstat, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { ProviderConnectionAttemptSchema } from "@matrix-os/contracts";
 import { z } from "zod/v4";
-import type { ShellRegistry } from "../shell/registry.js";
+import type { AgentKind } from "../shell/agent-session-state.js";
+import type { ShellAgentLiveness } from "../shell/registry.js";
 import { ProviderSettingsStoreError } from "./provider-settings-errors.js";
 import { writeProviderJsonAtomic } from "./provider-settings-persistence.js";
 import type { ProviderLoginCoordinator } from "./provider-settings-coordinators.js";
@@ -30,8 +31,19 @@ const ReceiptDocumentSchema = z.object({
 
 type LoginHarness = Parameters<ProviderLoginCoordinator["supportedMethods"]>[0];
 type LoginInput = Parameters<ProviderLoginCoordinator["startLogin"]>[0];
-type LoginRegistry = Pick<ShellRegistry,
-  "create" | "get" | "delete" | "rename" | "observeAgentLiveness">;
+interface LoginRegistry {
+  create(input: {
+    name: string;
+    cwd?: string;
+    cmd?: string;
+    agent?: AgentKind;
+    exclusive?: boolean;
+  }): Promise<{ name: string }>;
+  get(name: string): Promise<{ name: string }>;
+  delete(name: string, options?: { force?: boolean }): Promise<void>;
+  rename(name: string, nextName: string): Promise<{ name: string }>;
+  observeAgentLiveness(name: string, agent: AgentKind): Promise<ShellAgentLiveness>;
+}
 type ReceiptDocument = z.infer<typeof ReceiptDocumentSchema>;
 type ReceiptWriter = (path: string, value: ReceiptDocument) => Promise<void>;
 

--- a/tests/gateway/provider-settings-runtime-wiring.test.ts
+++ b/tests/gateway/provider-settings-runtime-wiring.test.ts
@@ -18,7 +18,11 @@ describe("provider settings runtime capability wiring", () => {
     expect(source).toContain("detectAgentInstallations: agentCredentialLauncher.detectAgentInstallations");
     expect(source).toContain("runtimeSource: agentRuntimeServices.source");
     expect(source).toContain("createProviderTerminalLoginCoordinator({");
-    expect(source).toContain("registry: zellijShellRegistry");
+    const loginCoordinatorWiring = source.match(
+      /const providerLoginCoordinator = createProviderTerminalLoginCoordinator\(\{[\s\S]*?\n  \}\);/,
+    )?.[0];
+    expect(loginCoordinatorWiring).toBeDefined();
+    expect(loginCoordinatorWiring).toContain("registry: zellijShellRegistry");
     expect(source).toContain("loginCoordinator: providerLoginCoordinator");
     expect(source).toContain("createDefaultProviderCliAccountLifecycleCoordinator({");
     expect(source).not.toContain("codingAgentWorkspaceAgents.flatMap((agent)");


### PR DESCRIPTION
## Summary

- narrow the provider terminal-login coordinator to the exact registry operations it consumes
- decouple provider login wiring from the legacy concrete shell registry before the workspace gateway cutover
- keep registration-time wiring verification independent of the backing terminal runtime variable name

## Stack

Layer 5 of 14. Depends on #1503; #1600 follows.

## Tests

- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- `pnpm exec vitest run tests/gateway/provider-settings-runtime-wiring.test.ts`
- full stack pattern scan: 0 violations
- full stack diff hygiene

## Review/Monitoring

- GitHub CI and Greptile are being monitored on the latest head until green and 5/5.

## Invariants

### Source of truth

- The provider settings service remains authoritative for login attempts; this layer changes only the dependency contract used to open and observe an interactive setup terminal.

### Lock/transaction scope

- This layer adds no database writes, locks, or network calls. Registry operations retain their existing lifecycle serialization.

### Acceptable orphan states

- Existing terminal-login cleanup behavior is unchanged. A failed login remains recoverable through the coordinator's existing bounded receipt and cleanup flow.

### Auth source of truth

- Existing provider-login authorization and owner-scoped gateway wiring remain authoritative; this layer adds no auth path.

### Deferred scope

- Replacing the legacy registry implementation is intentionally deferred to #1431, which supplies the shared workspace runtime.

