### PR TITLE
fix(vps): complete restore downloads before starting runtime

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -584,6 +584,9 @@ runcmd:
       exit 1
     fi
     usermod -d /home/matrix/home matrix
+    # Cloud-init does not reapply supplementary groups to an existing snapshot
+    # user. The restore gate must access the local Postgres container as matrix.
+    usermod -aG docker matrix
     install -d -o matrix -g matrix -m 0750 /home/matrix/home /home/matrix/home/projects /home/matrix/projects /var/lib/matrix/db /var/lib/matrix/db/snapshots /var/lib/matrix/logs
     ensure_owner_link() {
       local name="$1" mode="$2" legacy="/home/matrix/$1" target="/home/matrix/home/$1"

--- a/distro/customer-vps/host-bin/matrix-r2-broker.mjs
+++ b/distro/customer-vps/host-bin/matrix-r2-broker.mjs
@@ -3,8 +3,6 @@
 import { createReadStream } from 'node:fs';
 import { lstat, open, rename, rm } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
-import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
 import { randomUUID } from 'node:crypto';
 
 const API_TIMEOUT_MS = 10_000;
@@ -208,8 +206,12 @@ async function get(key, destination) {
   let handle;
   try {
     handle = await open(temp, 'wx', 0o600);
-    const output = handle.createWriteStream({ autoClose: false });
-    await pipeline(Readable.fromWeb(response.body), output);
+    // Keep file-handle ownership here: an autoClose:false WriteStream retains
+    // the handle, so close() can remain pending and the CLI exit before rename.
+    // Await each bounded chunk to preserve backpressure without a second owner.
+    for await (const chunk of response.body) {
+      await handle.writeFile(chunk);
+    }
     await handle.sync();
     await handle.close();
     handle = undefined;

--- a/docs/dev/backup-restore-readiness.md
+++ b/docs/dev/backup-restore-readiness.md
@@ -1,0 +1,44 @@
+# Backup restore and startup readiness
+
+The platform's provisioning page is shown before the Web Desktop starts. A VPS
+being powered on is not proof that its restore gate, gateway, or web frontend is
+ready. Never change a machine to `running` or create a restore-complete marker
+just to dismiss the loading screen.
+
+## Download completion contract
+
+`distro/customer-vps/host-bin/matrix-r2-broker.mjs` must return success for `get`
+only after it has streamed the response into an exclusive temporary file, synced
+and closed the descriptor, and atomically renamed it to the destination. A failed
+download must preserve an existing destination and clean its temporary file.
+
+Do not wrap the owned `FileHandle` in an `autoClose: false` write stream: that
+stream can retain a reference which prevents `FileHandle.close()` from resolving.
+A pending promise alone does not keep Node running, so the process can exit zero
+with only a hidden temporary file and no final destination. Awaiting bounded
+response chunks directly keeps backpressure and leaves one descriptor owner.
+
+## Snapshot account reconciliation
+
+Cloud-init's declarative user configuration does not reliably reapply groups to
+an existing snapshot user. Explicitly append the `docker` group to `matrix` before
+the restore gate starts. This restores the already-declared host permissions for
+access to the local Postgres container; it must not replace other groups or make
+the Docker socket world-writable.
+
+## Verification
+
+- Run `tests/platform/r2-broker-download.test.ts`: these spawn the real CLI with
+  mocked network responses and real files, covering initial/replacement/empty
+  downloads, private file permissions, cleanup, and streaming failure.
+- Run `tests/platform/snapshot-restore-groups.test.ts` and the existing
+  `tests/platform/customer-vps-host-bundle.test.ts` contract suite.
+- On a disposable snapshot-based VPS, verify restore success before checking
+  gateway/frontend health and platform registration. Verify the exact requested
+  bundle after deployment, not merely the base snapshot version.
+- Keep owner data, backup objects, and the primary computer untouched during
+  preview recovery. Do not publish customer identifiers or credentials in logs,
+  documentation, or PR descriptions.
+
+The platform's stale-provisioning/failure presentation is a separate concern;
+this fix does not claim to add automatic reconciliation or error UI.

--- a/tests/platform/r2-broker-download.test.ts
+++ b/tests/platform/r2-broker-download.test.ts
@@ -9,17 +9,30 @@ afterEach(() => {
   for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
 
-function download({ existing = false, broken = false, empty = false } = {}) {
+function download({
+  existing = false,
+  broken = false,
+  empty = false,
+  chunks,
+}: {
+  existing?: boolean;
+  broken?: boolean;
+  empty?: boolean;
+  chunks?: string[];
+} = {}) {
   const directory = mkdtempSync(join(tmpdir(), 'matrix-broker-download-'));
   directories.push(directory);
   const destination = join(directory, 'latest');
   if (existing) writeFileSync(destination, 'old snapshot');
   // Exercise the shipped CLI in a real subprocess with real file handles. No network/credentials.
+  const downloadBody = broken
+    ? "new ReadableStream({start(c){c.error(new Error('private storage failure'));}})"
+    : chunks
+      ? `new ReadableStream({start(c){for(const chunk of ${JSON.stringify(chunks)}) c.enqueue(new TextEncoder().encode(chunk));c.close();}})`
+      : JSON.stringify(empty ? '' : 'system/runtime-slots/pr-1502/db/snapshots/2026-09-09T1200Z.dump\n');
   const stub = `globalThis.fetch = async (url) => {
     if (String(url).endsWith('/presign/get')) return Response.json({url:'https://download.test/snapshot'});
-    return new Response(${broken
-      ? "new ReadableStream({start(c){c.error(new Error('private storage failure'));}})"
-      : JSON.stringify(empty ? '' : 'system/runtime-slots/pr-1502/db/snapshots/2026-09-09T1200Z.dump\n')});
+    return new Response(${downloadBody});
   };`;
   const result = spawnSync(process.execPath, [
     '--import', `data:text/javascript,${encodeURIComponent(stub)}`,
@@ -49,6 +62,19 @@ describe('host R2 download completion', () => {
     const { directory, destination, result } = download({ empty: true });
     expect(result.status).toBe(0);
     expect(readFileSync(destination).length).toBe(0);
+    expect(readdirSync(directory)).toEqual(['latest']);
+  });
+
+  it('preserves ordering across multiple successful response chunks', () => {
+    const chunks = [
+      'system/runtime-slots/pr-1502/',
+      'db/snapshots/',
+      '2026-09-09T1200Z.dump\n',
+    ];
+    const { directory, destination, result } = download({ chunks });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(readFileSync(destination, 'utf8')).toBe(chunks.join(''));
     expect(readdirSync(directory)).toEqual(['latest']);
   });
 

--- a/tests/platform/r2-broker-download.test.ts
+++ b/tests/platform/r2-broker-download.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const directories: string[] = [];
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function download({ existing = false, broken = false, empty = false } = {}) {
+  const directory = mkdtempSync(join(tmpdir(), 'matrix-broker-download-'));
+  directories.push(directory);
+  const destination = join(directory, 'latest');
+  if (existing) writeFileSync(destination, 'old snapshot');
+  // Exercise the shipped CLI in a real subprocess with real file handles. No network/credentials.
+  const stub = `globalThis.fetch = async (url) => {
+    if (String(url).endsWith('/presign/get')) return Response.json({url:'https://download.test/snapshot'});
+    return new Response(${broken
+      ? "new ReadableStream({start(c){c.error(new Error('private storage failure'));}})"
+      : JSON.stringify(empty ? '' : 'system/runtime-slots/pr-1502/db/snapshots/2026-09-09T1200Z.dump\n')});
+  };`;
+  const result = spawnSync(process.execPath, [
+    '--import', `data:text/javascript,${encodeURIComponent(stub)}`,
+    resolve('distro/customer-vps/host-bin/matrix-r2-broker.mjs'),
+    'get', 'system/runtime-slots/pr-1502/db/latest', destination,
+  ], {
+    encoding: 'utf8', timeout: 5_000,
+    env: {
+      MATRIX_HANDLE: 'pr-1502', PLATFORM_INTERNAL_URL: 'https://platform.test',
+      UPGRADE_TOKEN: 'test-only-token-not-a-real-credential',
+    },
+  });
+  return { directory, destination, result };
+}
+
+describe('host R2 download completion', () => {
+  it.each([false, true])('commits the destination before successful exit (existing=%s)', (existing) => {
+    const { directory, destination, result } = download({ existing });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(readFileSync(destination, 'utf8')).toBe('system/runtime-slots/pr-1502/db/snapshots/2026-09-09T1200Z.dump\n');
+    expect(statSync(destination).mode & 0o777).toBe(0o600);
+    expect(readdirSync(directory)).toEqual(['latest']);
+  });
+
+  it('completes empty downloads without leaving a temporary file', () => {
+    const { directory, destination, result } = download({ empty: true });
+    expect(result.status).toBe(0);
+    expect(readFileSync(destination).length).toBe(0);
+    expect(readdirSync(directory)).toEqual(['latest']);
+  });
+
+  it('preserves the previous file and cleans up when streaming fails', () => {
+    const { directory, destination, result } = download({ existing: true, broken: true });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('matrix-r2-broker: operation failed');
+    expect(result.stderr).not.toContain('private storage failure');
+    expect(readFileSync(destination, 'utf8')).toBe('old snapshot');
+    expect(readdirSync(directory)).toEqual(['latest']);
+  });
+});

--- a/tests/platform/snapshot-restore-groups.test.ts
+++ b/tests/platform/snapshot-restore-groups.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('snapshot restore account reconciliation', () => {
+  it('adds Docker access explicitly for existing snapshot users before starting restore', () => {
+    const source = readFileSync('distro/customer-vps/cloud-init.yaml', 'utf8');
+    const reconcile = source.indexOf('usermod -aG docker matrix');
+    expect(reconcile).toBeGreaterThan(-1);
+    expect(reconcile).toBeLessThan(source.indexOf('systemctl start matrix-restore.service'));
+    // Append, never replace the owner account’s other supplementary groups.
+    expect(source).not.toMatch(/usermod -G docker matrix/);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix restore downloads that exit successfully without publishing the destination: an `autoClose: false` stream retains the file handle, leaving `close()` pending before rename.
- Stream bounded response chunks directly into the owned handle, preserving backpressure, private temporary files, fsync, and atomic rename.
- Reconcile Docker group membership for an existing snapshot user before restore starts.
- Add public-safe operator documentation and subprocess regression tests.

## Tests

- TDD: reproduced missing destination on the original CLI, then green after the fix.
- 76 tests pass across `r2-broker-download`, `snapshot-restore-groups`, and `customer-vps-host-bundle`.
- `node --check` and `git diff --check` pass.
- `bun run check:patterns`: zero violations, five existing warnings.
- Full typecheck/test commands attempted but package-manager bootstrap stalled; stopped those commands. Full-suite pass is not claimed.
- Disposable snapshot-based VPS: restore completed, exact requested bundle installed, gateway/shell/sync active and Web Desktop loaded. No production fleet rollout.

## Invariants

### Source of truth
- Durable owner backups remain in the existing object store. Restore completion and actual runtime health gate readiness; power-on alone does not.

### Lock/transaction scope
- Exclusive temporary-file creation; one file-handle owner; awaited writes, fsync and close before atomic rename. No database changes.

### Acceptable orphan states
- Caught failures remove the temporary download and preserve an existing destination. Abrupt host/process termination may leave a private temporary file, as before.

### Auth source of truth
- Existing broker authorization and scoped presigned downloads are unchanged. Append only the Docker group already declared for the runtime account; do not relax socket permissions.

### Deferred scope
- Loading/error UI, TTL preview retention, and Cloudflare token-count authentication are separate concerns. Nothing in this PR claims funded inference works or requests a merge/deployment.
