### PR TITLE
feat(collaboration): add isolated scope runtime supervisor

### DIFF
--- a/distro/customer-vps/host-bin/matrix-scope-runtime
+++ b/distro/customer-vps/host-bin/matrix-scope-runtime
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -eu
+
+exec /opt/matrix/runtime/node/bin/node \
+  --enable-source-maps \
+  /opt/matrix/app/packages/scope-runtime/dist/main.js

--- a/distro/customer-vps/systemd/matrix-scope-runtime.service
+++ b/distro/customer-vps/systemd/matrix-scope-runtime.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=Matrix OS fixed-profile collaboration scope runtime supervisor
+After=matrix-restore.service
+Requires=matrix-restore.service
+ConditionPathExists=/opt/matrix/restore-complete
+ConditionPathExists=/opt/matrix/bin/matrix-scope-runtime
+ConditionPathExists=/opt/matrix/app/packages/scope-runtime/dist/main.js
+ConditionPathExists=!/opt/matrix/app/SCOPE_RUNTIME_DISABLED
+
+[Service]
+Type=simple
+# The system-owned supervisor needs the systemd manager to create transient
+# workload units. Its IPC accepts only source-controlled fixed-profile fields;
+# every spawned workload uses DynamicUser and the isolated profile.
+User=root
+Group=matrix
+ExecStart=/opt/matrix/bin/matrix-scope-runtime
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=30
+TimeoutStopSec=45
+KillMode=control-group
+RuntimeDirectory=matrix-scope-runtime
+RuntimeDirectoryMode=0770
+StateDirectory=matrix-scope-runtime
+StateDirectoryMode=0700
+UMask=0007
+PrivateNetwork=yes
+PrivateIPC=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectSystem=strict
+ProtectProc=invisible
+ProcSubset=pid
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+NoNewPrivileges=yes
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+LockPersonality=yes
+MemoryMax=256M
+TasksMax=64
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -34,6 +34,7 @@
     "@matrix-os/contracts": "workspace:*",
     "@matrix-os/kernel": "workspace:*",
     "@matrix-os/observability": "workspace:*",
+    "@matrix-os/scope-runtime": "workspace:*",
     "@pipedream/sdk": "^2.4.3",
     "@types/node-cron": "^3.0.11",
     "chokidar": "^4.0.0",
@@ -49,6 +50,7 @@
     "prom-client": "^15.1.3",
     "glob": "^13.0.6",
     "semver": "^7.7.0",
+    "undici": "7.24.8",
     "ws": "^8.19.0",
     "zod": "^4.4.3"
   }

--- a/packages/scope-runtime/package.json
+++ b/packages/scope-runtime/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@matrix-os/scope-runtime",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/protocol.ts",
+    "./broker-protocol": "./src/broker-protocol.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/scope-runtime/src/broker-protocol.ts
+++ b/packages/scope-runtime/src/broker-protocol.ts
@@ -1,0 +1,86 @@
+import { z } from "zod/v4";
+import { RuntimeHandleSchema } from "./protocol.js";
+
+const MAX_PROVIDER_BODY_BYTES = 256 * 1024;
+const MAX_BROKER_BODY_BYTES = 512 * 1024;
+const RequestIdSchema = z.string().uuid();
+const GenerationSchema = z.string().regex(/^(0|[1-9][0-9]{0,19})$/);
+const BoundedBodySchema = z.string().refine(
+  (value) => Buffer.byteLength(value, "utf8") <= MAX_PROVIDER_BODY_BYTES,
+  "Broker body exceeds limit",
+);
+
+const InferenceHeadersSchema = z.object({
+  "anthropic-version": z.string().min(1).max(64).regex(/^[A-Za-z0-9._-]+$/).optional(),
+  "anthropic-beta": z.string().min(1).max(512).regex(/^[A-Za-z0-9,._ -]+$/).optional(),
+}).strict();
+
+const InferenceRequestSchema = z.object({
+  version: z.literal(1),
+  action: z.literal("inference.messages"),
+  requestId: RequestIdSchema,
+  runtimeHandle: RuntimeHandleSchema,
+  executionGeneration: GenerationSchema,
+  method: z.enum(["HEAD", "POST"]),
+  path: z.enum(["/api/hello", "/v1/messages?beta=true"]),
+  headers: InferenceHeadersSchema,
+  body: BoundedBodySchema,
+}).strict().superRefine((value, context) => {
+  const valid = (value.method === "HEAD" && value.path === "/api/hello" && value.body === "")
+    || (value.method === "POST" && value.path === "/v1/messages?beta=true");
+  if (!valid) context.addIssue({ code: "custom", message: "Invalid inference route" });
+});
+
+const EgressRequestSchema = z.object({
+  version: z.literal(1),
+  action: z.literal("egress.fetch"),
+  requestId: RequestIdSchema,
+  runtimeHandle: RuntimeHandleSchema,
+  executionGeneration: GenerationSchema,
+  method: z.literal("GET"),
+  url: z.string().min(1).max(2_048).url(),
+  accept: z.enum(["application/json", "text/plain"]),
+}).strict();
+
+export const ScopeRuntimeBrokerRequestSchema = z.union([
+  InferenceRequestSchema,
+  EgressRequestSchema,
+]);
+
+const SuccessResponseSchema = z.object({
+  version: z.literal(1),
+  requestId: RequestIdSchema,
+  ok: z.literal(true),
+  status: z.number().int().min(200).max(299),
+  headers: z.object({
+    "content-type": z.string().min(1).max(128).optional(),
+    "cache-control": z.string().min(1).max(128).optional(),
+  }).strict(),
+  body: z.string().refine(
+    (value) => Buffer.byteLength(value, "utf8") <= MAX_BROKER_BODY_BYTES,
+    "Broker response exceeds limit",
+  ),
+}).strict();
+
+const FailureResponseSchema = z.object({
+  version: z.literal(1),
+  requestId: RequestIdSchema,
+  ok: z.literal(false),
+  error: z.enum([
+    "action_denied",
+    "route_denied",
+    "invalid_request",
+    "request_too_large",
+    "capacity_exceeded",
+    "provider_unavailable",
+    "response_too_large",
+  ]),
+}).strict();
+
+export const ScopeRuntimeBrokerResponseSchema = z.union([
+  SuccessResponseSchema,
+  FailureResponseSchema,
+]);
+
+export type ScopeRuntimeBrokerRequest = z.infer<typeof ScopeRuntimeBrokerRequestSchema>;
+export type ScopeRuntimeBrokerResponse = z.infer<typeof ScopeRuntimeBrokerResponseSchema>;

--- a/packages/scope-runtime/src/main.ts
+++ b/packages/scope-runtime/src/main.ts
@@ -1,0 +1,43 @@
+import { createScopeRuntimeServer } from "./server.js";
+import { createScopeRuntimeController } from "./supervisor.js";
+import { createSystemdScopeRuntimeLauncher, nextExecutionGeneration } from "./systemd-launcher.js";
+
+const RUNTIME_DIRECTORY = "/run/matrix-scope-runtime";
+const STATE_DIRECTORY = "/var/lib/matrix-scope-runtime";
+
+async function main(): Promise<void> {
+  const launcher = createSystemdScopeRuntimeLauncher({
+    stateRoot: STATE_DIRECTORY,
+    sdkDirectory: "/opt/matrix/app/node_modules/@anthropic-ai/claude-agent-sdk",
+    nativeDirectory: "/opt/matrix/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64",
+    workerFile: "/opt/matrix/app/packages/scope-runtime/dist/worker.js",
+    brokerSocket: `${RUNTIME_DIRECTORY}/broker.sock`,
+  });
+  const executionGeneration = await nextExecutionGeneration(`${STATE_DIRECTORY}/generation`);
+  const controller = await createScopeRuntimeController({ launcher, executionGeneration });
+  const server = createScopeRuntimeServer({
+    socketPath: `${RUNTIME_DIRECTORY}/supervisor.sock`,
+    controller,
+  });
+  await server.start();
+  process.stdout.write("scope_runtime_supervisor_ready\n");
+
+  let shutdown: Promise<void> | undefined;
+  const stop = () => {
+    shutdown ??= server.close();
+    void shutdown.then(() => {
+      process.exitCode = 0;
+    }).catch((error: unknown) => {
+      console.error("scope_runtime_supervisor_shutdown_failed:",
+        error instanceof Error ? error.name : "UnknownError");
+      process.exitCode = 1;
+    });
+  };
+  process.once("SIGTERM", stop);
+  process.once("SIGINT", stop);
+}
+
+main().catch((error: unknown) => {
+  console.error("scope_runtime_supervisor_failed:", error instanceof Error ? error.name : "UnknownError");
+  process.exitCode = 1;
+});

--- a/packages/scope-runtime/src/profile.ts
+++ b/packages/scope-runtime/src/profile.ts
@@ -1,0 +1,98 @@
+import { createHash } from "node:crypto";
+import { SCOPE_RUNTIME_WORKER_HARNESS_VERSION } from "./worker.js";
+
+export const SCOPE_RUNTIME_PROFILE_ID = "scope-runtime-proof-v1";
+export const SCOPE_RUNTIME_PROFILE_VERSION = 1;
+export const SCOPE_RUNTIME_HARNESS_VERSION = SCOPE_RUNTIME_WORKER_HARNESS_VERSION;
+
+export const SCOPE_ROOT_TOKEN = "<scope-root>";
+export const SDK_DIRECTORY_TOKEN = "<sdk-directory>";
+export const NATIVE_DIRECTORY_TOKEN = "<native-directory>";
+export const WORKER_FILE_TOKEN = "<worker-file>";
+export const BROKER_SOCKET_TOKEN = "<broker-socket>";
+export const READINESS_FILE_TOKEN = "<readiness-file>";
+
+export const FIXED_SYSTEMD_PROPERTIES = [
+  "Type=exec",
+  "User=matrix-scope-workload",
+  "DynamicUser=yes",
+  "PrivateUsers=yes",
+  `RootDirectory=${SCOPE_ROOT_TOKEN}`,
+  "MountAPIVFS=yes",
+  "PrivateNetwork=yes",
+  "PrivateIPC=yes",
+  "PrivateTmp=yes",
+  "PrivateDevices=yes",
+  "ProtectProc=invisible",
+  "ProcSubset=pid",
+  "ProtectSystem=strict",
+  "ProtectHome=yes",
+  "ProtectKernelTunables=yes",
+  "ProtectKernelModules=yes",
+  "ProtectKernelLogs=yes",
+  "ProtectControlGroups=yes",
+  "ProtectClock=yes",
+  "ProtectHostname=yes",
+  "NoNewPrivileges=yes",
+  "CapabilityBoundingSet=",
+  "AmbientCapabilities=",
+  "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6",
+  "RestrictNamespaces=yes",
+  "RestrictRealtime=yes",
+  "RestrictSUIDSGID=yes",
+  "SystemCallArchitectures=native",
+  "MemoryMax=1073741824",
+  "CPUQuota=200%",
+  "TasksMax=256",
+  "TemporaryFileSystem=/workspace:rw,nosuid,nodev,size=10G,mode=1777",
+  "TemporaryFileSystem=/tmp:rw,nosuid,nodev,noexec,size=64M,mode=1777",
+  "BindReadOnlyPaths=/lib",
+  "BindReadOnlyPaths=/lib64",
+  "BindReadOnlyPaths=/usr/lib",
+  "BindReadOnlyPaths=/usr/bin/env",
+  "BindReadOnlyPaths=/opt/matrix/runtime/node",
+  `BindReadOnlyPaths=${SDK_DIRECTORY_TOKEN}:/opt/matrix/scope-sdk/sdk`,
+  `BindReadOnlyPaths=${NATIVE_DIRECTORY_TOKEN}:/opt/matrix/scope-sdk/native`,
+  `BindReadOnlyPaths=${WORKER_FILE_TOKEN}:/opt/matrix/scope-runtime/worker.mjs`,
+  `BindPaths=${BROKER_SOCKET_TOKEN}:/run/matrix-scope/broker.sock`,
+  `BindPaths=${READINESS_FILE_TOKEN}:/run/matrix-scope-readiness/ready`,
+  "WorkingDirectory=/workspace",
+  "UMask=0077",
+  "RuntimeMaxSec=90",
+  "TimeoutStopSec=10",
+] as const;
+
+export const FIXED_SYSTEMD_ENVIRONMENT = [
+  "HOME=/workspace",
+  "PATH=/opt/matrix/runtime/node/bin",
+  "MATRIX_SCOPE_RUNTIME=1",
+] as const;
+
+export const SCOPE_RUNTIME_PROFILE_DIGEST = createHash("sha256")
+  .update([...FIXED_SYSTEMD_PROPERTIES, ...FIXED_SYSTEMD_ENVIRONMENT].join("\n") + "\n")
+  .digest("hex");
+
+export interface ScopeRuntimeProfilePaths {
+  scopeRoot: string;
+  sdkDirectory: string;
+  nativeDirectory: string;
+  workerFile: string;
+  brokerSocket: string;
+  readinessFile: string;
+}
+
+export function materializeFixedSystemdProperties(paths: ScopeRuntimeProfilePaths): string[] {
+  const replacements: Readonly<Record<string, string>> = {
+    [SCOPE_ROOT_TOKEN]: paths.scopeRoot,
+    [SDK_DIRECTORY_TOKEN]: paths.sdkDirectory,
+    [NATIVE_DIRECTORY_TOKEN]: paths.nativeDirectory,
+    [WORKER_FILE_TOKEN]: paths.workerFile,
+    [BROKER_SOCKET_TOKEN]: paths.brokerSocket,
+    [READINESS_FILE_TOKEN]: paths.readinessFile,
+  };
+  return FIXED_SYSTEMD_PROPERTIES.map((property) => {
+    let result: string = property;
+    for (const [token, value] of Object.entries(replacements)) result = result.replace(token, value);
+    return result;
+  });
+}

