### PR TITLE
test(gateway): wait for queued Codex turn completions

### DIFF
--- a/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
+++ b/tests/gateway/coding-agents-codex-app-server-runtime.test.ts
@@ -11,11 +11,14 @@ function visibleTranscript(transcript: string): string {
   return transcript.trim().split("\n").filter((line) => JSON.parse(line).type !== "thread.started").join("\n");
 }
 
-async function waitForTranscript(path: string, pattern: RegExp): Promise<string> {
+async function waitForTranscript(
+  path: string,
+  condition: RegExp | ((transcript: string) => boolean),
+): Promise<string> {
   const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
     const value = await readFile(path, "utf8").catch(() => "");
-    if (pattern.test(value)) return value;
+    if (typeof condition === "function" ? condition(value) : condition.test(value)) return value;
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
   throw new Error("Timed out waiting for Codex transcript");
@@ -633,7 +636,10 @@ describe("Codex app-server control runtime", () => {
     child.stdin?.write(`matrix-turn-v2:${secondTurn}\n`);
 
     try {
-      await waitForTranscript(eventPath, /answer-2/);
+      const transcript = await waitForTranscript(
+        eventPath,
+        (value) => (value.match(/"type":"turn.completed"/g) ?? []).length >= 2,
+      );
       const requests = (await readFile(requestsPath, "utf8"))
         .trim().split("\n").map((line) => JSON.parse(line));
       expect(requests).toHaveLength(2);
@@ -651,7 +657,6 @@ describe("Codex app-server control runtime", () => {
         effort: "high",
         serviceTier: "standard",
       });
-      const transcript = await readFile(eventPath, "utf8");
       expect(transcript.match(/"type":"turn.completed"/g)).toHaveLength(2);
       expect(transcript).toContain("answer-1");
       expect(transcript).toContain("answer-2");


### PR DESCRIPTION
## Summary

- make the bounded transcript polling helper accept a predicate
- wait for two persisted `turn.completed` records before asserting the queued-turn transcript
- keep the exact completion-count assertion and production runtime unchanged

## Tests

- red-phase ordering spike: reproduced the CI assertion (`expected 2`, received `1`) by widening the valid gap between assistant output and terminal persistence; spike reverted before commit
- focused failing test: 10/10 sequential runs passed
- `pnpm exec vitest run tests/gateway/coding-agents-codex-app-server-runtime.test.ts --maxWorkers=1 --no-file-parallelism`: 13/13 passed
- typecheck command sequence: passed for observability, integrations-mcp, gateway, platform, proxy, edge-router, and desktop (`bun` is unavailable on this host, so the same underlying pnpm scripts were run directly)
- `pnpm run check:patterns`: passed with 0 violations (pre-existing warnings only)
- `pnpm run test`: changed runtime file passed; broad local run became resource-bound and was stopped after unrelated platform timeouts in `proxy-routing.test.ts`, `golden-snapshot-repository.test.ts`, and worker teardown
- PR CI run `34413474294`: passed, including all four unit shards and E2E

## Review/Monitoring

- Greptile: 5/5 on commit `16a07687aa4d38cd61eb6371806918ce43631887`
- review threads: none
- Claude review and all required PR checks: passed
- PR is ready to merge; merge requires explicit authorization

## Invariants

- **Source of truth:** the append-only Codex provider transcript remains the sole source checked by the test
- **Lock/transaction scope:** unchanged; this is test synchronization only
- **Acceptable orphan states:** unchanged; no production writes or lifecycle behavior changed
- **Auth source of truth:** unchanged and out of scope
- **Deferred scope:** production runtime changes and unrelated local platform-test timeouts are explicitly out of scope