--- a/packages/scope-runtime/src/protocol.ts
+++ b/packages/scope-runtime/src/protocol.ts
@@ -1,0 +1,124 @@
+import { z } from "zod/v4";
+
+const RequestIdSchema = z.string().uuid();
+const ProfileIdSchema = z.string().regex(/^[a-z][a-z0-9-]{0,63}$/);
+export const ScopeHandleSchema = z.string().regex(/^scope_[a-f0-9]{32}$/);
+export const RuntimeHandleSchema = z.string().regex(/^runtime_[a-f0-9]{32}$/);
+const AdapterIdSchema = z.string().regex(/^[a-z][a-z0-9-]{0,63}$/);
+const SemanticVersionSchema = z.string().regex(/^[0-9]+\.[0-9]+\.[0-9]+$/);
+const GenerationSchema = z.string().regex(/^(0|[1-9][0-9]{0,19})$/);
+const DigestSchema = z.string().regex(/^[a-f0-9]{64}$/);
+
+const CapabilityRequestSchema = z.object({
+  version: z.literal(1),
+  type: z.literal("capability.get"),
+  requestId: RequestIdSchema,
+}).strict();
+
+const RuntimeCreateRequestSchema = z.object({
+  version: z.literal(1),
+  type: z.literal("runtime.create"),
+  requestId: RequestIdSchema,
+  scopeHandle: ScopeHandleSchema,
+  profileId: ProfileIdSchema,
+  workload: z.enum(["chat_ai", "terminal"]),
+  adapterId: AdapterIdSchema,
+  harnessVersion: SemanticVersionSchema,
+}).strict();
+
+const RuntimeStopRequestSchema = z.object({
+  version: z.literal(1),
+  type: z.literal("runtime.stop"),
+  requestId: RequestIdSchema,
+  runtimeHandle: RuntimeHandleSchema,
+}).strict();
+
+export const ScopeRuntimeRequestSchema = z.discriminatedUnion("type", [
+  CapabilityRequestSchema,
+  RuntimeCreateRequestSchema,
+  RuntimeStopRequestSchema,
+]);
+
+const RuntimeLimitsSchema = z.object({
+  memoryMaxBytes: z.number().int().min(64 * 1024 * 1024).max(16 * 1024 * 1024 * 1024),
+  cpuQuotaPercent: z.number().int().min(1).max(800),
+  tasksMax: z.number().int().min(8).max(4096),
+  storageMaxBytes: z.number().int().min(64 * 1024 * 1024).max(1024 * 1024 * 1024 * 1024),
+}).strict();
+
+const CapabilityProfileSchema = z.object({
+  profileId: ProfileIdSchema,
+  profileVersion: z.number().int().min(1).max(1_000_000),
+  profileDigest: DigestSchema,
+  executionGeneration: GenerationSchema,
+  identity: z.discriminatedUnion("mode", [
+    z.object({
+      mode: z.literal("dynamic"),
+      uidMin: z.number().int().min(0).max(4_294_967_294),
+      uidMax: z.number().int().min(0).max(4_294_967_294),
+    }).strict(),
+    z.object({
+      mode: z.literal("static"),
+      uid: z.number().int().min(0).max(4_294_967_294),
+    }).strict(),
+  ]),
+  limits: RuntimeLimitsSchema,
+  adapters: z.array(z.object({
+    adapterId: AdapterIdSchema,
+    harnessVersion: SemanticVersionSchema,
+    workloads: z.array(z.enum(["chat_ai", "terminal"])).min(1).max(2),
+  }).strict()).min(1).max(16),
+}).strict();
+
+const CapabilityResultSchema = z.object({
+  version: z.literal(1),
+  type: z.literal("capability.result"),
+  requestId: RequestIdSchema,
+  ok: z.literal(true),
+  supervisorVersion: SemanticVersionSchema,
+  profile: CapabilityProfileSchema,
+}).strict();
+
+const CapabilityErrorSchema = z.object({
+  version: z.literal(1),
+  type: z.literal("capability.result"),
+  requestId: RequestIdSchema,
+  ok: z.literal(false),
+  error: z.enum(["invalid_request", "profile_unavailable", "runtime_unavailable"]),
+}).strict();
+
+const RuntimeResultSchema = z.object({
+  version: z.literal(1),
+  type: z.literal("runtime.result"),
+  requestId: RequestIdSchema,
+  ok: z.literal(true),
+  runtimeHandle: RuntimeHandleSchema,
+  executionGeneration: GenerationSchema,
+  state: z.enum(["running", "stopped"]),
+}).strict();
+
+const RuntimeErrorSchema = z.object({
+  version: z.literal(1),
+  type: z.literal("runtime.result"),
+  requestId: RequestIdSchema,
+  ok: z.literal(false),
+  error: z.enum([
+    "invalid_request",
+    "profile_unavailable",
+    "adapter_unavailable",
+    "capacity_exceeded",
+    "runtime_not_found",
+    "runtime_unavailable",
+  ]),
+}).strict();
+
+export const ScopeRuntimeResponseSchema = z.union([
+  CapabilityResultSchema,
+  CapabilityErrorSchema,
+  RuntimeResultSchema,
+  RuntimeErrorSchema,
+]);
+
+export type ScopeRuntimeRequest = z.infer<typeof ScopeRuntimeRequestSchema>;
+export type ScopeRuntimeResponse = z.infer<typeof ScopeRuntimeResponseSchema>;
+export type ScopeRuntimeCapabilityProfile = z.infer<typeof CapabilityProfileSchema>;

--- a/packages/scope-runtime/src/server.ts
+++ b/packages/scope-runtime/src/server.ts
@@ -1,0 +1,153 @@
+import { chmod, lstat, unlink } from "node:fs/promises";
+import { createServer, type Server, type Socket } from "node:net";
+import { ScopeRuntimeRequestSchema, type ScopeRuntimeRequest, type ScopeRuntimeResponse } from "./protocol.js";
+
+const MAX_FRAME_BYTES = 64 * 1024;
+const MAX_CONNECTIONS = 64;
+const MAX_REQUEST_TIMEOUT_MS = 60_000;
+const DEFAULT_OPERATION_TIMEOUT_MS = 30_000;
+
+interface ScopeRuntimeController {
+  handle(request: ScopeRuntimeRequest): Promise<ScopeRuntimeResponse>;
+  close(): Promise<void> | void;
+}
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+async function removeStaleSocket(socketPath: string): Promise<void> {
+  try {
+    const entry = await lstat(socketPath);
+    if (!entry.isSocket()) throw new Error("Scope runtime socket path is not a socket");
+    await unlink(socketPath);
+  } catch (error: unknown) {
+    if (!isNotFound(error)) throw error;
+  }
+}
+
+export function createScopeRuntimeServer(options: {
+  socketPath: string;
+  controller: ScopeRuntimeController;
+  maxConnections?: number;
+  requestTimeoutMs?: number;
+  operationTimeoutMs?: number;
+}) {
+  const maxConnections = Math.max(1, Math.min(
+    Math.trunc(options.maxConnections ?? MAX_CONNECTIONS),
+    MAX_CONNECTIONS,
+  ));
+  const requestTimeoutMs = Math.max(1, Math.min(
+    Math.trunc(options.requestTimeoutMs ?? 10_000),
+    MAX_REQUEST_TIMEOUT_MS,
+  ));
+  const operationTimeoutMs = Math.max(1, Math.min(
+    Math.trunc(options.operationTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS),
+    MAX_REQUEST_TIMEOUT_MS,
+  ));
+  const sockets = new Set<Socket>();
+  const operations = new Set<Promise<void>>();
+  let server: Server | undefined;
+  let closed = false;
+
+  function accept(socket: Socket): void {
+    if (closed || sockets.size >= maxConnections) {
+      socket.destroy();
+      return;
+    }
+    sockets.add(socket);
+    let input = "";
+    let oversized = false;
+    socket.setEncoding("utf8");
+    socket.setTimeout(requestTimeoutMs, () => socket.destroy());
+    socket.once("error", (error: unknown) => {
+      console.warn("[scope-runtime] supervisor socket failed:",
+        error instanceof Error ? error.name : "UnknownError");
+    });
+    socket.once("close", () => sockets.delete(socket));
+    socket.on("data", (chunk) => {
+      if (oversized) return;
+      input += chunk;
+      if (Buffer.byteLength(input, "utf8") > MAX_FRAME_BYTES) {
+        oversized = true;
+        input = "";
+        socket.destroy();
+      }
+    });
+    socket.once("end", () => {
+      if (oversized || closed) {
+        socket.destroy();
+        return;
+      }
+      socket.setTimeout(operationTimeoutMs, () => socket.destroy());
+      const operation = (async () => {
+        try {
+          const frames = input.split("\n").filter((frame) => frame.trim().length > 0);
+          if (frames.length !== 1) {
+            socket.destroy();
+            return;
+          }
+          const request = ScopeRuntimeRequestSchema.parse(JSON.parse(frames[0]!));
+          const response = await options.controller.handle(request);
+          if (!closed && !socket.destroyed) socket.end(`${JSON.stringify(response)}\n`);
+          else socket.destroy();
+        } catch (error: unknown) {
+          if (!(error instanceof SyntaxError)) {
+            console.warn("[scope-runtime] rejected supervisor request");
+          }
+          socket.destroy();
+        }
+      })();
+      operations.add(operation);
+      void operation.finally(() => operations.delete(operation)).catch((error: unknown) => {
+        console.warn("[scope-runtime] supervisor request cleanup failed:",
+          error instanceof Error ? error.name : "UnknownError");
+      });
+    });
+  }
+
+  return {
+    async start(): Promise<void> {
+      if (closed || server) throw new Error("Scope runtime server cannot start");
+      await removeStaleSocket(options.socketPath);
+      const candidate = createServer({ allowHalfOpen: true }, accept);
+      server = candidate;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          candidate.once("error", reject);
+          candidate.listen(options.socketPath, resolve);
+        });
+        await chmod(options.socketPath, 0o660);
+      } catch (error: unknown) {
+        server = undefined;
+        candidate.close();
+        throw error;
+      }
+    },
+    connectionCount(): number {
+      return sockets.size;
+    },
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      const current = server;
+      server = undefined;
+      const serverClosed = current
+        ? new Promise<void>((resolve) => current.close(() => resolve()))
+        : Promise.resolve();
+      for (const socket of sockets) socket.destroy();
+      await serverClosed;
+      await Promise.allSettled([...operations]);
+      await options.controller.close();
+      try {
+        const entry = await lstat(options.socketPath);
+        if (entry.isSocket()) await unlink(options.socketPath);
+      } catch (error: unknown) {
+        if (!isNotFound(error)) {
+          console.warn("[scope-runtime] supervisor socket cleanup failed:",
+            error instanceof Error ? error.name : "UnknownError");
+        }
+      }
+    },
+  };
+}

--- a/packages/scope-runtime/src/supervisor.ts
+++ b/packages/scope-runtime/src/supervisor.ts
@@ -15,6 +15,7 @@ import {
 } from "./profile.js";
 
 export const SCOPE_RUNTIME_SUPERVISOR_VERSION = "1.0.0";
+const EXECUTION_GENERATION = /^(0|[1-9][0-9]{0,19})$/;
 
 export const SCOPE_RUNTIME_PROFILE: Omit<ScopeRuntimeCapabilityProfile, "executionGeneration"> = {
   profileId: SCOPE_RUNTIME_PROFILE_ID,
@@ -40,10 +41,16 @@ export interface ScopeRuntimeLaunchRequest {
   workload: "chat_ai" | "terminal";
   adapterId: string;
   harnessVersion: string;
+  executionGeneration: string;
+}
+
+export interface ScopeRuntimeReconciledRuntime {
+  runtimeHandle: string;
+  executionGeneration: string;
 }
 
 export interface ScopeRuntimeLauncher {
-  list(): Promise<string[]>;
+  list(): Promise<ScopeRuntimeReconciledRuntime[]>;
   start(input: ScopeRuntimeLaunchRequest): Promise<void>;
   stop(runtimeHandle: string): Promise<void>;
 }
@@ -73,14 +80,20 @@ export async function createScopeRuntimeController(options: {
   createRuntimeHandle?: () => string;
 }) {
   const maxRuntimes = Math.max(1, Math.min(Math.trunc(options.maxRuntimes ?? 32), 32));
+  if (!EXECUTION_GENERATION.test(options.executionGeneration)) {
+    throw new Error("Invalid scope runtime execution generation");
+  }
   const createRuntimeHandle = options.createRuntimeHandle ?? newRuntimeHandle;
   const existing = await options.launcher.list();
   if (existing.length > maxRuntimes) throw new Error("Scope runtime reconciliation exceeds capacity");
-  const runtimes = new Set<string>();
+  const runtimes = new Map<string, string>();
   for (const value of existing) {
-    const runtimeHandle = RuntimeHandleSchema.parse(value);
+    const runtimeHandle = RuntimeHandleSchema.parse(value.runtimeHandle);
+    if (!EXECUTION_GENERATION.test(value.executionGeneration)) {
+      throw new Error("Invalid reconciled scope runtime generation");
+    }
     if (runtimes.has(runtimeHandle)) throw new Error("Duplicate reconciled scope runtime");
-    runtimes.add(runtimeHandle);
+    runtimes.set(runtimeHandle, value.executionGeneration);
   }
   const operations = new Set<Promise<void>>();
   let reservedCreates = 0;
@@ -118,6 +131,7 @@ export async function createScopeRuntimeController(options: {
       workload: request.workload,
       adapterId: request.adapterId,
       harnessVersion: request.harnessVersion,
+      executionGeneration: options.executionGeneration,
     });
     operations.add(operation);
     try {
@@ -131,7 +145,7 @@ export async function createScopeRuntimeController(options: {
         }
         return runtimeFailure(request.requestId, "runtime_unavailable");
       }
-      runtimes.add(runtimeHandle);
+      runtimes.set(runtimeHandle, options.executionGeneration);
       return ScopeRuntimeResponseSchema.parse({
         version: 1,
         type: "runtime.result",
@@ -154,7 +168,8 @@ export async function createScopeRuntimeController(options: {
   async function stopRuntime(
     request: Extract<ScopeRuntimeRequest, { type: "runtime.stop" }>,
   ): Promise<ScopeRuntimeResponse> {
-    if (!runtimes.has(request.runtimeHandle)) {
+    const executionGeneration = runtimes.get(request.runtimeHandle);
+    if (executionGeneration === undefined) {
       return runtimeFailure(request.requestId, "runtime_not_found");
     }
     try {
@@ -166,7 +181,7 @@ export async function createScopeRuntimeController(options: {
         requestId: request.requestId,
         ok: true,
         runtimeHandle: request.runtimeHandle,
-        executionGeneration: options.executionGeneration,
+        executionGeneration,
         state: "stopped",
       });
     } catch (error: unknown) {
@@ -211,7 +226,7 @@ export async function createScopeRuntimeController(options: {
       if (closed) return;
       closed = true;
       await Promise.allSettled([...operations]);
-      const stops = [...runtimes].map(async (runtimeHandle) => {
+      const stops = [...runtimes.keys()].map(async (runtimeHandle) => {
         try {
           await options.launcher.stop(runtimeHandle);
         } catch (error: unknown) {

--- a/packages/scope-runtime/src/supervisor.ts
+++ b/packages/scope-runtime/src/supervisor.ts
@@ -1,0 +1,227 @@
+import { randomBytes } from "node:crypto";
+import {
+  RuntimeHandleSchema,
+  ScopeRuntimeRequestSchema,
+  ScopeRuntimeResponseSchema,
+  type ScopeRuntimeCapabilityProfile,
+  type ScopeRuntimeRequest,
+  type ScopeRuntimeResponse,
+} from "./protocol.js";
+import {
+  SCOPE_RUNTIME_HARNESS_VERSION,
+  SCOPE_RUNTIME_PROFILE_DIGEST,
+  SCOPE_RUNTIME_PROFILE_ID,
+  SCOPE_RUNTIME_PROFILE_VERSION,
+} from "./profile.js";
+
+export const SCOPE_RUNTIME_SUPERVISOR_VERSION = "1.0.0";
+
+export const SCOPE_RUNTIME_PROFILE: Omit<ScopeRuntimeCapabilityProfile, "executionGeneration"> = {
+  profileId: SCOPE_RUNTIME_PROFILE_ID,
+  profileVersion: SCOPE_RUNTIME_PROFILE_VERSION,
+  profileDigest: SCOPE_RUNTIME_PROFILE_DIGEST,
+  identity: { mode: "dynamic", uidMin: 61_184, uidMax: 65_519 },
+  limits: {
+    memoryMaxBytes: 1_073_741_824,
+    cpuQuotaPercent: 200,
+    tasksMax: 256,
+    storageMaxBytes: 10_737_418_240,
+  },
+  adapters: [{
+    adapterId: "claude-code",
+    harnessVersion: SCOPE_RUNTIME_HARNESS_VERSION,
+    workloads: ["chat_ai"],
+  }],
+};
+
+export interface ScopeRuntimeLaunchRequest {
+  runtimeHandle: string;
+  scopeHandle: string;
+  workload: "chat_ai" | "terminal";
+  adapterId: string;
+  harnessVersion: string;
+}
+
+export interface ScopeRuntimeLauncher {
+  list(): Promise<string[]>;
+  start(input: ScopeRuntimeLaunchRequest): Promise<void>;
+  stop(runtimeHandle: string): Promise<void>;
+}
+
+function newRuntimeHandle(): string {
+  return `runtime_${randomBytes(16).toString("hex")}`;
+}
+
+function runtimeFailure(
+  requestId: string,
+  error: "profile_unavailable" | "adapter_unavailable" | "capacity_exceeded"
+    | "runtime_not_found" | "runtime_unavailable",
+): ScopeRuntimeResponse {
+  return ScopeRuntimeResponseSchema.parse({
+    version: 1,
+    type: "runtime.result",
+    requestId,
+    ok: false,
+    error,
+  });
+}
+
+export async function createScopeRuntimeController(options: {
+  launcher: ScopeRuntimeLauncher;
+  executionGeneration: string;
+  maxRuntimes?: number;
+  createRuntimeHandle?: () => string;
+}) {
+  const maxRuntimes = Math.max(1, Math.min(Math.trunc(options.maxRuntimes ?? 32), 32));
+  const createRuntimeHandle = options.createRuntimeHandle ?? newRuntimeHandle;
+  const existing = await options.launcher.list();
+  if (existing.length > maxRuntimes) throw new Error("Scope runtime reconciliation exceeds capacity");
+  const runtimes = new Set<string>();
+  for (const value of existing) {
+    const runtimeHandle = RuntimeHandleSchema.parse(value);
+    if (runtimes.has(runtimeHandle)) throw new Error("Duplicate reconciled scope runtime");
+    runtimes.add(runtimeHandle);
+  }
+  const operations = new Set<Promise<void>>();
+  let reservedCreates = 0;
+  let closed = false;
+
+  async function createRuntime(
+    request: Extract<ScopeRuntimeRequest, { type: "runtime.create" }>,
+  ): Promise<ScopeRuntimeResponse> {
+    if (request.profileId !== SCOPE_RUNTIME_PROFILE.profileId) {
+      return runtimeFailure(request.requestId, "profile_unavailable");
+    }
+    const adapter = SCOPE_RUNTIME_PROFILE.adapters.find((candidate) =>
+      candidate.adapterId === request.adapterId
+      && candidate.harnessVersion === request.harnessVersion
+      && candidate.workloads.includes(request.workload));
+    if (!adapter) return runtimeFailure(request.requestId, "adapter_unavailable");
+    if (runtimes.size + reservedCreates >= maxRuntimes) {
+      return runtimeFailure(request.requestId, "capacity_exceeded");
+    }
+
+    let runtimeHandle: string | undefined;
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const candidate = RuntimeHandleSchema.parse(createRuntimeHandle());
+      if (!runtimes.has(candidate)) {
+        runtimeHandle = candidate;
+        break;
+      }
+    }
+    if (!runtimeHandle) return runtimeFailure(request.requestId, "runtime_unavailable");
+
+    reservedCreates += 1;
+    const operation = options.launcher.start({
+      runtimeHandle,
+      scopeHandle: request.scopeHandle,
+      workload: request.workload,
+      adapterId: request.adapterId,
+      harnessVersion: request.harnessVersion,
+    });
+    operations.add(operation);
+    try {
+      await operation;
+      if (closed) {
+        try {
+          await options.launcher.stop(runtimeHandle);
+        } catch (error: unknown) {
+          console.warn("[scope-runtime] post-close runtime cleanup failed:",
+            error instanceof Error ? error.name : "UnknownError");
+        }
+        return runtimeFailure(request.requestId, "runtime_unavailable");
+      }
+      runtimes.add(runtimeHandle);
+      return ScopeRuntimeResponseSchema.parse({
+        version: 1,
+        type: "runtime.result",
+        requestId: request.requestId,
+        ok: true,
+        runtimeHandle,
+        executionGeneration: options.executionGeneration,
+        state: "running",
+      });
+    } catch (error: unknown) {
+      console.warn("[scope-runtime] fixed-profile launch failed:",
+        error instanceof Error ? error.name : "UnknownError");
+      return runtimeFailure(request.requestId, "runtime_unavailable");
+    } finally {
+      reservedCreates -= 1;
+      operations.delete(operation);
+    }
+  }
+
+  async function stopRuntime(
+    request: Extract<ScopeRuntimeRequest, { type: "runtime.stop" }>,
+  ): Promise<ScopeRuntimeResponse> {
+    if (!runtimes.has(request.runtimeHandle)) {
+      return runtimeFailure(request.requestId, "runtime_not_found");
+    }
+    try {
+      await options.launcher.stop(request.runtimeHandle);
+      runtimes.delete(request.runtimeHandle);
+      return ScopeRuntimeResponseSchema.parse({
+        version: 1,
+        type: "runtime.result",
+        requestId: request.requestId,
+        ok: true,
+        runtimeHandle: request.runtimeHandle,
+        executionGeneration: options.executionGeneration,
+        state: "stopped",
+      });
+    } catch (error: unknown) {
+      console.warn("[scope-runtime] fixed-profile stop failed:",
+        error instanceof Error ? error.name : "UnknownError");
+      return runtimeFailure(request.requestId, "runtime_unavailable");
+    }
+  }
+
+  return {
+    async handle(input: ScopeRuntimeRequest): Promise<ScopeRuntimeResponse> {
+      const request = ScopeRuntimeRequestSchema.parse(input);
+      if (closed) {
+        return request.type === "capability.get"
+          ? ScopeRuntimeResponseSchema.parse({
+              version: 1,
+              type: "capability.result",
+              requestId: request.requestId,
+              ok: false,
+              error: "runtime_unavailable",
+            })
+          : runtimeFailure(request.requestId, "runtime_unavailable");
+      }
+      if (request.type === "capability.get") {
+        return ScopeRuntimeResponseSchema.parse({
+          version: 1,
+          type: "capability.result",
+          requestId: request.requestId,
+          ok: true,
+          supervisorVersion: SCOPE_RUNTIME_SUPERVISOR_VERSION,
+          profile: { ...SCOPE_RUNTIME_PROFILE, executionGeneration: options.executionGeneration },
+        });
+      }
+      return request.type === "runtime.create"
+        ? createRuntime(request)
+        : stopRuntime(request);
+    },
+    size(): number {
+      return runtimes.size;
+    },
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      await Promise.allSettled([...operations]);
+      const stops = [...runtimes].map(async (runtimeHandle) => {
+        try {
+          await options.launcher.stop(runtimeHandle);
+        } catch (error: unknown) {
+          console.warn("[scope-runtime] shutdown stop failed:",
+            error instanceof Error ? error.name : "UnknownError");
+        } finally {
+          runtimes.delete(runtimeHandle);
+        }
+      });
+      await Promise.all(stops);
+    },
+  };
+}

--- a/packages/scope-runtime/src/systemd-launcher.ts
+++ b/packages/scope-runtime/src/systemd-launcher.ts
@@ -1,0 +1,437 @@
+import { randomBytes } from "node:crypto";
+import { execFile } from "node:child_process";
+import {
+  access,
+  chmod,
+  lstat,
+  mkdir,
+  opendir,
+  open,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+  constants,
+} from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
+import { promisify } from "node:util";
+import { RuntimeHandleSchema, ScopeHandleSchema } from "./protocol.js";
+import {
+  FIXED_SYSTEMD_ENVIRONMENT,
+  SCOPE_RUNTIME_HARNESS_VERSION,
+  materializeFixedSystemdProperties,
+  type ScopeRuntimeProfilePaths,
+} from "./profile.js";
+import type { ScopeRuntimeLaunchRequest, ScopeRuntimeLauncher } from "./supervisor.js";
+import { scopeRuntimeWorkerFailureForExitCode } from "./worker.js";
+
+const execFileAsync = promisify(execFile);
+const COMMAND_TIMEOUT_MS = 10_000;
+const COMMAND_MAX_BUFFER_BYTES = 64 * 1024;
+const UNIT_PREFIX = "matrix-scope-runtime-";
+const READINESS_RELATIVE_PATH = "run/matrix-scope-readiness/ready";
+const MAX_RECONCILED_ENTRIES = 128;
+
+export interface ScopeRuntimeCommandRunner {
+  (command: string, args: readonly string[]): Promise<{ stdout: string }>;
+}
+
+interface LauncherPaths {
+  stateRoot: string;
+  sdkDirectory: string;
+  nativeDirectory: string;
+  workerFile: string;
+  brokerSocket: string;
+  nodeBinary?: string;
+}
+
+function unitName(runtimeHandle: string): string {
+  return `${UNIT_PREFIX}${RuntimeHandleSchema.parse(runtimeHandle).slice("runtime_".length)}.service`;
+}
+
+function assertTrustedAbsolutePath(value: string): string {
+  if (!isAbsolute(value) || value.includes("\0") || value.includes("\n") || value.includes("\r")) {
+    throw new Error("Invalid scope runtime host path");
+  }
+  return value;
+}
+
+export function buildFixedSystemdRunArgs(
+  input: ScopeRuntimeLaunchRequest,
+  paths: ScopeRuntimeProfilePaths & { nodeBinary: string },
+): string[] {
+  const runtimeHandle = RuntimeHandleSchema.parse(input.runtimeHandle);
+  const scopeHandle = ScopeHandleSchema.parse(input.scopeHandle);
+  if (input.workload !== "chat_ai" || input.adapterId !== "claude-code"
+    || input.harnessVersion !== SCOPE_RUNTIME_HARNESS_VERSION) {
+    throw new Error("Unsupported scope runtime adapter");
+  }
+  const properties = materializeFixedSystemdProperties({
+    scopeRoot: assertTrustedAbsolutePath(paths.scopeRoot),
+    sdkDirectory: assertTrustedAbsolutePath(paths.sdkDirectory),
+    nativeDirectory: assertTrustedAbsolutePath(paths.nativeDirectory),
+    workerFile: assertTrustedAbsolutePath(paths.workerFile),
+    brokerSocket: assertTrustedAbsolutePath(paths.brokerSocket),
+    readinessFile: assertTrustedAbsolutePath(paths.readinessFile),
+  });
+  return [
+    `--unit=${unitName(runtimeHandle)}`,
+    "--quiet",
+    "--no-block",
+    ...properties.map((property) => `--property=${property}`),
+    ...FIXED_SYSTEMD_ENVIRONMENT.map((entry) => `--setenv=${entry}`),
+    "--",
+    "/usr/bin/env",
+    "-i",
+    ...FIXED_SYSTEMD_ENVIRONMENT,
+    assertTrustedAbsolutePath(paths.nodeBinary),
+    "/opt/matrix/scope-runtime/worker.mjs",
+    runtimeHandle,
+    scopeHandle,
+    input.workload,
+    input.adapterId,
+    input.harnessVersion,
+  ];
+}
+
+async function defaultRunCommand(command: string, args: readonly string[]): Promise<{ stdout: string }> {
+  const result = await execFileAsync(command, [...args], {
+    encoding: "utf8",
+    timeout: COMMAND_TIMEOUT_MS,
+    maxBuffer: COMMAND_MAX_BUFFER_BYTES,
+    killSignal: "SIGKILL",
+  });
+  return { stdout: result.stdout };
+}
+
+async function assertPrivateDirectory(path: string): Promise<void> {
+  const entry = await lstat(path);
+  if (!entry.isDirectory() || entry.isSymbolicLink()) throw new Error("Unsafe scope runtime state directory");
+}
+
+async function prepareRuntimeRoot(
+  stateRoot: string,
+  runtimeHandle: string,
+): Promise<{ root: string; readinessFile: string }> {
+  const suffix = RuntimeHandleSchema.parse(runtimeHandle).slice("runtime_".length);
+  await mkdir(stateRoot, { recursive: true, mode: 0o700 });
+  await chmod(stateRoot, 0o700);
+  await assertPrivateDirectory(stateRoot);
+  const runtimesRoot = join(stateRoot, "runtimes");
+  await mkdir(runtimesRoot, { recursive: true, mode: 0o700 });
+  await assertPrivateDirectory(runtimesRoot);
+  const runtimeRoot = join(runtimesRoot, suffix);
+  await mkdir(runtimeRoot, { mode: 0o700 });
+  await assertPrivateDirectory(runtimeRoot);
+  const root = join(runtimeRoot, "root");
+  await mkdir(root, { mode: 0o755 });
+  await chmod(root, 0o755);
+  const directories = [
+    "dev",
+    "lib",
+    "lib64",
+    "opt",
+    "opt/matrix",
+    "opt/matrix/runtime",
+    "opt/matrix/scope-sdk",
+    "opt/matrix/scope-sdk/native",
+    "opt/matrix/scope-sdk/sdk",
+    "opt/matrix/scope-runtime",
+    "proc",
+    "run",
+    "run/matrix-scope",
+    "run/matrix-scope-readiness",
+    "sys",
+    "tmp",
+    "usr",
+    "usr/bin",
+    "usr/lib",
+    "workspace",
+  ];
+  for (const relative of directories) {
+    const directory = join(root, relative);
+    await mkdir(directory, { recursive: true, mode: 0o755 });
+    await chmod(directory, 0o755);
+  }
+  const readinessFile = join(runtimeRoot, "ready");
+  const readinessHandle = await open(readinessFile, "wx", 0o622);
+  await readinessHandle.close();
+  await chmod(readinessFile, 0o622);
+  const readinessTarget = join(root, READINESS_RELATIVE_PATH);
+  const readinessTargetHandle = await open(readinessTarget, "wx", 0o644);
+  await readinessTargetHandle.close();
+  await chmod(readinessTarget, 0o644);
+  const workerTarget = join(root, "opt/matrix/scope-runtime/worker.mjs");
+  const workerHandle = await open(workerTarget, "wx", 0o644);
+  await workerHandle.close();
+  const environmentTarget = join(root, "usr/bin/env");
+  const environmentHandle = await open(environmentTarget, "wx", 0o755);
+  await environmentHandle.close();
+  await chmod(environmentTarget, 0o755);
+  const brokerTarget = join(root, "run/matrix-scope/broker.sock");
+  const handle = await open(brokerTarget, "wx", 0o600);
+  await handle.close();
+  return { root, readinessFile };
+}
+
+async function validateRuntimeSources(paths: Required<LauncherPaths>): Promise<{
+  sdkDirectory: string;
+  nativeDirectory: string;
+  workerFile: string;
+}> {
+  const broker = await lstat(paths.brokerSocket);
+  if (!broker.isSocket() || broker.isSymbolicLink()) throw new Error("Scope runtime broker unavailable");
+  const worker = await lstat(paths.workerFile);
+  if (!worker.isFile() || worker.isSymbolicLink()) throw new Error("Scope runtime worker unavailable");
+  const sdkDirectory = await realpath(paths.sdkDirectory);
+  const nativeDirectory = await realpath(paths.nativeDirectory);
+  const workerFile = await realpath(paths.workerFile);
+  await access(join(sdkDirectory, "sdk.mjs"), constants.R_OK);
+  await access(join(nativeDirectory, "claude"), constants.X_OK);
+  await access("/usr/bin/env", constants.X_OK);
+  await access(paths.nodeBinary, constants.X_OK);
+  return { sdkDirectory, nativeDirectory, workerFile };
+}
+
+function inactiveUnitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code: unknown = (error as { code?: unknown }).code;
+  return code === 3 || code === 4;
+}
+
+async function waitUntilActive(runCommand: ScopeRuntimeCommandRunner, name: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      await runCommand("/usr/bin/systemctl", ["is-active", "--quiet", name]);
+      return;
+    } catch (error: unknown) {
+      lastError = error;
+      if (!inactiveUnitError(error)) throw error;
+      const { stdout } = await runCommand("/usr/bin/systemctl", [
+        "show", name, "--property=Result", "--property=ExecMainStatus",
+      ]);
+      const status = /^ExecMainStatus=([1-9][0-9]{0,2})$/m.exec(stdout)?.[1];
+      if (status) {
+        const workerFailureName = scopeRuntimeWorkerFailureForExitCode(Number(status));
+        const activationError = new Error("Scope runtime activation failed");
+        activationError.name = workerFailureName ?? `ScopeRuntimeActivationStatus${status}Error`;
+        throw activationError;
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("Scope runtime did not activate");
+}
+
+async function readinessPublished(path: string, runtimeHandle: string): Promise<boolean> {
+  let handle;
+  try {
+    handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (error: unknown) {
+    if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.size > 128) throw new Error("Invalid scope runtime readiness marker");
+    const buffer = Buffer.alloc(128);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).toString("utf8") === `${runtimeHandle}\n`;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function waitUntilReady(
+  runCommand: ScopeRuntimeCommandRunner,
+  name: string,
+  readinessPath: string,
+  runtimeHandle: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    await waitUntilActive(runCommand, name);
+    if (await readinessPublished(readinessPath, runtimeHandle)) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("Scope runtime worker readiness unavailable");
+}
+
+async function cleanupSubmittedUnit(
+  runCommand: ScopeRuntimeCommandRunner,
+  name: string,
+): Promise<boolean> {
+  let cleaned = true;
+  for (const action of ["stop", "reset-failed"] as const) {
+    try {
+      await runCommand("/usr/bin/systemctl", [action, name]);
+    } catch (error: unknown) {
+      if (!inactiveUnitError(error)) {
+        cleaned = false;
+        console.warn("[scope-runtime] submitted-unit cleanup failed:",
+          error instanceof Error ? error.name : "UnknownError");
+      }
+    }
+  }
+  return cleaned;
+}
+
+async function cleanupOrphanedRuntimeRoots(
+  stateRoot: string,
+  retainedSuffixes: ReadonlySet<string>,
+): Promise<void> {
+  const runtimesRoot = join(stateRoot, "runtimes");
+  let directory;
+  try {
+    directory = await opendir(runtimesRoot);
+  } catch (error: unknown) {
+    if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  let count = 0;
+  for await (const entry of directory) {
+    count += 1;
+    if (count > MAX_RECONCILED_ENTRIES) throw new Error("Scope runtime reconciliation exceeds capacity");
+    if (!/^[a-f0-9]{32}$/.test(entry.name) || !entry.isDirectory() || entry.isSymbolicLink()) {
+      throw new Error("Unsafe reconciled scope runtime root");
+    }
+    if (!retainedSuffixes.has(entry.name)) {
+      await rm(join(runtimesRoot, entry.name), { recursive: true, force: true });
+    }
+  }
+}
+
+export function createSystemdScopeRuntimeLauncher(
+  input: LauncherPaths & { runCommand?: ScopeRuntimeCommandRunner },
+): ScopeRuntimeLauncher {
+  const paths: Required<LauncherPaths> = {
+    stateRoot: assertTrustedAbsolutePath(input.stateRoot),
+    sdkDirectory: assertTrustedAbsolutePath(input.sdkDirectory),
+    nativeDirectory: assertTrustedAbsolutePath(input.nativeDirectory),
+    workerFile: assertTrustedAbsolutePath(input.workerFile),
+    brokerSocket: assertTrustedAbsolutePath(input.brokerSocket),
+    nodeBinary: assertTrustedAbsolutePath(input.nodeBinary ?? "/opt/matrix/runtime/node/bin/node"),
+  };
+  const runCommand = input.runCommand ?? defaultRunCommand;
+
+  return {
+    async list(): Promise<string[]> {
+      const { stdout } = await runCommand("/usr/bin/systemctl", [
+        "list-units",
+        "--type=service",
+        "--all",
+        "--plain",
+        "--no-legend",
+        `${UNIT_PREFIX}*.service`,
+      ]);
+      const handles: string[] = [];
+      const retainedSuffixes = new Set<string>();
+      let entries = 0;
+      for (const line of stdout.split("\n")) {
+        const [name, , activeState] = line.trim().split(/\s+/, 4);
+        if (!name) continue;
+        entries += 1;
+        if (entries > MAX_RECONCILED_ENTRIES) throw new Error("Scope runtime reconciliation exceeds capacity");
+        const match = /^matrix-scope-runtime-([a-f0-9]{32})\.service$/.exec(name);
+        if (!match) throw new Error("Invalid reconciled scope runtime unit");
+        const suffix = match[1]!;
+        const runtimeHandle = RuntimeHandleSchema.parse(`runtime_${suffix}`);
+        const ready = activeState === "active" && await readinessPublished(
+          join(paths.stateRoot, "runtimes", suffix, "ready"),
+          runtimeHandle,
+        );
+        if (!ready) {
+          if (!await cleanupSubmittedUnit(runCommand, name)) {
+            throw new Error("Scope runtime reconciliation cleanup unavailable");
+          }
+          await rm(join(paths.stateRoot, "runtimes", suffix), { recursive: true, force: true });
+          continue;
+        }
+        retainedSuffixes.add(suffix);
+        handles.push(runtimeHandle);
+        if (handles.length > 32) throw new Error("Scope runtime reconciliation exceeds capacity");
+      }
+      await cleanupOrphanedRuntimeRoots(paths.stateRoot, retainedSuffixes);
+      return handles;
+    },
+    async start(request: ScopeRuntimeLaunchRequest): Promise<void> {
+      const { root, readinessFile } = await prepareRuntimeRoot(paths.stateRoot, request.runtimeHandle);
+      let submitted = false;
+      try {
+        const sources = await validateRuntimeSources(paths);
+        const args = buildFixedSystemdRunArgs(request, {
+          scopeRoot: root,
+          sdkDirectory: sources.sdkDirectory,
+          nativeDirectory: sources.nativeDirectory,
+          workerFile: sources.workerFile,
+          brokerSocket: paths.brokerSocket,
+          readinessFile,
+          nodeBinary: paths.nodeBinary,
+        });
+        submitted = true;
+        await runCommand("/usr/bin/systemd-run", args);
+        await waitUntilReady(
+          runCommand,
+          unitName(request.runtimeHandle),
+          readinessFile,
+          request.runtimeHandle,
+        );
+      } catch (error: unknown) {
+        const cleaned = !submitted
+          || await cleanupSubmittedUnit(runCommand, unitName(request.runtimeHandle));
+        if (cleaned) await rm(dirname(root), { recursive: true, force: true });
+        throw error;
+      }
+    },
+    async stop(runtimeHandle: string): Promise<void> {
+      const handle = RuntimeHandleSchema.parse(runtimeHandle);
+      const name = unitName(handle);
+      try {
+        await runCommand("/usr/bin/systemctl", ["is-active", "--quiet", name]);
+        await runCommand("/usr/bin/systemctl", ["stop", name]);
+      } catch (error: unknown) {
+        if (!inactiveUnitError(error)) throw error;
+      }
+      try {
+        await runCommand("/usr/bin/systemctl", ["reset-failed", name]);
+      } catch (error: unknown) {
+        if (!inactiveUnitError(error)) {
+          console.warn("[scope-runtime] failed-unit cleanup unavailable:",
+            error instanceof Error ? error.name : "UnknownError");
+        }
+      }
+      const suffix = handle.slice("runtime_".length);
+      await rm(join(paths.stateRoot, "runtimes", suffix), { recursive: true, force: true });
+    },
+  };
+}
+
+export async function nextExecutionGeneration(path: string): Promise<string> {
+  const target = assertTrustedAbsolutePath(path);
+  await mkdir(dirname(target), { recursive: true, mode: 0o700 });
+  let current = 0n;
+  try {
+    const raw = (await readFile(target, "utf8")).trim();
+    if (!/^(0|[1-9][0-9]{0,19})$/.test(raw)) throw new Error("Invalid execution generation");
+    current = BigInt(raw);
+  } catch (error: unknown) {
+    if (!(error instanceof Error) || (error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  const next = current + 1n;
+  if (next > 9_999_999_999_999_999_999n) throw new Error("Execution generation exhausted");
+  const temporary = `${target}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  try {
+    await writeFile(temporary, `${next}\n`, { flag: "wx", mode: 0o600 });
+    await rename(temporary, target);
+  } catch (error: unknown) {
+    try {
+      await rm(temporary, { force: true });
+    } catch (cleanupError: unknown) {
+      console.warn("[scope-runtime] generation temp cleanup failed:",
+        cleanupError instanceof Error ? cleanupError.name : "UnknownError");
+    }
+    throw error;
+  }
+  return String(next);
+}

--- a/packages/scope-runtime/src/systemd-launcher.ts
+++ b/packages/scope-runtime/src/systemd-launcher.ts
@@ -20,10 +20,17 @@ import { RuntimeHandleSchema, ScopeHandleSchema } from "./protocol.js";
 import {
   FIXED_SYSTEMD_ENVIRONMENT,
   SCOPE_RUNTIME_HARNESS_VERSION,
+  SCOPE_RUNTIME_PROFILE_DIGEST,
+  SCOPE_RUNTIME_PROFILE_ID,
+  SCOPE_RUNTIME_PROFILE_VERSION,
   materializeFixedSystemdProperties,
   type ScopeRuntimeProfilePaths,
 } from "./profile.js";
-import type { ScopeRuntimeLaunchRequest, ScopeRuntimeLauncher } from "./supervisor.js";
+import type {
+  ScopeRuntimeLaunchRequest,
+  ScopeRuntimeLauncher,
+  ScopeRuntimeReconciledRuntime,
+} from "./supervisor.js";
 import { scopeRuntimeWorkerFailureForExitCode } from "./worker.js";
 
 const execFileAsync = promisify(execFile);
@@ -31,7 +38,10 @@ const COMMAND_TIMEOUT_MS = 10_000;
 const COMMAND_MAX_BUFFER_BYTES = 64 * 1024;
 const UNIT_PREFIX = "matrix-scope-runtime-";
 const READINESS_RELATIVE_PATH = "run/matrix-scope-readiness/ready";
+const PROVENANCE_FILE = "provenance.json";
 const MAX_RECONCILED_ENTRIES = 128;
+const MAX_PROVENANCE_BYTES = 2_048;
+const EXECUTION_GENERATION = /^(0|[1-9][0-9]{0,19})$/;
 
 export interface ScopeRuntimeCommandRunner {
   (command: string, args: readonly string[]): Promise<{ stdout: string }>;
@@ -112,8 +122,9 @@ async function assertPrivateDirectory(path: string): Promise<void> {
 
 async function prepareRuntimeRoot(
   stateRoot: string,
-  runtimeHandle: string,
+  request: ScopeRuntimeLaunchRequest,
 ): Promise<{ root: string; readinessFile: string }> {
+  const runtimeHandle = RuntimeHandleSchema.parse(request.runtimeHandle);
   const suffix = RuntimeHandleSchema.parse(runtimeHandle).slice("runtime_".length);
   await mkdir(stateRoot, { recursive: true, mode: 0o700 });
   await chmod(stateRoot, 0o700);
@@ -158,6 +169,22 @@ async function prepareRuntimeRoot(
   const readinessHandle = await open(readinessFile, "wx", 0o622);
   await readinessHandle.close();
   await chmod(readinessFile, 0o622);
+  const provenance = `${JSON.stringify({
+    version: 1,
+    runtimeHandle,
+    profileId: SCOPE_RUNTIME_PROFILE_ID,
+    profileVersion: SCOPE_RUNTIME_PROFILE_VERSION,
+    profileDigest: SCOPE_RUNTIME_PROFILE_DIGEST,
+    workload: request.workload,
+    adapterId: request.adapterId,
+    harnessVersion: request.harnessVersion,
+    executionGeneration: request.executionGeneration,
+  })}\n`;
+  if (Buffer.byteLength(provenance) > MAX_PROVENANCE_BYTES
+    || !EXECUTION_GENERATION.test(request.executionGeneration)) {
+    throw new Error("Invalid scope runtime provenance");
+  }
+  await writeFile(join(runtimeRoot, PROVENANCE_FILE), provenance, { flag: "wx", mode: 0o600 });
   const readinessTarget = join(root, READINESS_RELATIVE_PATH);
   const readinessTargetHandle = await open(readinessTarget, "wx", 0o644);
   await readinessTargetHandle.close();
@@ -173,6 +200,45 @@ async function prepareRuntimeRoot(
   const handle = await open(brokerTarget, "wx", 0o600);
   await handle.close();
   return { root, readinessFile };
+}
+
+async function readRuntimeProvenance(
+  runtimeRoot: string,
+  runtimeHandle: string,
+): Promise<ScopeRuntimeReconciledRuntime | undefined> {
+  let handle;
+  try {
+    handle = await open(join(runtimeRoot, PROVENANCE_FILE), constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (error: unknown) {
+    if (error instanceof Error && ["ENOENT", "ELOOP"].includes(
+      String((error as NodeJS.ErrnoException).code),
+    )) return undefined;
+    throw error;
+  }
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.size < 1 || metadata.size > MAX_PROVENANCE_BYTES) return undefined;
+    const parsed: unknown = JSON.parse(await handle.readFile("utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const value = parsed as Record<string, unknown>;
+    if (Object.keys(value).length !== 9
+      || value.version !== 1
+      || value.runtimeHandle !== runtimeHandle
+      || value.profileId !== SCOPE_RUNTIME_PROFILE_ID
+      || value.profileVersion !== SCOPE_RUNTIME_PROFILE_VERSION
+      || value.profileDigest !== SCOPE_RUNTIME_PROFILE_DIGEST
+      || value.workload !== "chat_ai"
+      || value.adapterId !== "claude-code"
+      || value.harnessVersion !== SCOPE_RUNTIME_HARNESS_VERSION
+      || typeof value.executionGeneration !== "string"
+      || !EXECUTION_GENERATION.test(value.executionGeneration)) return undefined;
+    return { runtimeHandle, executionGeneration: value.executionGeneration };
+  } catch (error: unknown) {
+    if (error instanceof SyntaxError) return undefined;
+    throw error;
+  } finally {
+    await handle.close();
+  }
 }
 
 async function validateRuntimeSources(paths: Required<LauncherPaths>): Promise<{
@@ -316,7 +382,7 @@ export function createSystemdScopeRuntimeLauncher(
   const runCommand = input.runCommand ?? defaultRunCommand;
 
   return {
-    async list(): Promise<string[]> {
+    async list(): Promise<ScopeRuntimeReconciledRuntime[]> {
       const { stdout } = await runCommand("/usr/bin/systemctl", [
         "list-units",
         "--type=service",
@@ -325,7 +391,7 @@ export function createSystemdScopeRuntimeLauncher(
         "--no-legend",
         `${UNIT_PREFIX}*.service`,
       ]);
-      const handles: string[] = [];
+      const handles: ScopeRuntimeReconciledRuntime[] = [];
       const retainedSuffixes = new Set<string>();
       let entries = 0;
       for (const line of stdout.split("\n")) {
@@ -341,7 +407,10 @@ export function createSystemdScopeRuntimeLauncher(
           join(paths.stateRoot, "runtimes", suffix, "ready"),
           runtimeHandle,
         );
-        if (!ready) {
+        const provenance = ready
+          ? await readRuntimeProvenance(join(paths.stateRoot, "runtimes", suffix), runtimeHandle)
+          : undefined;
+        if (!provenance) {
           if (!await cleanupSubmittedUnit(runCommand, name)) {
             throw new Error("Scope runtime reconciliation cleanup unavailable");
           }
@@ -349,14 +418,14 @@ export function createSystemdScopeRuntimeLauncher(
           continue;
         }
         retainedSuffixes.add(suffix);
-        handles.push(runtimeHandle);
+        handles.push(provenance);
         if (handles.length > 32) throw new Error("Scope runtime reconciliation exceeds capacity");
       }
       await cleanupOrphanedRuntimeRoots(paths.stateRoot, retainedSuffixes);
       return handles;
     },
     async start(request: ScopeRuntimeLaunchRequest): Promise<void> {
-      const { root, readinessFile } = await prepareRuntimeRoot(paths.stateRoot, request.runtimeHandle);
+      const { root, readinessFile } = await prepareRuntimeRoot(paths.stateRoot, request);
       let submitted = false;
       try {
         const sources = await validateRuntimeSources(paths);

--- a/packages/scope-runtime/src/worker.ts
+++ b/packages/scope-runtime/src/worker.ts
@@ -1,0 +1,237 @@
+import { access, constants, lstat, open } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const SCOPE_RUNTIME_WORKER_HARNESS_VERSION = "2.1.240";
+
+const RUNTIME_HANDLE = /^runtime_[a-f0-9]{32}$/;
+const SCOPE_HANDLE = /^scope_[a-f0-9]{32}$/;
+
+const SENSITIVE_ENVIRONMENT_KEY = /(?:^|_)(?:API_?KEY|AUTH_?TOKEN|TOKEN|SECRET|PASSWORD|CREDENTIAL|DATABASE_URL)(?:$|_)/i;
+const FORBIDDEN_PATHS = [
+  "/home/matrix/home",
+  "/opt/matrix/env",
+  "/run/systemd/private",
+  "/run/postgresql",
+  "/var/run/docker.sock",
+] as const;
+const READINESS_DIRECTORY = "/run/matrix-scope-readiness";
+const FIXED_ENVIRONMENT_SENTINEL = "--matrix-scope-fixed-environment";
+const FIXED_WORKER_ENVIRONMENT = Object.freeze({
+  HOME: "/workspace",
+  PATH: "/opt/matrix/runtime/node/bin",
+  MATRIX_SCOPE_RUNTIME: "1",
+});
+export const SCOPE_RUNTIME_WORKER_FAILURE_EXIT_CODES = Object.freeze({
+  ScopeRuntimeBrokerError: 80,
+  ScopeRuntimeEnvironmentCapacityError: 81,
+  ScopeRuntimeEnvironmentFixedError: 82,
+  ScopeRuntimeEnvironmentKeyError: 83,
+  ScopeRuntimeFilesystemError: 84,
+  ScopeRuntimeIdentityUidError: 85,
+  ScopeRuntimeIdentityWorkingDirectoryError: 86,
+  ScopeRuntimeInvocationError: 87,
+  ScopeRuntimeReadinessError: 88,
+  ScopeRuntimeUnknownError: 89,
+} as const);
+
+export type ScopeRuntimeWorkerFailureName = keyof typeof SCOPE_RUNTIME_WORKER_FAILURE_EXIT_CODES;
+
+function workerFailure(name: string, message: string): Error {
+  const error = new Error(message);
+  error.name = name;
+  return error;
+}
+
+export function parseScopeRuntimeWorkerArguments(input: readonly string[]) {
+  const [runtimeHandle, scopeHandle, workload, adapterId, harnessVersion] = input;
+  if (input.length !== 5
+    || typeof runtimeHandle !== "string" || !RUNTIME_HANDLE.test(runtimeHandle)
+    || typeof scopeHandle !== "string" || !SCOPE_HANDLE.test(scopeHandle)
+    || workload !== "chat_ai"
+    || adapterId !== "claude-code"
+    || harnessVersion !== SCOPE_RUNTIME_WORKER_HARNESS_VERSION) {
+    throw workerFailure("ScopeRuntimeInvocationError", "Invalid scope runtime worker invocation");
+  }
+  return { runtimeHandle, scopeHandle, workload, adapterId, harnessVersion };
+}
+
+export function validateScopeRuntimeWorkerEnvironment(
+  input: Readonly<Record<string, string | undefined>>,
+): Readonly<Record<string, string | undefined>> {
+  const entries = Object.entries(input);
+  if (entries.length > 256) {
+    throw workerFailure("ScopeRuntimeEnvironmentCapacityError", "Scope runtime environment exceeds capacity");
+  }
+  let bytes = 0;
+  for (const [key, value] of entries) {
+    if (key.length > 256 || (value?.length ?? 0) > 8_192 || SENSITIVE_ENVIRONMENT_KEY.test(key)) {
+      throw workerFailure("ScopeRuntimeEnvironmentKeyError", "Unsafe scope runtime environment");
+    }
+    bytes += Buffer.byteLength(key) + Buffer.byteLength(value ?? "");
+  }
+  if (bytes > 64 * 1024
+    || input.HOME !== "/workspace"
+    || input.PATH !== "/opt/matrix/runtime/node/bin"
+    || input.MATRIX_SCOPE_RUNTIME !== "1") {
+    throw workerFailure("ScopeRuntimeEnvironmentFixedError", "Invalid scope runtime environment");
+  }
+  return input;
+}
+
+export function scrubScopeRuntimeWorkerEnvironment(
+  input: Record<string, string | undefined>,
+): Readonly<Record<string, string | undefined>> {
+  const keys = Object.keys(input);
+  if (keys.length > 256) {
+    throw workerFailure("ScopeRuntimeEnvironmentCapacityError", "Scope runtime environment exceeds capacity");
+  }
+  for (const key of keys) {
+    if (!Object.hasOwn(FIXED_WORKER_ENVIRONMENT, key)) delete input[key];
+  }
+  Object.assign(input, FIXED_WORKER_ENVIRONMENT);
+  return validateScopeRuntimeWorkerEnvironment(input);
+}
+
+export function prepareScopeRuntimeWorkerEnvironment(
+  args: readonly string[],
+  environment: Record<string, string | undefined>,
+  executable: string,
+  workerFile: string,
+): {
+  invocationArguments?: readonly string[];
+  reexec?: {
+    executable: string;
+    arguments: string[];
+    environment: Record<string, string>;
+  };
+} {
+  if (args[0] === FIXED_ENVIRONMENT_SENTINEL) {
+    scrubScopeRuntimeWorkerEnvironment(environment);
+    return { invocationArguments: args.slice(1) };
+  }
+  return {
+    reexec: {
+      executable,
+      arguments: [executable, workerFile, FIXED_ENVIRONMENT_SENTINEL, ...args],
+      environment: { ...FIXED_WORKER_ENVIRONMENT },
+    },
+  };
+}
+
+async function verifyBoundary(): Promise<void> {
+  const uid = process.getuid?.();
+  if (uid === undefined || uid < 61_184 || uid > 65_519) {
+    throw workerFailure("ScopeRuntimeIdentityUidError", "Scope runtime identity unavailable");
+  }
+  if (process.cwd() !== "/workspace") {
+    throw workerFailure("ScopeRuntimeIdentityWorkingDirectoryError", "Scope runtime identity unavailable");
+  }
+  validateScopeRuntimeWorkerEnvironment(process.env);
+  for (const path of FORBIDDEN_PATHS) {
+    try {
+      await access(path);
+      throw workerFailure("ScopeRuntimeFilesystemError", "Scope runtime forbidden path is accessible");
+    } catch (error: unknown) {
+      if (error instanceof Error && ["ENOENT", "EACCES", "EPERM"].includes(
+        String((error as NodeJS.ErrnoException).code),
+      )) continue;
+      throw error;
+    }
+  }
+  const broker = await lstat("/run/matrix-scope/broker.sock");
+  if (!broker.isSocket() || broker.isSymbolicLink()) {
+    throw workerFailure("ScopeRuntimeBrokerError", "Scope runtime broker unavailable");
+  }
+}
+
+export async function writeScopeRuntimeReadiness(
+  runtimeHandle: string,
+  directory = READINESS_DIRECTORY,
+): Promise<void> {
+  if (!RUNTIME_HANDLE.test(runtimeHandle)) {
+    throw workerFailure("ScopeRuntimeInvocationError", "Invalid scope runtime worker invocation");
+  }
+  const marker = await open(
+    join(directory, "ready"),
+    constants.O_WRONLY | constants.O_TRUNC | constants.O_NOFOLLOW,
+  );
+  try {
+    await marker.writeFile(`${runtimeHandle}\n`);
+  } finally {
+    await marker.close();
+  }
+}
+
+export function scopeRuntimeWorkerFailureName(error: unknown): ScopeRuntimeWorkerFailureName {
+  const name = error instanceof Error ? error.name : "";
+  return Object.hasOwn(SCOPE_RUNTIME_WORKER_FAILURE_EXIT_CODES, name)
+    ? name as ScopeRuntimeWorkerFailureName
+    : "ScopeRuntimeUnknownError";
+}
+
+export function scopeRuntimeWorkerFailureExitCode(error: unknown): number {
+  return SCOPE_RUNTIME_WORKER_FAILURE_EXIT_CODES[scopeRuntimeWorkerFailureName(error)];
+}
+
+export function scopeRuntimeWorkerFailureForExitCode(
+  exitCode: number,
+): ScopeRuntimeWorkerFailureName | undefined {
+  for (const [name, code] of Object.entries(SCOPE_RUNTIME_WORKER_FAILURE_EXIT_CODES)) {
+    if (code === exitCode) return name as ScopeRuntimeWorkerFailureName;
+  }
+  return undefined;
+}
+
+export async function waitForScopeRuntimeShutdown(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    // Signal listeners do not keep Node's event loop alive. Without this
+    // referenced handle, the top-level await exits with status 13 before the
+    // supervisor can use the ready worker.
+    const keepAlive = setInterval(() => undefined, 60_000);
+    const stop = () => {
+      clearInterval(keepAlive);
+      process.removeListener("SIGTERM", stop);
+      process.removeListener("SIGINT", stop);
+      resolve();
+    };
+    process.once("SIGTERM", stop);
+    process.once("SIGINT", stop);
+  });
+}
+
+export async function runScopeRuntimeWorker(args = process.argv.slice(2)): Promise<void> {
+  const environment = prepareScopeRuntimeWorkerEnvironment(
+    args,
+    process.env,
+    process.execPath,
+    fileURLToPath(import.meta.url),
+  );
+  if (environment.reexec) {
+    if (typeof process.execve !== "function") {
+      throw workerFailure("ScopeRuntimeInvocationError", "Scope runtime worker re-exec unavailable");
+    }
+    process.execve(
+      environment.reexec.executable,
+      environment.reexec.arguments,
+      environment.reexec.environment,
+    );
+  }
+  const invocation = parseScopeRuntimeWorkerArguments(environment.invocationArguments ?? []);
+  await verifyBoundary();
+  try {
+    await writeScopeRuntimeReadiness(invocation.runtimeHandle);
+  } catch (error: unknown) {
+    if (!(error instanceof Error)) throw error;
+    throw workerFailure("ScopeRuntimeReadinessError", "Scope runtime readiness unavailable");
+  }
+  process.stdout.write("scope_runtime_worker_ready\n");
+  await waitForScopeRuntimeShutdown();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await runScopeRuntimeWorker().catch((error: unknown) => {
+    console.error("scope_runtime_worker_failed:", error instanceof Error ? error.name : "UnknownError");
+    process.exitCode = scopeRuntimeWorkerFailureExitCode(error);
+  });
+}

--- a/packages/scope-runtime/tsconfig.json
+++ b/packages/scope-runtime/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,6 +614,9 @@ importers:
       '@matrix-os/observability':
         specifier: workspace:*
         version: link:../observability
+      '@matrix-os/scope-runtime':
+        specifier: workspace:*
+        version: link:../scope-runtime
       '@pipedream/sdk':
         specifier: ^2.4.3
         version: 2.4.3
@@ -659,6 +662,9 @@ importers:
       semver:
         specifier: ^7.7.0
         version: 7.7.4
+      undici:
+        specifier: 7.24.8
+        version: 7.24.8
       ws:
         specifier: ^8.19.0
         version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -943,6 +949,19 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/scope-runtime:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.5.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -29530,24 +29549,6 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.2.4: {}
-
-  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.3):
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/react': 19.2.14
-      devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6
-      html-url-attributes: 3.0.1
-      mdast-util-to-hast: 13.2.1
-      react: 19.2.3
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      unified: 11.0.5
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.6):
     dependencies:

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -41,6 +41,7 @@ pnpm --filter '@matrix-os/observability' build
 pnpm --filter '@matrix-os/brand' build
 pnpm --filter '@matrix-os/kernel' build
 pnpm --filter '@matrix-os/integrations-mcp' build
+pnpm --filter '@matrix-os/scope-runtime' build
 pnpm --filter '@matrix-os/gateway' build
 mkdir -p "$ROOT_DIR/packages/gateway/dist/app-runtime"
 cp -a "$ROOT_DIR/packages/gateway/src/app-runtime/"*.html "$ROOT_DIR/packages/gateway/dist/app-runtime/"
@@ -127,7 +128,7 @@ cp -a "$ROOT_DIR/distro/customer-vps/systemd/." "$STAGE_DIR/systemd/"
 cp -a "$ROOT_DIR/distro/customer-vps/systemd-user/." "$STAGE_DIR/user-systemd/"
 # The bundle is usually extracted as root:root during in-place upgrades, while
 # the systemd units execute these wrappers as the matrix user.
-chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-agent-bridge" "$STAGE_DIR/bin/matrix-integrations" "$STAGE_DIR/bin/matrix-integrations-mcp" "$STAGE_DIR/bin/matrix-register-integrations-mcp" "$STAGE_DIR/bin/matrix-sync-bundled-home-assets" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-symphony-control" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-ensure-swap" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-hermes-dashboard" "$STAGE_DIR/bin/matrix-install-openclaw" "$STAGE_DIR/bin/matrix-openclaw-gateway" "$STAGE_DIR/bin/matrix-agent-runtime-control" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-install-developer-tools" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/matrix-prepare-host-prerequisites" "$STAGE_DIR/bin/matrix-aws-cli-smoke" "$STAGE_DIR/bin/matrix-golden-service-diagnostics" "$STAGE_DIR/bin/matrix-golden-snapshot-activate" "$STAGE_DIR/bin/matrix-golden-snapshot-fast-path" "$STAGE_DIR/bin/matrix-golden-snapshot-sanitize" "$STAGE_DIR/bin/matrix-golden-snapshot-validate" "$STAGE_DIR/bin/matrix-write-bootstrap-attestation" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
+chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-agent-bridge" "$STAGE_DIR/bin/matrix-integrations" "$STAGE_DIR/bin/matrix-integrations-mcp" "$STAGE_DIR/bin/matrix-register-integrations-mcp" "$STAGE_DIR/bin/matrix-sync-bundled-home-assets" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-scope-runtime" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-symphony-control" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-ensure-swap" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-hermes-dashboard" "$STAGE_DIR/bin/matrix-install-openclaw" "$STAGE_DIR/bin/matrix-openclaw-gateway" "$STAGE_DIR/bin/matrix-agent-runtime-control" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-install-developer-tools" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/matrix-prepare-host-prerequisites" "$STAGE_DIR/bin/matrix-aws-cli-smoke" "$STAGE_DIR/bin/matrix-golden-service-diagnostics" "$STAGE_DIR/bin/matrix-golden-snapshot-activate" "$STAGE_DIR/bin/matrix-golden-snapshot-fast-path" "$STAGE_DIR/bin/matrix-golden-snapshot-sanitize" "$STAGE_DIR/bin/matrix-golden-snapshot-validate" "$STAGE_DIR/bin/matrix-write-bootstrap-attestation" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
 
 cp -a "$ROOT_DIR/node_modules" "$STAGE_DIR/app/node_modules"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"
@@ -149,6 +150,10 @@ printf '%s\n' "$TERMINAL_RUNTIME_GENERATION" > "$STAGE_DIR/app/TERMINAL_RUNTIME_
 # Activation follows the installed app payload so the supported updater's
 # app rollback atomically returns pre-activation bundles to dormant behavior.
 printf '1\n' > "$STAGE_DIR/app/TERMINAL_USER_SYSTEMD_ENABLED"
+# PR2 installs the rollback-safe foundation only. The inverse systemd
+# ConditionPathExists fence prevents accidental activation until PR3 removes
+# this app-owned marker while completing M2.
+printf '1\n' > "$STAGE_DIR/app/SCOPE_RUNTIME_DISABLED"
 if [ -f "$ROOT_DIR/.npmrc" ]; then
   cp -a "$ROOT_DIR/.npmrc" "$STAGE_DIR/app/.npmrc"
 fi

--- a/tests/deploy/customer-vps/scope-runtime-systemd.test.ts
+++ b/tests/deploy/customer-vps/scope-runtime-systemd.test.ts
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("dormant scope runtime host bundle", () => {
+  it("installs a least-privilege system supervisor that is fenced by the app marker", async () => {
+    const unit = await readFile("distro/customer-vps/systemd/matrix-scope-runtime.service", "utf8");
+    expect(unit).toContain("User=root");
+    expect(unit).toContain("Group=matrix");
+    expect(unit).toContain("ConditionPathExists=!/opt/matrix/app/SCOPE_RUNTIME_DISABLED");
+    expect(unit).toContain("RuntimeDirectory=matrix-scope-runtime");
+    expect(unit).toContain("RuntimeDirectoryMode=0770");
+    expect(unit).toContain("StateDirectory=matrix-scope-runtime");
+    expect(unit).toContain("PrivateNetwork=yes");
+    expect(unit).toContain("ProtectHome=yes");
+    expect(unit).toContain("ProtectSystem=strict");
+    expect(unit).toContain("NoNewPrivileges=yes");
+    expect(unit).toContain("CapabilityBoundingSet=");
+    expect(unit).toContain("RestrictAddressFamilies=AF_UNIX");
+    expect(unit).not.toContain("EnvironmentFile=");
+  });
+
+  it("builds the supervisor package and leaves it disabled across fresh install and update", async () => {
+    const build = await readFile("scripts/build-host-bundle.sh", "utf8");
+    const cloudInit = await readFile("distro/customer-vps/cloud-init.yaml", "utf8");
+    const updater = await readFile("distro/customer-vps/host-bin/matrix-sync-agent", "utf8");
+    const wrapper = await readFile("distro/customer-vps/host-bin/matrix-scope-runtime", "utf8");
+
+    expect(build).toContain("pnpm --filter '@matrix-os/scope-runtime' build");
+    expect(build).toContain('printf \'1\\n\' > "$STAGE_DIR/app/SCOPE_RUNTIME_DISABLED"');
+    expect(build).toContain('"$STAGE_DIR/bin/matrix-scope-runtime"');
+    expect(wrapper).toContain("packages/scope-runtime/dist/main.js");
+    expect(cloudInit).not.toMatch(/systemctl enable[^\n]*matrix-scope-runtime/);
+    expect(cloudInit).not.toMatch(/systemctl start[^\n]*matrix-scope-runtime/);
+    expect(updater).not.toMatch(/systemctl enable[^\n]*matrix-scope-runtime/);
+    expect(updater).not.toMatch(/systemctl (?:start|restart)[^\n]*matrix-scope-runtime/);
+  });
+});

--- a/tests/scope-runtime/server.test.ts
+++ b/tests/scope-runtime/server.test.ts
@@ -1,0 +1,138 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { createConnection, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ScopeRuntimeRequest, ScopeRuntimeResponse } from "../../packages/scope-runtime/src/protocol.js";
+import { createScopeRuntimeServer } from "../../packages/scope-runtime/src/server.js";
+
+const REQUEST_ID = "018f0ce5-7b4a-7f95-a7c8-acae0dc5c5d1";
+const cleanup: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.allSettled(cleanup.splice(0).map((remove) => remove()));
+});
+
+async function pathForSocket(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "matrix-scope-server-"));
+  cleanup.push(() => rm(root, { recursive: true, force: true }));
+  return join(root, "supervisor.sock");
+}
+
+async function exchange(socketPath: string, frame: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ path: socketPath });
+    let output = "";
+    socket.setEncoding("utf8");
+    socket.once("error", reject);
+    socket.on("data", (chunk) => { output += chunk; });
+    socket.once("close", () => resolve(output));
+    socket.once("connect", () => socket.end(frame));
+  });
+}
+
+function response(request: ScopeRuntimeRequest): ScopeRuntimeResponse {
+  return {
+    version: 1,
+    type: "capability.result",
+    requestId: request.requestId,
+    ok: false,
+    error: "runtime_unavailable",
+  };
+}
+
+describe("scope runtime supervisor server", () => {
+  it("serves exactly one bounded request per Unix-socket connection", async () => {
+    const socketPath = await pathForSocket();
+    const controller = { handle: vi.fn(async (request: ScopeRuntimeRequest) => response(request)), close: vi.fn() };
+    const server = createScopeRuntimeServer({ socketPath, controller });
+    await server.start();
+    cleanup.push(() => server.close());
+
+    const output = await exchange(socketPath, `${JSON.stringify({
+      version: 1,
+      type: "capability.get",
+      requestId: REQUEST_ID,
+    })}\n`);
+    expect(JSON.parse(output)).toEqual(expect.objectContaining({ requestId: REQUEST_ID }));
+    expect(controller.handle).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops malformed, injected, multiple, and oversized frames before dispatch", async () => {
+    const socketPath = await pathForSocket();
+    const controller = { handle: vi.fn(async (request: ScopeRuntimeRequest) => response(request)), close: vi.fn() };
+    const server = createScopeRuntimeServer({ socketPath, controller });
+    await server.start();
+    cleanup.push(() => server.close());
+
+    for (const frame of [
+      "not-json\n",
+      `${JSON.stringify({ version: 1, type: "capability.get", requestId: REQUEST_ID, command: "/bin/sh" })}\n`,
+      `${JSON.stringify({ version: 1, type: "capability.get", requestId: REQUEST_ID })}\n${JSON.stringify({ version: 1, type: "capability.get", requestId: REQUEST_ID })}\n`,
+      `${"x".repeat(65 * 1024)}\n`,
+    ]) {
+      await expect(exchange(socketPath, frame)).resolves.toBe("");
+    }
+    expect(controller.handle).not.toHaveBeenCalled();
+  });
+
+  it("caps connections, times out stale clients, and drains on shutdown", async () => {
+    const socketPath = await pathForSocket();
+    const controller = { handle: vi.fn(async (request: ScopeRuntimeRequest) => response(request)), close: vi.fn() };
+    const server = createScopeRuntimeServer({
+      socketPath,
+      controller,
+      maxConnections: 1,
+      requestTimeoutMs: 20,
+    });
+    await server.start();
+
+    const first = createConnection({ path: socketPath });
+    await new Promise<void>((resolve, reject) => {
+      first.once("connect", resolve);
+      first.once("error", reject);
+    });
+    const second = createConnection({ path: socketPath });
+    await new Promise<void>((resolve) => second.once("close", resolve));
+    expect(server.connectionCount()).toBe(1);
+    await new Promise<void>((resolve) => first.once("close", resolve));
+    await vi.waitFor(() => expect(server.connectionCount()).toBe(0));
+
+    const third: Socket = createConnection({ path: socketPath });
+    await new Promise<void>((resolve, reject) => {
+      third.once("connect", resolve);
+      third.once("error", reject);
+    });
+    await server.close();
+    expect(third.destroyed).toBe(true);
+    expect(controller.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a separate bounded deadline after a complete frame is dispatched", async () => {
+    const socketPath = await pathForSocket();
+    const controller = {
+      handle: vi.fn(async (request: ScopeRuntimeRequest) => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 40));
+        return response(request);
+      }),
+      close: vi.fn(),
+    };
+    const server = createScopeRuntimeServer({
+      socketPath,
+      controller,
+      requestTimeoutMs: 20,
+      operationTimeoutMs: 100,
+    });
+    await server.start();
+    cleanup.push(() => server.close());
+
+    const output = await exchange(socketPath, `${JSON.stringify({
+      version: 1,
+      type: "capability.get",
+      requestId: REQUEST_ID,
+    })}\n`);
+
+    expect(JSON.parse(output)).toEqual(expect.objectContaining({ requestId: REQUEST_ID }));
+    expect(controller.handle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/scope-runtime/supervisor.test.ts
+++ b/tests/scope-runtime/supervisor.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SCOPE_RUNTIME_PROFILE,
+  createScopeRuntimeController,
+  type ScopeRuntimeLauncher,
+} from "../../packages/scope-runtime/src/supervisor.js";
+
+const REQUEST_ID = "018f0ce5-7b4a-7f95-a7c8-acae0dc5c5d1";
+const SCOPE_HANDLE = "scope_11111111111111111111111111111111";
+const RUNTIME_HANDLE = "runtime_22222222222222222222222222222222";
+
+function launcher(overrides: Partial<ScopeRuntimeLauncher> = {}): ScopeRuntimeLauncher {
+  return {
+    list: vi.fn(async () => []),
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe("scope runtime supervisor", () => {
+  it("advertises only the measured non-root Chat profile", async () => {
+    const controller = await createScopeRuntimeController({
+      launcher: launcher(),
+      executionGeneration: "9",
+      createRuntimeHandle: () => RUNTIME_HANDLE,
+    });
+
+    await expect(controller.handle({
+      version: 1,
+      type: "capability.get",
+      requestId: REQUEST_ID,
+    })).resolves.toEqual({
+      version: 1,
+      type: "capability.result",
+      requestId: REQUEST_ID,
+      ok: true,
+      supervisorVersion: "1.0.0",
+      profile: { ...SCOPE_RUNTIME_PROFILE, executionGeneration: "9" },
+    });
+    expect(SCOPE_RUNTIME_PROFILE.identity).toEqual({
+      mode: "dynamic",
+      uidMin: 61_184,
+      uidMax: 65_519,
+    });
+    expect(SCOPE_RUNTIME_PROFILE.profileDigest)
+      .toBe("8f5c1d40eb30581026f89870c98d21064187386d36a80928a9eb2be7b671da37");
+    expect(SCOPE_RUNTIME_PROFILE.adapters).toEqual([{
+      adapterId: "claude-code",
+      harnessVersion: "2.1.240",
+      workloads: ["chat_ai"],
+    }]);
+  });
+
+  it("maps an opaque create request to the fixed launcher and stops by handle", async () => {
+    const native = launcher();
+    const controller = await createScopeRuntimeController({
+      launcher: native,
+      executionGeneration: "10",
+      createRuntimeHandle: () => RUNTIME_HANDLE,
+    });
+
+    await expect(controller.handle({
+      version: 1,
+      type: "runtime.create",
+      requestId: REQUEST_ID,
+      scopeHandle: SCOPE_HANDLE,
+      profileId: SCOPE_RUNTIME_PROFILE.profileId,
+      workload: "chat_ai",
+      adapterId: "claude-code",
+      harnessVersion: "2.1.240",
+    })).resolves.toMatchObject({ ok: true, runtimeHandle: RUNTIME_HANDLE, state: "running" });
+    expect(native.start).toHaveBeenCalledWith({
+      runtimeHandle: RUNTIME_HANDLE,
+      scopeHandle: SCOPE_HANDLE,
+      workload: "chat_ai",
+      adapterId: "claude-code",
+      harnessVersion: "2.1.240",
+    });
+
+    await expect(controller.handle({
+      version: 1,
+      type: "runtime.stop",
+      requestId: REQUEST_ID,
+      runtimeHandle: RUNTIME_HANDLE,
+    })).resolves.toMatchObject({ ok: true, state: "stopped" });
+    expect(native.stop).toHaveBeenCalledWith(RUNTIME_HANDLE);
+  });
+
+  it("fails closed for unproven profiles, harnesses, workloads, and launcher failures", async () => {
+    const native = launcher({ start: vi.fn(async () => { throw new Error("host detail"); }) });
+    const controller = await createScopeRuntimeController({
+      launcher: native,
+      executionGeneration: "11",
+      createRuntimeHandle: () => RUNTIME_HANDLE,
+    });
+    const base = {
+      version: 1 as const,
+      type: "runtime.create" as const,
+      requestId: REQUEST_ID,
+      scopeHandle: SCOPE_HANDLE,
+      profileId: SCOPE_RUNTIME_PROFILE.profileId,
+      workload: "chat_ai" as const,
+      adapterId: "claude-code",
+      harnessVersion: "2.1.240",
+    };
+
+    await expect(controller.handle({ ...base, profileId: "scope-runtime-proof-v2" }))
+      .resolves.toMatchObject({ ok: false, error: "profile_unavailable" });
+    await expect(controller.handle({ ...base, harnessVersion: "2.1.241" }))
+      .resolves.toMatchObject({ ok: false, error: "adapter_unavailable" });
+    await expect(controller.handle({ ...base, workload: "terminal" }))
+      .resolves.toMatchObject({ ok: false, error: "adapter_unavailable" });
+    await expect(controller.handle(base))
+      .resolves.toEqual(expect.objectContaining({ ok: false, error: "runtime_unavailable" }));
+    expect(controller.size()).toBe(0);
+  });
+
+  it("reserves capacity across concurrent creates and drains owned runtimes on shutdown", async () => {
+    let releaseStart: (() => void) | undefined;
+    const startBarrier = new Promise<void>((resolve) => { releaseStart = resolve; });
+    const native = launcher({ start: vi.fn(async () => startBarrier) });
+    let sequence = 1;
+    const controller = await createScopeRuntimeController({
+      launcher: native,
+      executionGeneration: "12",
+      maxRuntimes: 1,
+      createRuntimeHandle: () => `runtime_${String(sequence++).padStart(32, "0")}`,
+    });
+    const create = (requestId: string) => controller.handle({
+      version: 1,
+      type: "runtime.create",
+      requestId,
+      scopeHandle: SCOPE_HANDLE,
+      profileId: SCOPE_RUNTIME_PROFILE.profileId,
+      workload: "chat_ai",
+      adapterId: "claude-code",
+      harnessVersion: "2.1.240",
+    });
+
+    const first = create(REQUEST_ID);
+    await expect(create("018f0ce5-7b4a-7f95-a7c8-acae0dc5c5d2"))
+      .resolves.toMatchObject({ ok: false, error: "capacity_exceeded" });
+    releaseStart?.();
+    await expect(first).resolves.toMatchObject({ ok: true });
+
+    await controller.close();
+    expect(native.stop).toHaveBeenCalledWith("runtime_00000000000000000000000000000001");
+    await expect(create("018f0ce5-7b4a-7f95-a7c8-acae0dc5c5d3"))
+      .resolves.toMatchObject({ ok: false, error: "runtime_unavailable" });
+  });
+});

--- a/tests/scope-runtime/supervisor.test.ts
+++ b/tests/scope-runtime/supervisor.test.ts
@@ -76,6 +76,7 @@ describe("scope runtime supervisor", () => {
       workload: "chat_ai",
       adapterId: "claude-code",
       harnessVersion: "2.1.240",
+      executionGeneration: "10",
     });
 
     await expect(controller.handle({
@@ -85,6 +86,27 @@ describe("scope runtime supervisor", () => {
       runtimeHandle: RUNTIME_HANDLE,
     })).resolves.toMatchObject({ ok: true, state: "stopped" });
     expect(native.stop).toHaveBeenCalledWith(RUNTIME_HANDLE);
+  });
+
+  it("preserves the attested launch generation for a reconciled runtime", async () => {
+    const native = launcher({
+      list: vi.fn(async () => [{ runtimeHandle: RUNTIME_HANDLE, executionGeneration: "7" }]),
+    });
+    const controller = await createScopeRuntimeController({
+      launcher: native,
+      executionGeneration: "13",
+    });
+
+    await expect(controller.handle({
+      version: 1,
+      type: "runtime.stop",
+      requestId: REQUEST_ID,
+      runtimeHandle: RUNTIME_HANDLE,
+    })).resolves.toMatchObject({
+      ok: true,
+      state: "stopped",
+      executionGeneration: "7",
+    });
   });
 
   it("fails closed for unproven profiles, harnesses, workloads, and launcher failures", async () => {

--- a/tests/scope-runtime/systemd-launcher.test.ts
+++ b/tests/scope-runtime/systemd-launcher.test.ts
@@ -1,4 +1,4 @@
-import { chmod, lstat, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,6 +9,12 @@ import {
   nextExecutionGeneration,
   type ScopeRuntimeCommandRunner,
 } from "../../packages/scope-runtime/src/systemd-launcher.js";
+import {
+  SCOPE_RUNTIME_HARNESS_VERSION,
+  SCOPE_RUNTIME_PROFILE_DIGEST,
+  SCOPE_RUNTIME_PROFILE_ID,
+  SCOPE_RUNTIME_PROFILE_VERSION,
+} from "../../packages/scope-runtime/src/profile.js";
 
 const RUNTIME_HANDLE = "runtime_22222222222222222222222222222222";
 const SCOPE_HANDLE = "scope_11111111111111111111111111111111";
@@ -47,7 +53,27 @@ const launch = {
   workload: "chat_ai" as const,
   adapterId: "claude-code",
   harnessVersion: "2.1.240",
+  executionGeneration: "7",
 };
+
+async function writeProvenance(
+  stateRoot: string,
+  suffix: string,
+  overrides: Record<string, unknown> = {},
+) {
+  await writeFile(join(stateRoot, "runtimes", suffix, "provenance.json"), JSON.stringify({
+    version: 1,
+    runtimeHandle: `runtime_${suffix}`,
+    profileId: SCOPE_RUNTIME_PROFILE_ID,
+    profileVersion: SCOPE_RUNTIME_PROFILE_VERSION,
+    profileDigest: SCOPE_RUNTIME_PROFILE_DIGEST,
+    workload: "chat_ai",
+    adapterId: "claude-code",
+    harnessVersion: SCOPE_RUNTIME_HARNESS_VERSION,
+    executionGeneration: "7",
+    ...overrides,
+  }));
+}
 
 describe("scope runtime systemd launcher", () => {
   it("builds only the source-controlled profile and fixed worker command", () => {
@@ -96,6 +122,7 @@ describe("scope runtime systemd launcher", () => {
       paths.stateRoot,
       "runtimes/33333333333333333333333333333333/ready",
     ), "runtime_33333333333333333333333333333333\n");
+    await writeProvenance(paths.stateRoot, "33333333333333333333333333333333");
     const calls: Array<{ command: string; args: readonly string[] }> = [];
     const runCommand: ScopeRuntimeCommandRunner = vi.fn(async (command, args) => {
       calls.push({ command, args });
@@ -112,7 +139,10 @@ describe("scope runtime systemd launcher", () => {
     });
     const launcher = createSystemdScopeRuntimeLauncher({ ...paths, runCommand });
 
-    await expect(launcher.list()).resolves.toEqual(["runtime_33333333333333333333333333333333"]);
+    await expect(launcher.list()).resolves.toEqual([{
+      runtimeHandle: "runtime_33333333333333333333333333333333",
+      executionGeneration: "7",
+    }]);
     const previousUmask = process.umask(0o007);
     try {
       await expect(launcher.start(launch)).resolves.toBeUndefined();
@@ -131,6 +161,13 @@ describe("scope runtime systemd launcher", () => {
     expect((await stat(join(sandboxRoot, "run/matrix-scope-readiness"))).mode & 0o777).toBe(0o755);
     expect((await stat(join(sandboxRoot, "run/matrix-scope-readiness/ready"))).mode & 0o777).toBe(0o644);
     expect((await stat(join(runtimeRoot, "ready"))).mode & 0o777).toBe(0o622);
+    expect(JSON.parse(await readFile(join(runtimeRoot, "provenance.json"), "utf8")))
+      .toMatchObject({
+        runtimeHandle: RUNTIME_HANDLE,
+        profileDigest: SCOPE_RUNTIME_PROFILE_DIGEST,
+        harnessVersion: SCOPE_RUNTIME_HARNESS_VERSION,
+        executionGeneration: "7",
+      });
     expect((await lstat(
       join(sandboxRoot, "opt/matrix/scope-runtime/worker.mjs"),
     )).isFile()).toBe(true);
@@ -224,13 +261,24 @@ describe("scope runtime systemd launcher", () => {
     const activating = "55555555555555555555555555555555";
     const orphan = "66666666666666666666666666666666";
     const activeWithoutReadiness = "77777777777777777777777777777777";
-    for (const suffix of [active, failed, activating, orphan, activeWithoutReadiness]) {
+    const activeWithStaleProvenance = "88888888888888888888888888888888";
+    for (const suffix of [
+      active, failed, activating, orphan, activeWithoutReadiness, activeWithStaleProvenance,
+    ]) {
       await mkdir(join(paths.stateRoot, "runtimes", suffix), { recursive: true });
     }
     await writeFile(
       join(paths.stateRoot, "runtimes", active, "ready"),
       `runtime_${active}\n`,
     );
+    await writeProvenance(paths.stateRoot, active);
+    await writeFile(
+      join(paths.stateRoot, "runtimes", activeWithStaleProvenance, "ready"),
+      `runtime_${activeWithStaleProvenance}\n`,
+    );
+    await writeProvenance(paths.stateRoot, activeWithStaleProvenance, {
+      profileDigest: "0".repeat(64),
+    });
     const calls: Array<readonly string[]> = [];
     const runCommand: ScopeRuntimeCommandRunner = vi.fn(async (_command, args) => {
       calls.push(args);
@@ -239,14 +287,18 @@ describe("scope runtime systemd launcher", () => {
         `matrix-scope-runtime-${failed}.service loaded failed failed`,
         `matrix-scope-runtime-${activating}.service loaded activating start`,
         `matrix-scope-runtime-${activeWithoutReadiness}.service loaded active running`,
+        `matrix-scope-runtime-${activeWithStaleProvenance}.service loaded active running`,
       ].join("\n") };
       return { stdout: "" };
     });
     const launcher = createSystemdScopeRuntimeLauncher({ ...paths, runCommand });
 
-    await expect(launcher.list()).resolves.toEqual([`runtime_${active}`]);
+    await expect(launcher.list()).resolves.toEqual([{
+      runtimeHandle: `runtime_${active}`,
+      executionGeneration: "7",
+    }]);
     expect(calls.some((args) => args[0] === "list-units" && args.includes("--all"))).toBe(true);
-    for (const suffix of [failed, activating, activeWithoutReadiness]) {
+    for (const suffix of [failed, activating, activeWithoutReadiness, activeWithStaleProvenance]) {
       const unit = `matrix-scope-runtime-${suffix}.service`;
       expect(calls.some((args) => args[0] === "stop" && args[1] === unit)).toBe(true);
       expect(calls.some((args) => args[0] === "reset-failed" && args[1] === unit)).toBe(true);
@@ -255,6 +307,8 @@ describe("scope runtime systemd launcher", () => {
     await expect(stat(join(paths.stateRoot, "runtimes", activating))).rejects.toMatchObject({ code: "ENOENT" });
     await expect(stat(join(paths.stateRoot, "runtimes", orphan))).rejects.toMatchObject({ code: "ENOENT" });
     await expect(stat(join(paths.stateRoot, "runtimes", activeWithoutReadiness)))
+      .rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(paths.stateRoot, "runtimes", activeWithStaleProvenance)))
       .rejects.toMatchObject({ code: "ENOENT" });
     await expect(stat(join(paths.stateRoot, "runtimes", active))).resolves.toBeDefined();
   });

--- a/tests/scope-runtime/systemd-launcher.test.ts
+++ b/tests/scope-runtime/systemd-launcher.test.ts
@@ -1,0 +1,272 @@
+import { chmod, lstat, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildFixedSystemdRunArgs,
+  createSystemdScopeRuntimeLauncher,
+  nextExecutionGeneration,
+  type ScopeRuntimeCommandRunner,
+} from "../../packages/scope-runtime/src/systemd-launcher.js";
+
+const RUNTIME_HANDLE = "runtime_22222222222222222222222222222222";
+const SCOPE_HANDLE = "scope_11111111111111111111111111111111";
+const cleanup: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.allSettled(cleanup.splice(0).map((remove) => remove()));
+});
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "matrix-scope-launcher-"));
+  cleanup.push(() => rm(root, { recursive: true, force: true }));
+  const sdkDirectory = join(root, "sdk");
+  const nativeDirectory = join(root, "native");
+  const workerFile = join(root, "worker.js");
+  const brokerSocket = join(root, "broker.sock");
+  const stateRoot = join(root, "state");
+  await mkdir(sdkDirectory);
+  await mkdir(nativeDirectory);
+  await writeFile(join(sdkDirectory, "sdk.mjs"), "export {};\n");
+  await writeFile(join(nativeDirectory, "claude"), "#!/bin/sh\nexit 0\n");
+  await chmod(join(nativeDirectory, "claude"), 0o755);
+  await writeFile(workerFile, "setInterval(() => {}, 1000);\n");
+  const broker: Server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    broker.once("error", reject);
+    broker.listen(brokerSocket, resolve);
+  });
+  cleanup.push(() => new Promise<void>((resolve) => broker.close(() => resolve())));
+  return { root, sdkDirectory, nativeDirectory, workerFile, brokerSocket, stateRoot, nodeBinary: process.execPath };
+}
+
+const launch = {
+  runtimeHandle: RUNTIME_HANDLE,
+  scopeHandle: SCOPE_HANDLE,
+  workload: "chat_ai" as const,
+  adapterId: "claude-code",
+  harnessVersion: "2.1.240",
+};
+
+describe("scope runtime systemd launcher", () => {
+  it("builds only the source-controlled profile and fixed worker command", () => {
+    const args = buildFixedSystemdRunArgs(launch, {
+      scopeRoot: "/var/lib/matrix-scope-runtime/runtimes/222/root",
+      sdkDirectory: "/opt/matrix/app/node_modules/sdk",
+      nativeDirectory: "/opt/matrix/app/node_modules/native",
+      workerFile: "/opt/matrix/app/packages/scope-runtime/dist/worker.js",
+      brokerSocket: "/run/matrix-scope-runtime/broker.sock",
+      readinessFile: "/var/lib/matrix-scope-runtime/runtimes/222/ready",
+      nodeBinary: "/opt/matrix/runtime/node/bin/node",
+    });
+
+    expect(args).toContain("--property=DynamicUser=yes");
+    expect(args).toContain("--property=PrivateUsers=yes");
+    expect(args).toContain("--property=PrivateNetwork=yes");
+    expect(args).toContain("--property=MemoryMax=1073741824");
+    expect(args).toContain("--property=TasksMax=256");
+    expect(args).toContain("--property=BindReadOnlyPaths=/usr/bin/env");
+    expect(args).toContain("--property=BindPaths=/var/lib/matrix-scope-runtime/runtimes/222/ready:/run/matrix-scope-readiness/ready");
+    expect(args).not.toContain("--collect");
+    expect(args.slice(args.indexOf("--") + 1)).toEqual([
+      "/usr/bin/env",
+      "-i",
+      "HOME=/workspace",
+      "PATH=/opt/matrix/runtime/node/bin",
+      "MATRIX_SCOPE_RUNTIME=1",
+      "/opt/matrix/runtime/node/bin/node",
+      "/opt/matrix/scope-runtime/worker.mjs",
+      RUNTIME_HANDLE,
+      SCOPE_HANDLE,
+      "chat_ai",
+      "claude-code",
+      "2.1.240",
+    ]);
+    expect(JSON.stringify(args)).not.toMatch(/OWNER_TOKEN|\/home\/matrix|\/run\/systemd\/private/);
+  });
+
+  it("prepares a private root, starts the fixed unit, reconciles handles, and cleans up on stop", async () => {
+    const paths = await fixture();
+    await mkdir(join(
+      paths.stateRoot,
+      "runtimes/33333333333333333333333333333333",
+    ), { recursive: true });
+    await writeFile(join(
+      paths.stateRoot,
+      "runtimes/33333333333333333333333333333333/ready",
+    ), "runtime_33333333333333333333333333333333\n");
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    const runCommand: ScopeRuntimeCommandRunner = vi.fn(async (command, args) => {
+      calls.push({ command, args });
+      if (args[0] === "list-units") {
+        return { stdout: "matrix-scope-runtime-33333333333333333333333333333333.service loaded active running\n" };
+      }
+      if (command === "/usr/bin/systemd-run") {
+        await writeFile(join(
+          paths.stateRoot,
+          "runtimes/22222222222222222222222222222222/ready",
+        ), `${RUNTIME_HANDLE}\n`, { mode: 0o600 });
+      }
+      return { stdout: "active\n" };
+    });
+    const launcher = createSystemdScopeRuntimeLauncher({ ...paths, runCommand });
+
+    await expect(launcher.list()).resolves.toEqual(["runtime_33333333333333333333333333333333"]);
+    const previousUmask = process.umask(0o007);
+    try {
+      await expect(launcher.start(launch)).resolves.toBeUndefined();
+    } finally {
+      process.umask(previousUmask);
+    }
+    const runtimeRoot = join(paths.stateRoot, "runtimes", "22222222222222222222222222222222");
+    const sandboxRoot = join(runtimeRoot, "root");
+    expect((await stat(runtimeRoot)).mode & 0o777).toBe(0o700);
+    for (const path of [
+      sandboxRoot,
+      join(sandboxRoot, "opt"),
+      join(sandboxRoot, "opt/matrix/scope-runtime"),
+      join(sandboxRoot, "run/matrix-scope"),
+    ]) expect((await stat(path)).mode & 0o777).toBe(0o755);
+    expect((await stat(join(sandboxRoot, "run/matrix-scope-readiness"))).mode & 0o777).toBe(0o755);
+    expect((await stat(join(sandboxRoot, "run/matrix-scope-readiness/ready"))).mode & 0o777).toBe(0o644);
+    expect((await stat(join(runtimeRoot, "ready"))).mode & 0o777).toBe(0o622);
+    expect((await lstat(
+      join(sandboxRoot, "opt/matrix/scope-runtime/worker.mjs"),
+    )).isFile()).toBe(true);
+    expect((await lstat(join(sandboxRoot, "usr/bin/env"))).isFile()).toBe(true);
+    expect(calls.some((call) => call.command === "/usr/bin/systemd-run")).toBe(true);
+    await expect(launcher.stop(RUNTIME_HANDLE)).resolves.toBeUndefined();
+    expect(calls.some((call) => call.args.includes("matrix-scope-runtime-22222222222222222222222222222222.service")))
+      .toBe(true);
+  });
+
+  it("allows bounded native activation latency and stops a submitted unit before failed-root cleanup", async () => {
+    const delayed = await fixture();
+    let delayedPolls = 0;
+    const delayedRunner: ScopeRuntimeCommandRunner = vi.fn(async (_command, args) => {
+      if (args[0]?.startsWith("--unit=")) {
+        await writeFile(join(
+          delayed.stateRoot,
+          "runtimes/22222222222222222222222222222222/ready",
+        ), `${RUNTIME_HANDLE}\n`, { mode: 0o600 });
+      }
+      if (args[0] === "is-active" && delayedPolls++ < 24) {
+        throw Object.assign(new Error("activating"), { code: 3 });
+      }
+      return { stdout: "active\n" };
+    });
+    const delayedLauncher = createSystemdScopeRuntimeLauncher({ ...delayed, runCommand: delayedRunner });
+
+    await expect(delayedLauncher.start(launch)).resolves.toBeUndefined();
+    expect(delayedPolls).toBe(25);
+
+    const failed = await fixture();
+    const failedCalls: Array<{ command: string; args: readonly string[] }> = [];
+    const failedRunner: ScopeRuntimeCommandRunner = vi.fn(async (command, args) => {
+      failedCalls.push({ command, args });
+      if (args[0] === "show") return { stdout: "Result=exit-code\nExecMainStatus=203\n" };
+      if (args[0] === "is-active") {
+        const error = new Error("inactive") as NodeJS.ErrnoException;
+        error.code = 3;
+        throw error;
+      }
+      return { stdout: "" };
+    });
+    const failedLauncher = createSystemdScopeRuntimeLauncher({ ...failed, runCommand: failedRunner });
+
+    await expect(failedLauncher.start(launch)).rejects
+      .toThrow(expect.objectContaining({ name: "ScopeRuntimeActivationStatus203Error" }));
+    const stopIndex = failedCalls.findIndex((call) => call.args[0] === "stop");
+    const resetIndex = failedCalls.findIndex((call) => call.args[0] === "reset-failed");
+    expect(stopIndex).toBeGreaterThan(-1);
+    expect(resetIndex).toBeGreaterThan(stopIndex);
+  }, 20_000);
+
+  it("does not report an active unit as running before the worker readiness marker exists", async () => {
+    const paths = await fixture();
+    let activePolls = 0;
+    const runCommand: ScopeRuntimeCommandRunner = vi.fn(async (_command, args) => {
+      if (args[0] === "is-active") {
+        activePolls += 1;
+        if (activePolls < 3) return { stdout: "active\n" };
+        throw Object.assign(new Error("failed"), { code: 3 });
+      }
+      if (args[0] === "show") return { stdout: "Result=exit-code\nExecMainStatus=1\n" };
+      return { stdout: "" };
+    });
+    const launcher = createSystemdScopeRuntimeLauncher({ ...paths, runCommand });
+
+    await expect(launcher.start(launch)).rejects
+      .toThrow(expect.objectContaining({ name: "ScopeRuntimeActivationStatus1Error" }));
+    expect(activePolls).toBe(3);
+  });
+
+  it("preserves a bounded worker failure class through its fixed exit status", async () => {
+    const paths = await fixture();
+    const runCommand: ScopeRuntimeCommandRunner = vi.fn(async (_command, args) => {
+      if (args[0] === "is-active") {
+        throw Object.assign(new Error("failed"), { code: 3 });
+      }
+      if (args[0] === "show") return { stdout: "Result=exit-code\nExecMainStatus=80\n" };
+      return { stdout: "" };
+    });
+    const launcher = createSystemdScopeRuntimeLauncher({ ...paths, runCommand });
+
+    await expect(launcher.start(launch)).rejects
+      .toThrow(expect.objectContaining({ name: "ScopeRuntimeBrokerError" }));
+  });
+
+  it("cleans non-active units and orphaned private roots during restart reconciliation", async () => {
+    const paths = await fixture();
+    const active = "33333333333333333333333333333333";
+    const failed = "44444444444444444444444444444444";
+    const activating = "55555555555555555555555555555555";
+    const orphan = "66666666666666666666666666666666";
+    const activeWithoutReadiness = "77777777777777777777777777777777";
+    for (const suffix of [active, failed, activating, orphan, activeWithoutReadiness]) {
+      await mkdir(join(paths.stateRoot, "runtimes", suffix), { recursive: true });
+    }
+    await writeFile(
+      join(paths.stateRoot, "runtimes", active, "ready"),
+      `runtime_${active}\n`,
+    );
+    const calls: Array<readonly string[]> = [];
+    const runCommand: ScopeRuntimeCommandRunner = vi.fn(async (_command, args) => {
+      calls.push(args);
+      if (args[0] === "list-units") return { stdout: [
+        `matrix-scope-runtime-${active}.service loaded active running`,
+        `matrix-scope-runtime-${failed}.service loaded failed failed`,
+        `matrix-scope-runtime-${activating}.service loaded activating start`,
+        `matrix-scope-runtime-${activeWithoutReadiness}.service loaded active running`,
+      ].join("\n") };
+      return { stdout: "" };
+    });
+    const launcher = createSystemdScopeRuntimeLauncher({ ...paths, runCommand });
+
+    await expect(launcher.list()).resolves.toEqual([`runtime_${active}`]);
+    expect(calls.some((args) => args[0] === "list-units" && args.includes("--all"))).toBe(true);
+    for (const suffix of [failed, activating, activeWithoutReadiness]) {
+      const unit = `matrix-scope-runtime-${suffix}.service`;
+      expect(calls.some((args) => args[0] === "stop" && args[1] === unit)).toBe(true);
+      expect(calls.some((args) => args[0] === "reset-failed" && args[1] === unit)).toBe(true);
+    }
+    await expect(stat(join(paths.stateRoot, "runtimes", failed))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(paths.stateRoot, "runtimes", activating))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(paths.stateRoot, "runtimes", orphan))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(paths.stateRoot, "runtimes", activeWithoutReadiness)))
+      .rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(paths.stateRoot, "runtimes", active))).resolves.toBeDefined();
+  });
+
+  it("increments a durable generation and refuses corrupt state", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-scope-generation-"));
+    cleanup.push(() => rm(root, { recursive: true, force: true }));
+    const path = join(root, "generation");
+
+    await expect(nextExecutionGeneration(path)).resolves.toBe("1");
+    await expect(nextExecutionGeneration(path)).resolves.toBe("2");
+    await writeFile(path, "not-a-generation\n");
+    await expect(nextExecutionGeneration(path)).rejects.toThrow("generation");
+  });
+});

--- a/tests/scope-runtime/worker.test.ts
+++ b/tests/scope-runtime/worker.test.ts
@@ -1,0 +1,193 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import {
+  parseScopeRuntimeWorkerArguments,
+  prepareScopeRuntimeWorkerEnvironment,
+  scrubScopeRuntimeWorkerEnvironment,
+  scopeRuntimeWorkerFailureExitCode,
+  scopeRuntimeWorkerFailureForExitCode,
+  validateScopeRuntimeWorkerEnvironment,
+  writeScopeRuntimeReadiness,
+} from "../../packages/scope-runtime/src/worker.js";
+
+const argumentsFixture = [
+  "runtime_22222222222222222222222222222222",
+  "scope_11111111111111111111111111111111",
+  "chat_ai",
+  "claude-code",
+  "2.1.240",
+];
+const execFileAsync = promisify(execFile);
+
+describe("scope runtime worker boundary", () => {
+  it("is a standalone entrypoint inside the minimal root", async () => {
+    const source = await readFile("packages/scope-runtime/src/worker.ts", "utf8");
+    const imports = [...source.matchAll(/from\s+["']([^"']+)["']/g)]
+      .map((match) => match[1]);
+
+    expect(imports.length).toBeGreaterThan(0);
+    expect(imports.every((specifier) => specifier?.startsWith("node:"))).toBe(true);
+  });
+
+  it("accepts only the fixed proven adapter invocation", () => {
+    expect(parseScopeRuntimeWorkerArguments(argumentsFixture)).toEqual({
+      runtimeHandle: argumentsFixture[0],
+      scopeHandle: argumentsFixture[1],
+      workload: "chat_ai",
+      adapterId: "claude-code",
+      harnessVersion: "2.1.240",
+    });
+    expect(() => parseScopeRuntimeWorkerArguments([...argumentsFixture, "/bin/sh"]))
+      .toThrow(expect.objectContaining({ name: "ScopeRuntimeInvocationError" }));
+    expect(() => parseScopeRuntimeWorkerArguments([
+      argumentsFixture[0]!, argumentsFixture[1]!, "terminal", "claude-code", "2.1.240",
+    ])).toThrow(expect.objectContaining({ name: "ScopeRuntimeInvocationError" }));
+  });
+
+  it("re-execs once with only the fixed environment before validating the boundary", () => {
+    const inherited = {
+      HOME: "/home/matrix/home",
+      PATH: "/usr/local/bin:/usr/bin",
+      MATRIX_AUTH_TOKEN: "owner-secret",
+      INVOCATION_ID: "public-systemd-id",
+    };
+    const executable = "/opt/matrix/runtime/node/bin/node";
+    const workerFile = "/opt/matrix/scope-runtime/worker.mjs";
+
+    const first = prepareScopeRuntimeWorkerEnvironment(
+      argumentsFixture,
+      inherited,
+      executable,
+      workerFile,
+    );
+    expect(first).toEqual({
+      reexec: {
+        executable,
+        arguments: [
+          executable,
+          workerFile,
+          "--matrix-scope-fixed-environment",
+          ...argumentsFixture,
+        ],
+        environment: {
+          HOME: "/workspace",
+          PATH: "/opt/matrix/runtime/node/bin",
+          MATRIX_SCOPE_RUNTIME: "1",
+        },
+      },
+    });
+    expect(inherited).toHaveProperty("MATRIX_AUTH_TOKEN", "owner-secret");
+
+    const fixedEnvironment = { ...first.reexec!.environment };
+    expect(prepareScopeRuntimeWorkerEnvironment(
+      first.reexec!.arguments.slice(2),
+      fixedEnvironment,
+      executable,
+      workerFile,
+    )).toEqual({ invocationArguments: argumentsFixture });
+    expect(fixedEnvironment).toEqual(first.reexec!.environment);
+  });
+
+  it("removes inherited credentials at the OS process boundary", async () => {
+    await expect(execFileAsync(process.execPath, [
+      "packages/scope-runtime/src/worker.ts",
+      ...argumentsFixture,
+    ], {
+      env: { ...process.env, MATRIX_AUTH_TOKEN: "owner-secret" },
+      timeout: 5_000,
+    })).rejects.toMatchObject({
+      code: 85,
+    });
+  });
+
+  it("keeps the ready worker alive until the supervisor signals shutdown", async () => {
+    await expect(execFileAsync(process.execPath, [
+      "--input-type=module",
+      "--eval",
+      'import { waitForScopeRuntimeShutdown } from "./packages/scope-runtime/src/worker.ts";'
+        + 'process.stdout.write("ready\\n"); await waitForScopeRuntimeShutdown();',
+    ], {
+      cwd: process.cwd(),
+      timeout: 250,
+      killSignal: "SIGKILL",
+    })).rejects.toMatchObject({ killed: true, signal: "SIGKILL" });
+  });
+
+  it("requires the minimal fixed environment and rejects inherited credentials", () => {
+    const safe = {
+      HOME: "/workspace",
+      PATH: "/opt/matrix/runtime/node/bin",
+      MATRIX_SCOPE_RUNTIME: "1",
+      INVOCATION_ID: "public-systemd-id",
+    };
+    expect(validateScopeRuntimeWorkerEnvironment(safe)).toEqual(safe);
+    for (const injected of [
+      { ANTHROPIC_API_KEY: "secret" },
+      { MATRIX_AUTH_TOKEN: "secret" },
+      { DATABASE_URL: "postgres://owner" },
+    ]) {
+      expect(() => validateScopeRuntimeWorkerEnvironment({ ...safe, ...injected }))
+        .toThrow(expect.objectContaining({ name: "ScopeRuntimeEnvironmentKeyError" }));
+    }
+    expect(() => validateScopeRuntimeWorkerEnvironment({ ...safe, HOME: "/home/matrix/home" }))
+      .toThrow(expect.objectContaining({ name: "ScopeRuntimeEnvironmentFixedError" }));
+    const oversized = Object.fromEntries(Array.from({ length: 257 }, (_, index) => [`KEY_${index}`, "value"]));
+    expect(() => validateScopeRuntimeWorkerEnvironment({ ...safe, ...oversized }))
+      .toThrow(expect.objectContaining({ name: "ScopeRuntimeEnvironmentCapacityError" }));
+  });
+
+  it("scrubs inherited entries before any workload code can observe them", () => {
+    const inherited = {
+      HOME: "/workspace",
+      PATH: "/opt/matrix/runtime/node/bin",
+      MATRIX_SCOPE_RUNTIME: "1",
+      INVOCATION_ID: "public-systemd-id",
+      MATRIX_AUTH_TOKEN: "owner-secret",
+      OVERSIZED_INHERITED_VALUE: "x".repeat(9_000),
+      ["K".repeat(300)]: "discarded-before-validation",
+    };
+
+    expect(scrubScopeRuntimeWorkerEnvironment(inherited)).toEqual({
+      HOME: "/workspace",
+      PATH: "/opt/matrix/runtime/node/bin",
+      MATRIX_SCOPE_RUNTIME: "1",
+    });
+    expect(inherited).toEqual({
+      HOME: "/workspace",
+      PATH: "/opt/matrix/runtime/node/bin",
+      MATRIX_SCOPE_RUNTIME: "1",
+    });
+  });
+
+  it("publishes through only the supervisor-created readiness marker", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "matrix-scope-worker-ready-"));
+    try {
+      const marker = join(directory, "ready");
+      await writeFile(marker, "", { flag: "wx", mode: 0o622 });
+      await chmod(marker, 0o622);
+      await writeScopeRuntimeReadiness(argumentsFixture[0]!, directory);
+      expect(await readFile(marker, "utf8")).toBe(`${argumentsFixture[0]}\n`);
+      expect((await stat(marker)).mode & 0o777).toBe(0o622);
+      await rm(marker);
+      await expect(writeScopeRuntimeReadiness(argumentsFixture[0]!, directory)).rejects
+        .toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("maps allowlisted worker failure classes to bounded process exit codes", () => {
+    expect(scopeRuntimeWorkerFailureExitCode(Object.assign(new Error("raw path"), {
+      name: "ScopeRuntimeBrokerError",
+    }))).toBe(80);
+    expect(scopeRuntimeWorkerFailureExitCode(Object.assign(new Error("readiness failed"), {
+      name: "ScopeRuntimeReadinessError",
+    }))).toBe(88);
+    expect(scopeRuntimeWorkerFailureForExitCode(13)).toBeUndefined();
+    expect(scopeRuntimeWorkerFailureExitCode(new Error("raw unknown message"))).toBe(89);
+  });
+});


### PR DESCRIPTION
## Summary

- Stack: PR2b for Spec 121, after the native-boundary proof in #1587.
- Adds the dormant VPS-native scope-runtime supervisor, strict protocol, fixed source-controlled systemd sandbox profile, dynamic workload identities, readiness signaling, reconciliation, and bounded lifecycle cleanup.
- Packages the service in the host bundle behind `SCOPE_RUNTIME_DISABLED`; this PR does not enable shared execution.
- Split from #1588 to satisfy the repository's hard 3,000-addition review limit. This layer is 2,321 additions across 20 files.

## Tests

- Scope-runtime and deployment suites: 5 files, 26 tests passed outside the sandbox for Unix-socket coverage.
- Scope-runtime TypeScript check passed using the repository toolchain.
- The complete post-split stack has the same tree as the previously validated combined head.
- No React files changed; React Doctor and screenshot evidence are not applicable.

## Review/Monitoring

- Non-draft and monitored independently for current-head Greptile 5/5 and CI.
- Exact disposable-VPS production acceptance remains in stacked PR #1589.

## Invariants

### Source of truth

The source-controlled runtime protocol/profile and systemd state are authoritative for this dormant execution boundary. Owner-controlled Postgres remains authoritative for future collaboration authorization and execution records.

### Lock/transaction scope

This layer adds no database writes. Capacity reservations are bounded in the supervisor; systemd operations stay outside any future database transaction.

### Acceptable orphan states

Failed launches clean their private roots and submitted units. Restart reconciliation retains only active, ready runtimes and removes bounded orphan state. The app-owned disabled marker prevents accidental activation.

### Auth source of truth

This supervisor accepts only source-controlled fixed-profile fields. It grants no collaboration membership and has no configured-owner fallback; the downstream broker reauthorizes scoped actions.

### Deferred scope

Gateway credential/egress brokerage is #1588. Exact production acceptance is #1589. Shared Chat AI admission, queueing, approvals, controls, and enablement remain PR3/M2.
