### PR TITLE
feat(gateway): add terminal workspace HTTP contract

### DIFF
--- a/packages/gateway/src/project-lifecycle.ts
+++ b/packages/gateway/src/project-lifecycle.ts
@@ -10,6 +10,7 @@ export const ProjectLifecycleActionSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("delete"),
     confirmation: z.string().min(1).max(128),
+    confirmTerminate: z.boolean().optional(),
   }).strict(),
 ]);
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -325,6 +325,7 @@ import {
 import { registerAppRuntimeRoutes } from "./server/app-runtime-routes.js";
 import { registerFileRoutes } from "./server/file-routes.js";
 import { registerConversationHistoryRoutes } from "./server/conversation-history-routes.js";
+import { startTerminalPasteAssetCleanup } from "./shell/paste-asset-cleanup-runtime.js";
 import {
   metricsRegistry,
   httpRequestsTotal,
@@ -4688,6 +4689,10 @@ export async function createGateway(config: GatewayConfig) {
   void chatAttachmentCleanup.runNow().catch((error: unknown) => {
     logBestEffortFailure("Initial temporary Chat attachment cleanup failed", error);
   });
+  const terminalPasteAssetCleanup = startTerminalPasteAssetCleanup({
+    homePath,
+    onFailure: logBestEffortFailure,
+  });
 
   return {
     app,
@@ -4702,6 +4707,7 @@ export async function createGateway(config: GatewayConfig) {
     pluginRegistry,
     hookRunner,
     async close() {
+      await terminalPasteAssetCleanup.close();
       await chatIdleReaper?.close().catch((error: unknown) => {
         logBestEffortFailure("Chat idle runtime reconciliation shutdown failed", error);
       });

--- a/packages/gateway/src/server/route-inventory.ts
+++ b/packages/gateway/src/server/route-inventory.ts
@@ -28,7 +28,7 @@ export const GATEWAY_ROUTE_GROUPS: GatewayRouteGroup[] = [
   {
     id: "shell-terminal",
     label: "Shell terminal HTTP and WebSocket routes",
-    paths: ["/api/terminal", "/api", "/ws/terminal", "/ws/terminal/session"],
+    paths: ["/api/terminal/workspaces", "/ws/terminal/tab"],
     plannedModule: "server/routes/shell-terminal.ts",
   },
   {

--- a/packages/gateway/src/shell/index.ts
+++ b/packages/gateway/src/shell/index.ts
@@ -23,3 +23,4 @@ export * from "./user-systemd-zellij-adapter.js";
 export * from "./terminal-acceptance-routes.js";
 export * from "./terminal-window-layout-routes.js";
 export * from "./terminal-window-layout-store.js";
+export * from "./workspace-routes.js";

--- a/packages/gateway/src/shell/paste-asset-cleanup-runtime.ts
+++ b/packages/gateway/src/shell/paste-asset-cleanup-runtime.ts
@@ -1,0 +1,27 @@
+import { createTerminalPasteAssetCleanupLifecycle } from "./paste-assets.js";
+
+export interface TerminalPasteAssetCleanupRuntime {
+  close(): Promise<void>;
+}
+
+export function startTerminalPasteAssetCleanup(options: {
+  homePath: string;
+  onFailure: (context: string, error: unknown) => void;
+}): TerminalPasteAssetCleanupRuntime {
+  const lifecycle = createTerminalPasteAssetCleanupLifecycle({
+    homePath: options.homePath,
+    onError: (error) => options.onFailure("Temporary terminal paste cleanup failed", error),
+  });
+  void lifecycle.runNow().catch((error: unknown) => {
+    options.onFailure("Initial temporary terminal paste cleanup failed", error);
+  });
+
+  return {
+    async close() {
+      lifecycle.close();
+      await lifecycle.waitForIdle().catch((error: unknown) => {
+        options.onFailure("Temporary terminal paste cleanup shutdown failed", error);
+      });
+    },
+  };
+}

--- a/packages/gateway/src/shell/paste-assets.ts
+++ b/packages/gateway/src/shell/paste-assets.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, open, rename, unlink } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, readdir, rename, unlink, type FileHandle } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 import { resolveWritableFileApiPath } from "../path-security.js";
 import { shellError } from "./errors.js";
@@ -13,6 +14,12 @@ const SUPPORTED_MIME_TYPES = new Set([
   "image/webp",
 ]);
 const SAFE_CLIENT_FILENAME = /^[^/\\\0]{1,255}$/;
+const PASTE_ASSET_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_RETAINED_PASTE_ASSETS = 128;
+const DATE_DIRECTORY = /^\d{4}-\d{2}-\d{2}$/;
+export const TERMINAL_PASTE_ASSET_CLEANUP_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const { O_DIRECTORY, O_NOFOLLOW, O_RDONLY } = constants;
+const DIRECTORY_OPEN_FLAGS = O_RDONLY | O_DIRECTORY | O_NOFOLLOW;
 
 interface PasteAssetKind {
   mimeType: "image/png" | "image/jpeg" | "image/gif" | "image/webp";
@@ -35,6 +42,63 @@ export interface TerminalPasteAssetResult {
   mimeType: string;
 }
 
+export interface TerminalPasteAssetCleanupLifecycle {
+  runNow(): Promise<void>;
+  waitForIdle(): Promise<void>;
+  close(): void;
+}
+
+export function createTerminalPasteAssetCleanupLifecycle(options: {
+  homePath: string;
+  intervalMs?: number;
+  now?: () => number;
+  schedule?: (callback: () => void, intervalMs: number) => unknown;
+  cancel?: (handle: unknown) => void;
+  onError?: (error: unknown) => void;
+}): TerminalPasteAssetCleanupLifecycle {
+  const intervalMs = options.intervalMs ?? TERMINAL_PASTE_ASSET_CLEANUP_INTERVAL_MS;
+  if (!Number.isSafeInteger(intervalMs) || intervalMs <= 0) {
+    throw new Error("InvalidTerminalPasteAssetCleanupInterval");
+  }
+  const now = options.now ?? Date.now;
+  const schedule = options.schedule ?? ((callback, ms) => setInterval(callback, ms));
+  const cancel = options.cancel ?? ((handle) => clearInterval(handle as ReturnType<typeof setInterval>));
+  let closed = false;
+  let inFlight: Promise<void> | null = null;
+
+  const runNow = (): Promise<void> => {
+    if (closed) return Promise.resolve();
+    if (inFlight) return inFlight;
+    const cleanup = cleanupTerminalPasteAssets(options.homePath, now());
+    inFlight = cleanup.then(
+      () => { inFlight = null; },
+      (error: unknown) => {
+        inFlight = null;
+        throw error;
+      },
+    );
+    return inFlight;
+  };
+
+  const handle = schedule(() => {
+    void runNow().catch((error: unknown) => options.onError?.(error));
+  }, intervalMs);
+  if (typeof handle === "object" && handle !== null && "unref" in handle) {
+    const unref = (handle as { unref?: unknown }).unref;
+    if (typeof unref === "function") unref.call(handle);
+  }
+
+  return {
+    runNow,
+    async waitForIdle() { await inFlight; },
+    close() {
+      if (closed) return;
+      closed = true;
+      cancel(handle);
+    },
+  };
+}
+
 export async function saveTerminalPasteAsset(input: TerminalPasteAssetInput): Promise<TerminalPasteAssetResult> {
   if (input.bytes.byteLength < 1 || input.bytes.byteLength > TERMINAL_PASTE_ASSET_BODY_LIMIT) {
     throw shellError("payload_too_large", "Request too large", 413);
@@ -49,7 +113,8 @@ export async function saveTerminalPasteAsset(input: TerminalPasteAssetInput): Pr
     throw shellError("unsupported_media_type", "Invalid request", 400);
   }
 
-  const date = formatPasteAssetDate(input.now ?? new Date());
+  const now = input.now ?? new Date();
+  const date = formatPasteAssetDate(now);
   const relativeDir = join("temporary", "terminal-pastes", date);
   const filename = `${Date.now()}-${randomUUID()}${kind.extension}`;
   const relativePath = join(relativeDir, filename);
@@ -62,6 +127,7 @@ export async function saveTerminalPasteAsset(input: TerminalPasteAssetInput): Pr
     throw shellError("invalid_request", "Invalid request", 400);
   }
 
+  await cleanupTerminalPasteAssets(input.homePath, now.getTime());
   await mkdir(absoluteDir, { recursive: true });
   const tempPath = join(absoluteDir, `.${filename}.tmp`);
   const handle = await open(tempPath, "wx");
@@ -88,6 +154,101 @@ export async function saveTerminalPasteAsset(input: TerminalPasteAssetInput): Pr
     size: input.bytes.byteLength,
     mimeType: kind.mimeType,
   };
+}
+
+interface PinnedDirectory {
+  handle: FileHandle;
+  path: string;
+}
+
+async function openPinnedDirectory(path: string): Promise<PinnedDirectory | null> {
+  let handle: FileHandle;
+  try {
+    handle = await open(path, DIRECTORY_OPEN_FLAGS);
+  } catch (error: unknown) {
+    if (isMissing(error) || isUnsafeDirectory(error)) return null;
+    throw error;
+  }
+  const pinnedPath = process.platform === "linux"
+    ? `/proc/self/fd/${handle.fd}`
+    : process.platform === "darwin" ? `/dev/fd/${handle.fd}` : path;
+  return { handle, path: pinnedPath };
+}
+
+async function cleanupTerminalPasteAssets(homePath: string, nowMs: number): Promise<void> {
+  const root = resolveWritableFileApiPath(homePath, join("temporary", "terminal-pastes"));
+  if (!root) throw shellError("invalid_request", "Invalid request", 400);
+  const pinnedHome = await openPinnedDirectory(homePath);
+  if (!pinnedHome) return;
+  let pinnedTemporary: PinnedDirectory | null = null;
+  let pinnedRoot: PinnedDirectory | null = null;
+  try {
+    pinnedTemporary = await openPinnedDirectory(join(pinnedHome.path, "temporary"));
+    if (!pinnedTemporary) return;
+    pinnedRoot = await openPinnedDirectory(join(pinnedTemporary.path, "terminal-pastes"));
+    if (!pinnedRoot) return;
+    const retained: Array<{ path: string; mtimeMs: number; directory: PinnedDirectory }> = [];
+    const retainedDirectories = new Set<PinnedDirectory>();
+    try {
+      for (const dateDirectory of await readdir(pinnedRoot.path)) {
+        if (!DATE_DIRECTORY.test(dateDirectory)) continue;
+        const pinnedDirectory = await openPinnedDirectory(join(pinnedRoot.path, dateDirectory));
+        if (!pinnedDirectory) continue;
+        try {
+          for (const filename of await readdir(pinnedDirectory.path)) {
+            const path = join(pinnedDirectory.path, filename);
+            let stat;
+            try { stat = await lstat(path); }
+            catch (error: unknown) { if (isMissing(error)) continue; throw error; }
+            if (stat.isSymbolicLink() || !stat.isFile()) continue;
+            if (nowMs - stat.mtimeMs >= PASTE_ASSET_TTL_MS) {
+              await unlinkIfPresent(path);
+              continue;
+            }
+            retained.push({ path, mtimeMs: stat.mtimeMs, directory: pinnedDirectory });
+            retained.sort((left, right) => right.mtimeMs - left.mtimeMs);
+            if (retained.length > MAX_RETAINED_PASTE_ASSETS - 1) {
+              const evicted = retained.pop()!;
+              await unlinkIfPresent(evicted.path);
+              if (evicted.directory !== pinnedDirectory
+                && !retained.some((candidate) => candidate.directory === evicted.directory)) {
+                retainedDirectories.delete(evicted.directory);
+                await evicted.directory.handle.close();
+              }
+            }
+          }
+          if (retained.some((candidate) => candidate.directory === pinnedDirectory)) {
+            retainedDirectories.add(pinnedDirectory);
+          } else {
+            await pinnedDirectory.handle.close();
+          }
+        } catch (error: unknown) {
+          if (!retainedDirectories.has(pinnedDirectory)) await pinnedDirectory.handle.close();
+          throw error;
+        }
+      }
+    } finally {
+      await Promise.all([...retainedDirectories].map((directory) => directory.handle.close()));
+    }
+  } finally {
+    if (pinnedRoot) await pinnedRoot.handle.close();
+    if (pinnedTemporary) await pinnedTemporary.handle.close();
+    await pinnedHome.handle.close();
+  }
+}
+
+async function unlinkIfPresent(path: string): Promise<void> {
+  try { await unlink(path); }
+  catch (error: unknown) { if (!isMissing(error)) throw error; }
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function isUnsafeDirectory(error: unknown): boolean {
+  return error instanceof Error && "code" in error
+    && (error.code === "ELOOP" || error.code === "ENOTDIR");
 }
 
 function normalizeContentType(contentType: string | undefined): string | undefined {

--- a/packages/gateway/src/shell/workspace-routes.ts
+++ b/packages/gateway/src/shell/workspace-routes.ts
@@ -1,0 +1,327 @@
+import { bodyLimit } from "hono/body-limit";
+import { Hono } from "hono";
+import {
+  CanonicalChatIdSchema,
+  ProjectIdSchema,
+  ProviderIdSchema,
+  SafeDisplayStringSchema,
+  TerminalPaneActionSchema,
+  TerminalRefSchema,
+  TerminalTabIdSchema,
+  TerminalWorkspaceIdSchema,
+  ThreadIdSchema,
+  type TerminalTab,
+  type TerminalPaneAction,
+  type TerminalWorkspace,
+} from "@matrix-os/contracts";
+import type { Context } from "hono";
+import { TerminalRuntimeError } from "@matrix-os/terminal-runtime";
+import type { RequestPrincipal } from "../request-principal.js";
+import { z } from "zod/v4";
+import {
+  saveTerminalPasteAsset,
+  TERMINAL_PASTE_ASSET_BODY_LIMIT,
+} from "./paste-assets.js";
+
+const TERMINAL_PASTE_ASSET_BASE64_LIMIT = Math.ceil(TERMINAL_PASTE_ASSET_BODY_LIMIT / 3) * 4;
+const TERMINAL_PASTE_ASSET_JSON_LIMIT = TERMINAL_PASTE_ASSET_BASE64_LIMIT + 1024;
+
+const EnsureWorkspaceSchema = z.object({ projectId: ProjectIdSchema.optional() }).strict();
+const CreateTabSchema = z.object({
+  name: SafeDisplayStringSchema,
+  cwd: z.string().max(4096),
+  command: z.array(z.string().min(1).max(4096)).min(1).max(128).optional(),
+  agent: z.object({
+    providerId: ProviderIdSchema,
+    threadId: ThreadIdSchema.optional(),
+  }).strict().optional(),
+  chatId: CanonicalChatIdSchema.optional(),
+}).strict();
+const RenameTabSchema = z.object({
+  name: SafeDisplayStringSchema,
+  baseRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+}).strict();
+const ReorderTabsSchema = z.object({
+  tabIds: z.array(TerminalTabIdSchema).max(10_000),
+  baseRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+}).strict();
+const UiStateSchema = z.object({
+  placement: z.enum(["active", "background"]).optional(),
+  lastSeenSeq: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER).nullable().optional(),
+  pinned: z.boolean().optional(),
+  baseRevision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+}).strict();
+const DeleteWorkspaceSchema = z.object({ confirmTerminate: z.boolean() }).strict();
+const PaneActionQuerySchema = z.object({ chatId: CanonicalChatIdSchema.optional() }).strict();
+const PasteAssetsSchema = z.object({
+  assets: z.array(z.object({
+    name: z.string().min(1).max(255),
+    mimeType: z.string().min(1).max(120),
+    dataBase64: z.string().min(1).max(TERMINAL_PASTE_ASSET_BASE64_LIMIT),
+  }).strict()).length(1),
+}).strict();
+
+export interface TerminalWorkspaceRouteRuntime {
+  listWorkspaces(): Promise<TerminalWorkspace[]>;
+  ensureWorkspace(input?: { projectId?: string }): Promise<TerminalWorkspace>;
+  createTab(workspaceId: string, input: {
+    name: string;
+    cwd: string;
+    accessScope?: TerminalTab["accessScope"];
+    command?: string[];
+    agent?: TerminalTab["agent"];
+  }): Promise<TerminalTab>;
+  renameTab?(ref: { workspaceId: string; tabId: string }, input: { name: string; baseRevision: number }): Promise<TerminalTab>;
+  reorderTabs?(workspaceId: string, input: { tabIds: string[]; baseRevision: number }): Promise<TerminalWorkspace>;
+  terminateTab?(ref: { workspaceId: string; tabId: string }): Promise<void>;
+  paneAction?(ref: { workspaceId: string; tabId: string }, action: TerminalPaneAction): Promise<void>;
+  updateTabUiState?(ref: { workspaceId: string; tabId: string }, input: z.infer<typeof UiStateSchema>): Promise<TerminalTab>;
+  deletionImpact(workspaceId: string): Promise<{ runningTabs: number; tabs: TerminalTab[] }>;
+  deleteWorkspace(workspaceId: string, input: { confirmTerminate: boolean }): Promise<void>;
+}
+
+export type TerminalRuntimeOwnerAccess = "allowed" | "not_found" | "unavailable";
+
+export function terminalRuntimeOwnerAccess(
+  principal: RequestPrincipal,
+  terminalOwnerIds: readonly string[],
+): TerminalRuntimeOwnerAccess {
+  if (terminalOwnerIds.length === 0) return "unavailable";
+  return terminalOwnerIds.includes(principal.userId) ? "allowed" : "not_found";
+}
+
+export function createTerminalWorkspaceRoutes(options: {
+  runtime: TerminalWorkspaceRouteRuntime;
+  homePath?: string;
+  getPrincipal: (context: Context) => RequestPrincipal;
+  terminalOwnerIds: readonly string[];
+  chatTerminals?: {
+    prepare(principal: RequestPrincipal, chatId: string): Promise<{ runId?: string; cwd?: string }>;
+    bind(principal: RequestPrincipal, input: {
+      chatId: string;
+      runId?: string;
+      sessionId: string;
+      sessionCreatedAt: string;
+    }): Promise<void>;
+    authorizePaneAction?(principal: RequestPrincipal, input: {
+      chatId: string;
+      sessionId: string;
+      sessionCreatedAt: string;
+    }): Promise<boolean>;
+    listBoundSessionIds?(principal: RequestPrincipal, sessionIds: readonly string[]): Promise<readonly string[]>;
+  };
+}): Hono {
+  const terminateTabForChat = options.chatTerminals
+    ? options.runtime.terminateTab?.bind(options.runtime)
+    : undefined;
+  if (options.chatTerminals && !terminateTabForChat) {
+    throw new Error("Chat terminal cleanup is unavailable");
+  }
+  const app = new Hono();
+  const mutationLimit = bodyLimit({ maxSize: 16 * 1024 });
+  const deleteLimit = bodyLimit({ maxSize: 1024 });
+  const pasteLimit = bodyLimit({ maxSize: TERMINAL_PASTE_ASSET_JSON_LIMIT });
+
+  app.use("*", async (c, next) => {
+    const access = terminalRuntimeOwnerAccess(options.getPrincipal(c), options.terminalOwnerIds);
+    if (access === "unavailable") return c.json({ error: "Terminal operation unavailable" }, 503);
+    if (access === "not_found") return c.json({ error: "Terminal operation failed" }, 404);
+    await next();
+  });
+
+  app.get("/workspaces", async (c) => {
+    try { return c.json({ workspaces: await options.runtime.listWorkspaces() }); }
+    catch (error) { return runtimeFailure(c, error); }
+  });
+
+  app.post("/workspaces/ensure", mutationLimit, async (c) => {
+    try {
+      const body = EnsureWorkspaceSchema.parse(await c.req.json());
+      return c.json({ workspace: await options.runtime.ensureWorkspace(body) });
+    } catch (error) { return requestFailure(c, error); }
+  });
+
+  app.post("/workspaces/:workspaceId/tabs", mutationLimit, async (c) => {
+    try {
+      const workspaceId = TerminalWorkspaceIdSchema.parse(c.req.param("workspaceId"));
+      const body = CreateTabSchema.parse(await c.req.json());
+      const principal = body.chatId ? options.getPrincipal(c) : undefined;
+      if (body.chatId && (!principal || !options.chatTerminals)) {
+        throw new Error("Chat terminal dependencies are unavailable");
+      }
+      const binding = body.chatId && principal && options.chatTerminals
+        ? await options.chatTerminals.prepare(principal, body.chatId)
+        : null;
+      const tab = await options.runtime.createTab(workspaceId, {
+        name: body.name,
+        cwd: binding?.cwd ?? body.cwd,
+        accessScope: body.chatId ? "chat" : "owner",
+        ...(body.command ? { command: body.command } : {}),
+        ...(body.agent ? { agent: body.agent } : {}),
+      });
+      if (body.chatId && principal && binding && options.chatTerminals && terminateTabForChat) {
+        try {
+          await options.chatTerminals.bind(principal, {
+            chatId: body.chatId,
+            ...(binding.runId ? { runId: binding.runId } : {}),
+            sessionId: `${workspaceId}:${tab.id}`,
+            sessionCreatedAt: tab.createdAt,
+          });
+        } catch (error: unknown) {
+          try { await terminateTabForChat({ workspaceId, tabId: tab.id }); }
+          catch (cleanupError: unknown) { console.error("[gateway] Chat terminal cleanup failed", cleanupError); }
+          throw error;
+        }
+      }
+      return c.json({ tab }, 201);
+    } catch (error) { return requestFailure(c, error); }
+  });
+
+  app.patch("/workspaces/:workspaceId/tabs/:tabId", mutationLimit, async (c) => {
+    try {
+      if (!options.runtime.renameTab) return c.json({ error: "Terminal operation unavailable" }, 503);
+      const ref = terminalRefFromParams(c.req.param("workspaceId"), c.req.param("tabId"));
+      return c.json({ tab: await options.runtime.renameTab(ref, RenameTabSchema.parse(await c.req.json())) });
+    } catch (error) { return requestFailure(c, error); }
+  });
+
+  app.put("/workspaces/:workspaceId/tabs/order", mutationLimit, async (c) => {
+    try {
+      if (!options.runtime.reorderTabs) return c.json({ error: "Terminal operation unavailable" }, 503);
+      const workspaceId = TerminalWorkspaceIdSchema.parse(c.req.param("workspaceId"));
+      return c.json({ workspace: await options.runtime.reorderTabs(workspaceId, ReorderTabsSchema.parse(await c.req.json())) });
+    } catch (error) { return requestFailure(c, error); }
+  });
+
+  app.delete("/workspaces/:workspaceId/tabs/:tabId", deleteLimit, async (c) => {
+    try {
+      if (!options.runtime.terminateTab) return c.json({ error: "Terminal operation unavailable" }, 503);
+      await options.runtime.terminateTab(terminalRefFromParams(c.req.param("workspaceId"), c.req.param("tabId")));
+      return c.body(null, 204);
+    } catch (error) { return requestFailure(c, error); }
+  });
+
+  app.post("/workspaces/:workspaceId/tabs/:tabId/pane-actions", mutationLimit, async (c) => {
+    try {
+      if (!options.runtime.paneAction) return c.json({ error: "Terminal operation unavailable" }, 503);
+      const ref = terminalRefFromParams(c.req.param("workspaceId"), c.req.param("tabId"));
+      const query = PaneActionQuerySchema.parse(Object.fromEntries(new URL(c.req.url).searchParams.entries()));
+      const action = TerminalPaneActionSchema.parse(await c.req.json());
+      const principal = options.getPrincipal(c);
+      const sessionId = `${ref.workspaceId}:${ref.tabId}`;
+      if (query.chatId !== undefined) {
+        if (!options.chatTerminals?.authorizePaneAction) {
+          return c.json({ error: "Terminal operation unavailable" }, 503);
+        }
+        const workspace = (await options.runtime.listWorkspaces()).find((candidate) => candidate.id === ref.workspaceId);
+        const tab = workspace?.tabs.find((candidate) => candidate.id === ref.tabId);
+        if (!tab || !await options.chatTerminals.authorizePaneAction(principal, {
+          chatId: query.chatId,
+          sessionId,
+          sessionCreatedAt: tab.createdAt,
+        })) {
+          return c.json({ error: "Terminal operation failed" }, 404);
+        }
+      } else if (options.chatTerminals) {
+        if (!options.chatTerminals.listBoundSessionIds) {
+          return c.json({ error: "Terminal operation unavailable" }, 503);
+        }
+        const bound = await options.chatTerminals.listBoundSessionIds(principal, [sessionId]);
+        if (bound.includes(sessionId)) return c.json({ error: "Terminal operation failed" }, 404);
+      }
+      await options.runtime.paneAction(ref, action);
+      return c.json({ ok: true });
+    } catch (error) { return requestFailure(c, error); }
+  });
+
+  app.patch("/workspaces/:workspaceId/tabs/:tabId/ui-state", mutationLimit, async (c) => {
+    try {
+      if (!options.runtime.updateTabUiState) return c.json({ error: "Terminal operation unavailable" }, 503);
+      const ref = terminalRefFromParams(c.req.param("workspaceId"), c.req.param("tabId"));
+      return c.json({ tab: await options.runtime.updateTabUiState(ref, UiStateSchema.parse(await c.req.json())) });
+    } catch (error) { return requestFailure(c, error); }
+  });
+
+  app.post("/workspaces/:workspaceId/tabs/:tabId/paste-assets", pasteLimit, async (c) => {
+    try {
+      if (!options.homePath) return c.json({ error: "Terminal operation unavailable" }, 503);
+      const ref = terminalRefFromParams(c.req.param("workspaceId"), c.req.param("tabId"));
+      const input = PasteAssetsSchema.parse(await c.req.json());
+      const workspace = (await options.runtime.listWorkspaces()).find((candidate) => candidate.id === ref.workspaceId);
+      const tab = workspace?.tabs.find((candidate) => candidate.id === ref.tabId);
+      if (!tab) return c.json({ error: "Terminal operation failed" }, 404);
+      const assets = [];
+      for (const asset of input.assets) {
+        const bytes = decodeBase64(asset.dataBase64);
+        assets.push(await saveTerminalPasteAsset({
+          homePath: options.homePath,
+          cwd: tab.cwd,
+          bytes,
+          contentType: asset.mimeType,
+          filename: asset.name,
+        }));
+      }
+      return c.json({ assets });
+    } catch (error) { return requestFailure(c, error); }
+  });
+
+  app.get("/workspaces/:workspaceId/deletion-impact", async (c) => {
+    try {
+      const workspaceId = TerminalWorkspaceIdSchema.parse(c.req.param("workspaceId"));
+      return c.json(await options.runtime.deletionImpact(workspaceId));
+    } catch (error) { return requestFailure(c, error); }
+  });
+
+  app.delete("/workspaces/:workspaceId", deleteLimit, async (c) => {
+    try {
+      const workspaceId = TerminalWorkspaceIdSchema.parse(c.req.param("workspaceId"));
+      const body = DeleteWorkspaceSchema.parse(await c.req.json());
+      const impact = await options.runtime.deletionImpact(workspaceId);
+      if (impact.runningTabs > 0 && !body.confirmTerminate) {
+        return c.json({ error: "terminal_termination_confirmation_required", ...impact }, 409);
+      }
+      await options.runtime.deleteWorkspace(workspaceId, body);
+      return c.body(null, 204);
+    } catch (error) { return requestFailure(c, error); }
+  });
+
+  return app;
+}
+
+function decodeBase64(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value) || value.length % 4 === 1) {
+    throw new z.ZodError([{ code: "custom", path: ["dataBase64"], message: "Invalid base64" }]);
+  }
+  return Buffer.from(value, "base64");
+}
+
+function terminalRefFromParams(workspaceId: string, tabId: string) {
+  return TerminalRefSchema.parse({ workspaceId, tabId });
+}
+
+function requestFailure(c: Parameters<typeof runtimeFailure>[0], error: unknown) {
+  if (error instanceof Error && error.name === "BodyLimitError") {
+    return c.json({ error: "Request body is too large" }, 413);
+  }
+  if (error instanceof z.ZodError || error instanceof SyntaxError) {
+    return c.json({ error: "Invalid request" }, 400);
+  }
+  return runtimeFailure(c, error);
+}
+
+function runtimeFailure(c: {
+  json: (body: { error: string }, status: 400 | 404 | 409 | 413 | 500 | 503) => Response;
+}, error: unknown) {
+  console.error("[gateway] terminal workspace request failed", error);
+  if (error instanceof TerminalRuntimeError) {
+    if (error.code === "invalid_request") return c.json({ error: "Invalid request" }, 400);
+    if (error.code === "not_found") return c.json({ error: "Terminal operation failed" }, 404);
+    if (error.code === "conflict") return c.json({ error: "terminal_revision_conflict" }, 409);
+    if (error.code === "confirmation_required") {
+      return c.json({ error: "terminal_termination_confirmation_required" }, 409);
+    }
+    if (error.code === "capacity") return c.json({ error: "terminal_capacity_reached" }, 409);
+    if (error.code === "unavailable") return c.json({ error: "Terminal operation unavailable" }, 503);
+  }
+  return c.json({ error: "Terminal operation failed" }, 500);
+}

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -419,7 +419,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       }
       runtime.outputCompat = outputCompat;
       // zellij attach can lose the race against the session's own creation
-      // (POST /api/terminal/sessions followed immediately by the ws attach, or
+      // (POST /api/terminal/workspaces/:workspaceId/tabs followed immediately by the ws attach, or
       // a cold zellij daemon). Retry briefly before declaring attach_failed so
       // transient startup races do not surface as user-visible errors.
       const maxAttachAttempts = 3;

--- a/packages/terminal-runtime/src/errors.ts
+++ b/packages/terminal-runtime/src/errors.ts
@@ -1,0 +1,67 @@
+export const TERMINAL_RUNTIME_ERROR_CODES = [
+  "invalid_request",
+  "not_found",
+  "conflict",
+  "confirmation_required",
+  "capacity",
+  "unavailable",
+  "failed",
+] as const;
+
+export type TerminalRuntimeErrorCode = typeof TERMINAL_RUNTIME_ERROR_CODES[number];
+
+export const TERMINAL_RUNTIME_PROTOCOL_ERROR_CODES = [
+  "invalid_request",
+  "not_found",
+  "conflict",
+  "unavailable",
+  "failed",
+] as const;
+
+export type TerminalRuntimeProtocolErrorCode = typeof TERMINAL_RUNTIME_PROTOCOL_ERROR_CODES[number];
+
+const SAFE_MESSAGES: Record<TerminalRuntimeErrorCode, string> = {
+  invalid_request: "Invalid terminal runtime request",
+  not_found: "Terminal operation failed",
+  conflict: "Terminal state changed",
+  confirmation_required: "Terminal termination confirmation required",
+  capacity: "Terminal capacity reached",
+  unavailable: "Terminal operation unavailable",
+  failed: "Terminal operation failed",
+};
+
+export class TerminalRuntimeError extends Error {
+  readonly code: TerminalRuntimeErrorCode;
+
+  constructor(code: TerminalRuntimeErrorCode, message = SAFE_MESSAGES[code], options?: ErrorOptions) {
+    super(message, options);
+    this.name = "TerminalRuntimeError";
+    this.code = code;
+  }
+}
+
+export function terminalRuntimeErrorDetails(error: unknown): {
+  code: TerminalRuntimeProtocolErrorCode;
+  message: string;
+} {
+  if (error instanceof TerminalRuntimeError) {
+    const code = error.code === "confirmation_required" || error.code === "capacity"
+      ? "conflict"
+      : error.code;
+    return { code, message: SAFE_MESSAGES[error.code] };
+  }
+  return { code: "failed", message: SAFE_MESSAGES.failed };
+}
+
+export function terminalRuntimeErrorFromDetails(input: {
+  code: TerminalRuntimeProtocolErrorCode;
+  message: string;
+}): TerminalRuntimeError {
+  if (input.code === "conflict" && input.message === SAFE_MESSAGES.confirmation_required) {
+    return new TerminalRuntimeError("confirmation_required");
+  }
+  if (input.code === "conflict" && input.message === SAFE_MESSAGES.capacity) {
+    return new TerminalRuntimeError("capacity");
+  }
+  return new TerminalRuntimeError(input.code);
+}

--- a/packages/terminal-runtime/src/index.ts
+++ b/packages/terminal-runtime/src/index.ts
@@ -6,5 +6,6 @@ export * from "./socket-client.js";
 export * from "./socket-server.js";
 export * from "./socket-protocol.js";
 export * from "./runtime-config.js";
+export * from "./errors.js";
 export * from "./user-systemd-controller.js";
 export * from "./user-systemd-workspace.js";

--- a/packages/terminal-runtime/src/runtime.ts
+++ b/packages/terminal-runtime/src/runtime.ts
@@ -9,6 +9,7 @@ import {
 } from "@matrix-os/contracts";
 import { setTimeout as delay } from "node:timers/promises";
 import { z } from "zod/v4";
+import { TerminalRuntimeError } from "./errors.js";
 import {
   TerminalWorkspaceStore,
   type TerminalRuntimeWorkspaceState,
@@ -172,20 +173,21 @@ export class TerminalRuntime {
     command?: string[];
     agent?: TerminalTab["agent"];
     git?: TerminalTab["git"];
+    accessScope?: TerminalTab["accessScope"];
   }): Promise<TerminalTab> {
     const workspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
     return this.runWorkspaceMutation(async () => {
       const workspaces = await this.listWorkspaces();
       const workspace = workspaces.find((candidate) => candidate.id === workspaceId);
-      if (!workspace) throw new Error("Terminal workspace not found");
+      if (!workspace) throw new TerminalRuntimeError("not_found");
       if (workspace.tabs.filter(tabOccupiesAdmission).length >= this.maxTabsPerWorkspace) {
-        throw new Error("Terminal workspace tab capacity reached");
+        throw new TerminalRuntimeError("capacity");
       }
       if (workspaces.reduce(
         (count, candidate) => count + candidate.tabs.filter(tabOccupiesAdmission).length,
         0,
       ) >= this.maxTabsTotal) {
-        throw new Error("Terminal runtime tab capacity reached");
+        throw new TerminalRuntimeError("capacity");
       }
       const releaseObserverReservation = this.reserveObserverSlot(workspaceId);
       let stagedTab: TerminalTab | undefined;
@@ -195,7 +197,10 @@ export class TerminalRuntime {
         const runtimeWorkspace = await this.requireRuntimeWorkspace(workspaceId);
         sessionName = runtimeWorkspace.zellijSessionName;
         await this.zellij.ensureSession(runtimeWorkspace.zellijSessionName, runtimeWorkspace.canonicalSize);
-        stagedTab = await this.store.createTab(workspaceId, input);
+        stagedTab = await this.store.createTab(workspaceId, {
+          ...input,
+          accessScope: input.accessScope ?? "owner",
+        });
         const stagedWorkspace = await this.requireRuntimeWorkspace(workspaceId);
         const internalTab = stagedWorkspace.tabs[stagedTab.id];
         if (!internalTab) throw new Error("Terminal tab staging failed");
@@ -248,10 +253,16 @@ export class TerminalRuntime {
       for (const tab of Object.values(workspace.tabs).sort((left, right) => left.order - right.order)) {
         if (tab.status === "exited" || tab.status === "failed") continue;
         let ids = await this.zellij.findTabByInternalName?.(workspace.zellijSessionName, tab.zellijTabName);
-        ids ??= await this.zellij.createTab(workspace.zellijSessionName, {
-          internalName: tab.zellijTabName,
-          cwd: tab.cwd,
-        });
+        if (!ids) {
+          if (tab.status !== "starting") {
+            await this.store.markTabExited({ workspaceId, tabId: tab.id });
+            continue;
+          }
+          ids = await this.zellij.createTab(workspace.zellijSessionName, {
+            internalName: tab.zellijTabName,
+            cwd: tab.cwd,
+          });
+        }
         await this.store.activateTab({ workspaceId, tabId: tab.id }, ids);
       }
       await this.restartObserver(workspaceId);
@@ -264,7 +275,8 @@ export class TerminalRuntime {
     const ref = TerminalRefSchema.parse(refInput);
     const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
     const tab = workspace.tabs[ref.tabId];
-    if (!tab || tab.zellijTabId === null || !this.zellij.renameTab) throw new Error("Terminal tab unavailable");
+    if (!tab || tab.zellijTabId === null) throw new TerminalRuntimeError("not_found");
+    if (!this.zellij.renameTab) throw new TerminalRuntimeError("unavailable");
     await this.zellij.renameTab(workspace.zellijSessionName, tab.zellijTabId, input.name);
     return this.store.renameTab(ref, input);
   }
@@ -288,7 +300,7 @@ export class TerminalRuntime {
   }): Promise<TerminalWorkspace> {
     const ref = TerminalRefSchema.parse(refInput);
     const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
-    if (!workspace.tabs[ref.tabId]) throw new Error("Terminal tab not found");
+    if (!workspace.tabs[ref.tabId]) throw new TerminalRuntimeError("not_found");
     if (input.mode === "soft") return (await this.listWorkspaces()).find((item) => item.id === ref.workspaceId)!;
     const updated = await this.store.updateCanonicalSize(ref.workspaceId, input.size);
     await this.zellij.resizeSession?.(workspace.zellijSessionName, updated.canonicalSize);
@@ -301,16 +313,17 @@ export class TerminalRuntime {
   async terminateTab(refInput: TerminalRef): Promise<void> {
     const ref = TerminalRefSchema.parse(refInput);
     const key = refKey(ref);
-    if (this.terminatingTabKeys.has(key)) throw new Error("Terminal tab termination in progress");
+    if (this.terminatingTabKeys.has(key)) throw new TerminalRuntimeError("conflict");
     if (this.terminatingTabKeys.size >= this.maxAttachments * 2) {
-      throw new Error("Terminal tab termination capacity reached");
+      throw new TerminalRuntimeError("capacity");
     }
     this.terminatingTabKeys.add(key);
     try {
       await this.runWorkspaceMutation(async () => {
         const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
         const tab = workspace.tabs[ref.tabId];
-        if (!tab || tab.zellijTabId === null || !this.zellij.closeTab) throw new Error("Terminal tab unavailable");
+        if (!tab || tab.zellijTabId === null) throw new TerminalRuntimeError("not_found");
+        if (!this.zellij.closeTab) throw new TerminalRuntimeError("unavailable");
         await this.drainTabInput(key);
         await this.closeAttachment(key, true);
         await this.zellij.closeTab(workspace.zellijSessionName, tab.zellijTabId);
@@ -327,14 +340,11 @@ export class TerminalRuntime {
     await this.enqueueWrite(ref, dataInput, async (data) => {
       const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
       const tab = workspace.tabs[ref.tabId];
+      if (!tab || tab.zellijPaneId === null) throw new TerminalRuntimeError("not_found");
       if (
-        !tab ||
         (tab.status !== "running" && tab.status !== "idle") ||
-        tab.zellijPaneId === null ||
         !this.zellij.writeToPane
-      ) {
-        throw new Error("Terminal tab unavailable");
-      }
+      ) throw new TerminalRuntimeError("unavailable");
       await this.zellij.writeToPane(workspace.zellijSessionName, tab.zellijPaneId, data);
     });
   }
@@ -365,7 +375,7 @@ export class TerminalRuntime {
   async deletionImpact(workspaceIdInput: string): Promise<{ runningTabs: number; tabs: TerminalTab[] }> {
     const workspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
     const workspace = (await this.listWorkspaces()).find((item) => item.id === workspaceId);
-    if (!workspace) throw new Error("Terminal workspace not found");
+    if (!workspace) throw new TerminalRuntimeError("not_found");
     const tabs = workspace.tabs.filter((tab) => tab.status === "running" || tab.status === "starting" || tab.status === "idle");
     return { runningTabs: tabs.length, tabs };
   }
@@ -374,9 +384,11 @@ export class TerminalRuntime {
     const workspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
     await this.runWorkspaceMutation(async () => {
       const impact = await this.deletionImpact(workspaceId);
-      if (impact.runningTabs > 0 && !input.confirmTerminate) throw new Error("Terminal termination confirmation required");
+      if (impact.runningTabs > 0 && !input.confirmTerminate) {
+        throw new TerminalRuntimeError("confirmation_required");
+      }
       const workspace = await this.requireRuntimeWorkspace(workspaceId);
-      if (!this.zellij.deleteSession) throw new Error("Terminal workspace deletion unavailable");
+      if (!this.zellij.deleteSession) throw new TerminalRuntimeError("unavailable");
       this.deletingWorkspaceId = workspaceId;
       try {
         await this.drainWorkspaceInput(workspaceId);
@@ -424,10 +436,10 @@ export class TerminalRuntime {
     const key = refKey(ref);
     let attachment = this.attachments.get(key);
     if (!attachment) {
-      if (this.attachments.size >= this.maxAttachments) throw new Error("Terminal attachment capacity reached");
+      if (this.attachments.size >= this.maxAttachments) throw new TerminalRuntimeError("capacity");
       const workspace = await this.requireRuntimeWorkspace(ref.workspaceId);
       const tab = workspace.tabs[ref.tabId];
-      if (!tab || tab.zellijPaneId === null) throw new Error("Terminal tab unavailable");
+      if (!tab || tab.zellijPaneId === null) throw new TerminalRuntimeError("not_found");
       const next: AttachmentState = {
         ref,
         handle: undefined as unknown as ZellijAttachment,
@@ -453,7 +465,7 @@ export class TerminalRuntime {
       attachment = next;
     }
     if (!attachment.viewers.has(viewerId) && attachment.viewers.size >= this.maxViewersPerTab) {
-      throw new Error("Terminal viewer capacity reached");
+      throw new TerminalRuntimeError("capacity");
     }
     attachment.viewers.set(viewerId, {
       id: viewerId,
@@ -464,9 +476,9 @@ export class TerminalRuntime {
     let detached = false;
     return {
       write: async (data) => {
-        if (detached) throw new Error("Terminal viewer detached");
+        if (detached) throw new TerminalRuntimeError("conflict");
         const viewer = attachment!.viewers.get(viewerId);
-        if (!viewer) throw new Error("Terminal viewer unavailable");
+        if (!viewer) throw new TerminalRuntimeError("unavailable");
         viewer.lastTouched = Date.now();
         await this.enqueueWrite(ref, data, (encoded) => attachment!.handle.write(encoded));
       },
@@ -520,7 +532,7 @@ export class TerminalRuntime {
   }
 
   private runWorkspaceMutation<T>(operation: () => Promise<T>): Promise<T> {
-    if (this.shuttingDown) return Promise.reject(new Error("Terminal runtime shutting down"));
+    if (this.shuttingDown) return Promise.reject(new TerminalRuntimeError("unavailable"));
     const result = this.workspaceMutationChain.then(operation);
     this.workspaceMutationChain = result.then(
       () => undefined,
@@ -578,7 +590,7 @@ export class TerminalRuntime {
       existing = undefined;
     }
     if (!existing && !this.observerReservations.has(workspaceId) && this.observerCount() >= this.maxObservers) {
-      throw new Error("Terminal observer capacity reached");
+      throw new TerminalRuntimeError("capacity");
     }
     const observerInput = {
       paneIds: [...paneRefs.keys()],
@@ -698,7 +710,7 @@ export class TerminalRuntime {
       this.observerReservations.set(workspaceId, currentReservations + 1);
     } else {
       if (this.observerCount() + this.observerReservations.size >= this.maxObservers) {
-        throw new Error("Terminal observer capacity reached");
+        throw new TerminalRuntimeError("capacity");
       }
       this.observerReservations.set(workspaceId, 1);
     }
@@ -717,9 +729,9 @@ export class TerminalRuntime {
     dataInput: string,
     writer: (data: Uint8Array) => Promise<void>,
   ): Promise<void> {
-    if (this.shuttingDown) throw new Error("Terminal runtime shutting down");
+    if (this.shuttingDown) throw new TerminalRuntimeError("unavailable");
     if (this.deletingWorkspaceId === ref.workspaceId) {
-      throw new Error("Terminal workspace deletion in progress");
+      throw new TerminalRuntimeError("conflict", "Terminal workspace deletion in progress");
     }
     const data = new TextEncoder().encode(z.string().min(1).max(64 * 1024).parse(dataInput));
     const key = refKey(ref);
@@ -730,14 +742,14 @@ export class TerminalRuntime {
         const idle = [...this.inputQueues.entries()]
           .filter(([, candidate]) => candidate.pendingBytes === 0)
           .sort((left, right) => left[1].lastTouched - right[1].lastTouched)[0];
-        if (!idle) throw new Error("Terminal input queue capacity reached");
+        if (!idle) throw new TerminalRuntimeError("capacity");
         this.inputQueues.delete(idle[0]);
       }
       queue = { chain: Promise.resolve(), pendingBytes: 0, lastTouched: Date.now() };
       this.inputQueues.set(key, queue);
     }
     if (queue.pendingBytes + data.byteLength > this.maxPendingInputBytes) {
-      throw new Error("Terminal input queue capacity reached");
+      throw new TerminalRuntimeError("capacity");
     }
     queue.pendingBytes += data.byteLength;
     queue.lastTouched = Date.now();
@@ -761,10 +773,10 @@ export class TerminalRuntime {
 
   private assertTabAcceptsInput(key: string): void {
     if (this.terminatingTabKeys.has(key)) {
-      throw new Error("Terminal tab termination in progress");
+      throw new TerminalRuntimeError("conflict", "Terminal tab termination in progress");
     }
     if (this.closingPaneTabKeys.has(key) || this.untrackedPaneClosures > 0) {
-      throw new Error("Terminal tab closure in progress");
+      throw new TerminalRuntimeError("conflict", "Terminal tab closure in progress");
     }
   }
 
@@ -895,7 +907,7 @@ export class TerminalRuntime {
 
   private async requireRuntimeWorkspace(workspaceId: string): Promise<TerminalRuntimeWorkspaceState> {
     const workspace = await this.store.getRuntimeWorkspace(workspaceId);
-    if (!workspace) throw new Error("Terminal workspace not found");
+    if (!workspace) throw new TerminalRuntimeError("not_found");
     return workspace;
   }
 }

--- a/packages/terminal-runtime/src/service-shutdown.ts
+++ b/packages/terminal-runtime/src/service-shutdown.ts
@@ -1,0 +1,13 @@
+export async function runBestEffortTerminalShutdown(
+  shutdown: () => Promise<void>,
+  log: (message: string, errorType: string) => void = console.warn,
+): Promise<void> {
+  try {
+    await shutdown();
+  } catch (error: unknown) {
+    log(
+      "[terminal-runtime] graceful shutdown incomplete:",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+  }
+}

--- a/packages/terminal-runtime/src/service.ts
+++ b/packages/terminal-runtime/src/service.ts
@@ -9,6 +9,7 @@ import { TerminalWorkspaceStore } from "./workspace-store.js";
 import { ZellijCliRuntimeAdapter } from "./zellij-adapter.js";
 import { resolveTerminalRuntimeLimits } from "./runtime-config.js";
 import { startTerminalOrphanSweepLifecycle } from "./orphan-sweep-lifecycle.js";
+import { runBestEffortTerminalShutdown } from "./service-shutdown.js";
 import {
   createUserSystemdTerminalRuntime,
   loadInstalledTerminalRuntimeGeneration,
@@ -110,7 +111,7 @@ async function main(): Promise<void> {
     closing = true;
     await server.close();
     await orphanSweep.close();
-    await runtime.shutdown();
+    await runBestEffortTerminalShutdown(() => runtime.shutdown());
   };
   process.once("SIGTERM", () => { void close().then(() => process.exit(0)); });
   process.once("SIGINT", () => { void close().then(() => process.exit(0)); });

--- a/packages/terminal-runtime/src/socket-client.ts
+++ b/packages/terminal-runtime/src/socket-client.ts
@@ -10,6 +10,7 @@ import {
   type TerminalWorkspace,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
+import { terminalRuntimeErrorFromDetails } from "./errors.js";
 import { encodeSocketFrame, SocketFrameDecoder } from "./socket-framing.js";
 import { MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES } from "./limits.js";
 import {
@@ -47,6 +48,7 @@ export class TerminalRuntimeSocketClient {
   async createTab(workspaceId: string, input: {
     name: string;
     cwd: string;
+    accessScope?: TerminalTab["accessScope"];
     command?: string[];
     agent?: TerminalTab["agent"];
   }): Promise<TerminalTab> {
@@ -99,7 +101,7 @@ export class TerminalRuntimeSocketClient {
     );
   }
 
-  async deleteWorkspace(workspaceId: string, input: { confirmTerminate: true }): Promise<void> {
+  async deleteWorkspace(workspaceId: string, input: { confirmTerminate: boolean }): Promise<void> {
     await this.call("DeleteWorkspace", { workspaceId, ...input });
   }
 
@@ -170,7 +172,7 @@ export class TerminalRuntimeSocketClient {
           const [raw] = decoder.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
           if (raw === undefined) return;
           const response = TerminalRuntimeResponseSchema.parse(raw);
-          if (!response.ok) throw new Error(response.error.message);
+          if (!response.ok) throw terminalRuntimeErrorFromDetails(response.error);
           if (response.requestId !== requestId) throw new Error("Terminal runtime response mismatch");
           finish();
           socket.end();

--- a/packages/terminal-runtime/src/socket-protocol.ts
+++ b/packages/terminal-runtime/src/socket-protocol.ts
@@ -6,6 +6,7 @@ import {
   TerminalWorkspaceIdSchema,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
+import { TERMINAL_RUNTIME_PROTOCOL_ERROR_CODES } from "./errors.js";
 
 const RequestIdSchema = z.string().regex(/^req_[0-9a-f]{32}$/);
 const RequestBase = { version: z.literal(1), requestId: RequestIdSchema };
@@ -24,6 +25,7 @@ export const TerminalRuntimeRequestSchema = z.discriminatedUnion("operation", [
       workspaceId: TerminalWorkspaceIdSchema,
       name: SafeDisplayStringSchema,
       cwd: z.string().max(4096),
+      accessScope: z.enum(["owner", "chat"]).optional(),
       command: z.array(z.string().min(1).max(4096)).min(1).max(128).optional(),
       agent: z.object({
         providerId: z.string().min(1).max(80).regex(/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/),
@@ -90,7 +92,7 @@ export const TerminalRuntimeRequestSchema = z.discriminatedUnion("operation", [
   z.object({
     ...RequestBase,
     operation: z.literal("DeleteWorkspace"),
-    input: z.object({ workspaceId: TerminalWorkspaceIdSchema, confirmTerminate: z.literal(true) }).strict(),
+    input: z.object({ workspaceId: TerminalWorkspaceIdSchema, confirmTerminate: z.boolean() }).strict(),
   }).strict(),
   z.object({
     ...RequestBase,
@@ -116,7 +118,7 @@ export const TerminalRuntimeResponseSchema = z.discriminatedUnion("ok", [
     requestId: RequestIdSchema.optional(),
     ok: z.literal(false),
     error: z.object({
-      code: z.enum(["invalid_request", "not_found", "conflict", "unavailable", "failed"]),
+      code: z.enum(TERMINAL_RUNTIME_PROTOCOL_ERROR_CODES),
       message: z.string().min(1).max(128),
     }).strict(),
   }).strict(),

--- a/packages/terminal-runtime/src/socket-server.ts
+++ b/packages/terminal-runtime/src/socket-server.ts
@@ -10,6 +10,7 @@ import {
   type TerminalWorkspace,
 } from "@matrix-os/contracts";
 import type { z } from "zod/v4";
+import { terminalRuntimeErrorDetails } from "./errors.js";
 import type { TerminalSnapshot } from "./workspace-store.js";
 import { encodeSocketFrame, SocketFrameDecoder } from "./socket-framing.js";
 import { MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES } from "./limits.js";
@@ -25,6 +26,7 @@ export interface TerminalRuntimeControlApi {
   createTab(workspaceId: string, input: {
     name: string;
     cwd: string;
+    accessScope?: TerminalTab["accessScope"];
     command?: string[];
     agent?: TerminalTab["agent"];
   }): Promise<TerminalTab>;
@@ -212,11 +214,12 @@ export class TerminalRuntimeSocketServer {
       return null;
     } catch (error: unknown) {
       console.error("[terminal-runtime] control request failed", error);
+      const details = terminalRuntimeErrorDetails(error);
       socket.end(encodeSocketResponseFrame({
         version: 1,
         requestId: parsed.data.requestId,
         ok: false,
-        error: { code: "failed", message: "Terminal operation failed" },
+        error: details,
       } satisfies TerminalRuntimeResponse));
       return null;
     }

--- a/packages/terminal-runtime/src/workspace-store.ts
+++ b/packages/terminal-runtime/src/workspace-store.ts
@@ -15,6 +15,7 @@ import {
   type TerminalWorkspace,
 } from "@matrix-os/contracts";
 import { z } from "zod/v4";
+import { TerminalRuntimeError } from "./errors.js";
 import {
   MAX_TERMINAL_SNAPSHOT_ANSI_BYTES,
   MAX_TERMINAL_SNAPSHOT_BYTES,
@@ -143,7 +144,7 @@ export class TerminalWorkspaceStore {
     const now = this.now().toISOString();
     return this.mutate((state) => {
       const workspace = state.workspaces[targetWorkspaceId];
-      if (!workspace) throw new Error("Terminal workspace not found");
+      if (!workspace) throw new TerminalRuntimeError("not_found");
       const id = tabId();
       const tab = InternalTabSchema.parse({
         id,
@@ -183,7 +184,7 @@ export class TerminalWorkspaceStore {
     const name = SafeDisplayStringSchema.parse(input.name);
     return this.mutate((state) => {
       const workspace = state.workspaces[targetWorkspaceId];
-      if (!workspace) throw new Error("Terminal workspace not found");
+      if (!workspace) throw new TerminalRuntimeError("not_found");
       const existing = Object.values(workspace.tabs).find((tab) => tab.migrationKey === migrationKey);
       if (existing) return this.toPublicTab(existing);
       const id = tabId();
@@ -242,7 +243,7 @@ export class TerminalWorkspaceStore {
     return this.mutate((state) => {
       const workspace = state.workspaces[ref.workspaceId];
       const tab = workspace?.tabs[ref.tabId];
-      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      if (!workspace || !tab) throw new TerminalRuntimeError("not_found");
       tab.zellijTabId = zellijTabId;
       tab.zellijPaneId = zellijPaneId;
       tab.status = "running";
@@ -262,7 +263,7 @@ export class TerminalWorkspaceStore {
     await this.mutate((state) => {
       const workspace = state.workspaces[ref.workspaceId];
       const tab = workspace?.tabs[ref.tabId];
-      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      if (!workspace || !tab) throw new TerminalRuntimeError("not_found");
       delete workspace.tabs[ref.tabId];
       Object.values(workspace.tabs)
         .sort((left, right) => left.order - right.order)
@@ -287,7 +288,7 @@ export class TerminalWorkspaceStore {
     return this.mutate(async (state) => {
       const workspace = state.workspaces[ref.workspaceId];
       const tab = workspace?.tabs[ref.tabId];
-      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      if (!workspace || !tab) throw new TerminalRuntimeError("not_found");
       const previous = await this.readSnapshot(ref);
       const now = this.now().toISOString();
       tab.revision = Math.max(tab.revision, previous?.revision ?? 0) + 1;
@@ -322,7 +323,7 @@ export class TerminalWorkspaceStore {
     return this.mutate(async (state) => {
       const workspace = state.workspaces[ref.workspaceId];
       const tab = workspace?.tabs[ref.tabId];
-      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      if (!workspace || !tab) throw new TerminalRuntimeError("not_found");
       const previous = await this.readSnapshot(ref);
       if (
         previous?.seq === seq &&
@@ -362,8 +363,8 @@ export class TerminalWorkspaceStore {
     return this.mutate((state) => {
       const workspace = state.workspaces[ref.workspaceId];
       const tab = workspace?.tabs[ref.tabId];
-      if (!workspace || !tab) throw new Error("Terminal tab not found");
-      if (tab.revision !== baseRevision) throw new Error("Terminal tab revision conflict");
+      if (!workspace || !tab) throw new TerminalRuntimeError("not_found");
+      if (tab.revision !== baseRevision) throw new TerminalRuntimeError("conflict");
       tab.name = name;
       tab.revision += 1;
       tab.updatedAt = now;
@@ -381,12 +382,12 @@ export class TerminalWorkspaceStore {
     const now = this.now().toISOString();
     return this.mutate((state) => {
       const workspace = state.workspaces[workspaceId];
-      if (!workspace) throw new Error("Terminal workspace not found");
-      if (workspace.revision !== baseRevision) throw new Error("Terminal workspace revision conflict");
+      if (!workspace) throw new TerminalRuntimeError("not_found");
+      if (workspace.revision !== baseRevision) throw new TerminalRuntimeError("conflict");
       const existingIds = Object.keys(workspace.tabs);
       if (new Set(tabIds).size !== tabIds.length || tabIds.length !== existingIds.length ||
           existingIds.some((id) => !tabIds.includes(id))) {
-        throw new Error("Terminal tab order is incomplete");
+        throw new TerminalRuntimeError("invalid_request");
       }
       tabIds.forEach((id, order) => { workspace.tabs[id]!.order = order; });
       workspace.revision += 1;
@@ -408,8 +409,8 @@ export class TerminalWorkspaceStore {
     return this.mutate((state) => {
       const workspace = state.workspaces[ref.workspaceId];
       const tab = workspace?.tabs[ref.tabId];
-      if (!workspace || !tab) throw new Error("Terminal tab not found");
-      if (tab.revision !== baseRevision) throw new Error("Terminal tab revision conflict");
+      if (!workspace || !tab) throw new TerminalRuntimeError("not_found");
+      if (tab.revision !== baseRevision) throw new TerminalRuntimeError("conflict");
       tab.uiState = {
         placement: input.placement ?? tab.uiState?.placement ?? "active",
         lastSeenSeq: input.lastSeenSeq === undefined ? tab.uiState?.lastSeenSeq ?? null : input.lastSeenSeq,
@@ -432,7 +433,7 @@ export class TerminalWorkspaceStore {
     return this.mutate((state) => {
       const workspace = state.workspaces[ref.workspaceId];
       const tab = workspace?.tabs[ref.tabId];
-      if (!workspace || !tab) throw new Error("Terminal tab not found");
+      if (!workspace || !tab) throw new TerminalRuntimeError("not_found");
       if (tab.status === "exited" && tab.exitCode === exitCode) return this.toPublicTab(tab);
       tab.status = "exited";
       tab.exitCode = exitCode;
@@ -451,7 +452,7 @@ export class TerminalWorkspaceStore {
     const now = this.now().toISOString();
     return this.mutate((state) => {
       const workspace = state.workspaces[workspaceId];
-      if (!workspace) throw new Error("Terminal workspace not found");
+      if (!workspace) throw new TerminalRuntimeError("not_found");
       workspace.canonicalSize = size;
       workspace.revision += 1;
       workspace.updatedAt = now;
@@ -464,7 +465,7 @@ export class TerminalWorkspaceStore {
     const workspaceId = TerminalWorkspaceIdSchema.parse(workspaceIdInput);
     const workspace = await this.mutate((state) => {
       const existing = state.workspaces[workspaceId];
-      if (!existing) throw new Error("Terminal workspace not found");
+      if (!existing) throw new TerminalRuntimeError("not_found");
       delete state.workspaces[workspaceId];
       state.revision += 1;
       return structuredClone(existing);
@@ -532,7 +533,9 @@ export class TerminalWorkspaceStore {
 
   private async persistSnapshot(snapshot: TerminalSnapshot): Promise<void> {
     const content = `${JSON.stringify(SnapshotSchema.parse(snapshot))}\n`;
-    if (Buffer.byteLength(content) > MAX_TERMINAL_SNAPSHOT_BYTES) throw new Error("Terminal snapshot capacity reached");
+    if (Buffer.byteLength(content) > MAX_TERMINAL_SNAPSHOT_BYTES) {
+      throw new TerminalRuntimeError("capacity");
+    }
     const target = this.snapshotPath(snapshot.terminalRef.tabId);
     await writeTextAtomic(target, content);
   }

--- a/packages/ui/src/collaboration/ChatCollaboration.tsx
+++ b/packages/ui/src/collaboration/ChatCollaboration.tsx
@@ -212,6 +212,13 @@ type SharedScope = z.infer<typeof CollaborationScopeSchema>;
 type SharedChat = z.infer<typeof CollaborationChatSchema>;
 type SharedChatError = "load" | "send" | "unavailable" | null;
 
+class CollaborationRecoverySupersededError extends Error {
+  constructor() {
+    super("CollaborationRecoverySuperseded");
+    this.name = "CollaborationRecoverySupersededError";
+  }
+}
+
 interface SharedChatState {
   scope: SharedScope | null;
   chat: SharedChat | null;
@@ -326,7 +333,7 @@ function useSharedChatController({ api, actorId, runtimeId, scopeId, storage }: 
         if (additions.length === 0) throw new Error("CollaborationRecoveryIncomplete");
         combined = [...combined, ...additions];
       }
-      if (generation !== loadGeneration.current) throw new Error("CollaborationRecoverySuperseded");
+      if (generation !== loadGeneration.current) throw new CollaborationRecoverySupersededError();
       dispatch({ type: "loaded", scope: nextScope, chat: nextChat, messages: combined, clearForegroundError: false });
       markRead(api, base, combined);
     } catch (failure: unknown) {
@@ -384,6 +391,7 @@ function useSharedChatController({ api, actorId, runtimeId, scopeId, storage }: 
       try {
         await recoverCanonical();
       } catch (failure: unknown) {
+        if (failure instanceof CollaborationRecoverySupersededError) return;
         console.warn("[chat-collaboration] sent message refresh failed", failure instanceof Error ? failure.name : "UnknownError");
         dispatch({ type: "load_failed" });
       }

--- a/tests/gateway/route-inventory.test.ts
+++ b/tests/gateway/route-inventory.test.ts
@@ -23,7 +23,7 @@ describe("gateway route inventory", () => {
 
   it("maps representative routes to their planned modules", () => {
     expect(gatewayRouteGroupForPath("/api/apps/weather/session")?.id).toBe("app-runtime");
-    expect(gatewayRouteGroupForPath("/ws/terminal/session")?.id).toBe("shell-terminal");
+    expect(gatewayRouteGroupForPath("/ws/terminal/tab")?.id).toBe("shell-terminal");
     expect(gatewayRouteGroupForPath("/api/bridge/data")?.id).toBe("bridge");
     expect(gatewayRouteGroupForPath("/api/canvases/abc")?.id).toBe("data-features");
     expect(gatewayRouteGroupForPath("/files/system/icons/app.png")?.id).toBe("files-workspace");

--- a/tests/gateway/terminal-workspace-routes.test.ts
+++ b/tests/gateway/terminal-workspace-routes.test.ts
@@ -1,0 +1,455 @@
+import { access, lstat, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalWorkspaceRoutes } from "../../packages/gateway/src/shell/workspace-routes.js";
+import {
+  createTerminalPasteAssetCleanupLifecycle,
+  saveTerminalPasteAsset,
+} from "../../packages/gateway/src/shell/paste-assets.js";
+import { TerminalRuntimeError } from "../../packages/terminal-runtime/src/errors.js";
+
+const workspace = {
+  id: "tws_0123456789abcdef0123456789abcdef",
+  scope: "project" as const,
+  projectId: "matrix-os",
+  canonicalSize: { cols: 120, rows: 36 },
+  status: "running" as const,
+  revision: 1,
+  createdAt: "2026-08-11T12:00:00.000Z",
+  updatedAt: "2026-08-11T12:00:00.000Z",
+  tabs: [],
+};
+
+describe("terminal workspace gateway routes", () => {
+  const ownerOptions = {
+    getPrincipal: () => ({ userId: "user_owner", source: "jwt" as const }),
+    terminalOwnerIds: ["user_owner"],
+  };
+
+  it("expires stale terminal paste assets before retaining a new upload", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-workspace-paste-cleanup-"));
+    const staleDirectory = join(homePath, "temporary", "terminal-pastes", "2026-09-08");
+    const stalePath = join(staleDirectory, "stale.png");
+    await mkdir(staleDirectory, { recursive: true });
+    await writeFile(stalePath, Uint8Array.from([0x89, 0x50, 0x4e, 0x47]));
+    await utimes(stalePath, new Date("2026-09-08T00:00:00Z"), new Date("2026-09-08T00:00:00Z"));
+
+    try {
+      await saveTerminalPasteAsset({
+        homePath,
+        cwd: "projects/matrix-os",
+        bytes: Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+        contentType: "image/png",
+        now: new Date("2026-09-10T12:00:00Z"),
+      });
+      await expect(access(stalePath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("runs recurring paste cleanup without overlap and clears its timer on close", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-workspace-paste-lifecycle-"));
+    let scheduled: (() => void) | undefined;
+    const schedule = vi.fn((callback: () => void) => {
+      scheduled = callback;
+      return "terminal-paste-cleanup-timer";
+    });
+    const cancel = vi.fn();
+    const lifecycle = createTerminalPasteAssetCleanupLifecycle({
+      homePath,
+      intervalMs: 100,
+      schedule,
+      cancel,
+      now: () => new Date("2026-09-10T12:00:00Z").getTime(),
+    });
+
+    try {
+      const initialRun = lifecycle.runNow();
+      expect(lifecycle.runNow()).toBe(initialRun);
+      await initialRun;
+      const directory = join(homePath, "temporary", "terminal-pastes", "2026-09-08");
+      const stalePath = join(directory, "later.png");
+      await mkdir(directory, { recursive: true });
+      await writeFile(stalePath, Uint8Array.from([0x89, 0x50, 0x4e, 0x47]));
+      await utimes(stalePath, new Date("2026-09-08T00:00:00Z"), new Date("2026-09-08T00:00:00Z"));
+
+      scheduled?.();
+      await lifecycle.waitForIdle();
+      await expect(lstat(stalePath)).rejects.toMatchObject({ code: "ENOENT" });
+
+      lifecycle.close();
+      expect(cancel).toHaveBeenCalledWith("terminal-paste-cleanup-timer");
+      expect(schedule).toHaveBeenCalledOnce();
+    } finally {
+      lifecycle.close();
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("starts recurring paste cleanup after gateway startup and cancels it before awaited shutdown", async () => {
+    const [source, lifecycleSource] = await Promise.all([
+      readFile(new URL("../../packages/gateway/src/server.ts", import.meta.url), "utf8"),
+      readFile(new URL(
+        "../../packages/gateway/src/shell/paste-asset-cleanup-runtime.ts",
+        import.meta.url,
+      ), "utf8"),
+    ]);
+    const serverStart = source.indexOf("const server = serve(");
+    const cleanupStart = source.indexOf("startTerminalPasteAssetCleanup({");
+    const cleanupClose = source.indexOf("await terminalPasteAssetCleanup.close();", cleanupStart);
+
+    expect(serverStart).toBeGreaterThan(-1);
+    expect(cleanupStart).toBeGreaterThan(serverStart);
+    expect(cleanupClose).toBeGreaterThan(cleanupStart);
+    expect(source).not.toContain("createTerminalPasteAssetCleanupLifecycle({");
+    expect(lifecycleSource).toContain("createTerminalPasteAssetCleanupLifecycle({");
+    expect(lifecycleSource).toContain("void lifecycle.runNow()");
+    expect(lifecycleSource).toContain("lifecycle.close();");
+    expect(lifecycleSource).toContain("await lifecycle.waitForIdle()");
+  });
+
+  it("pins each paste directory while enumerating and deleting its entries", async () => {
+    const source = await readFile(new URL(
+      "../../packages/gateway/src/shell/paste-assets.ts",
+      import.meta.url,
+    ), "utf8");
+
+    expect(source).toContain("O_DIRECTORY | O_NOFOLLOW");
+    expect(source).toContain("`/proc/self/fd/${handle.fd}`");
+    expect(source).toContain("await pinnedDirectory.handle.close()");
+  });
+
+  it("validates workspace/tab mutations and requires deletion confirmation", async () => {
+    const runtime = {
+      listWorkspaces: vi.fn(async () => [workspace]),
+      ensureWorkspace: vi.fn(async () => workspace),
+      createTab: vi.fn(async () => ({
+        id: "tt_0123456789abcdef0123456789abcdef",
+        workspaceId: workspace.id,
+        name: "main",
+        cwd: "projects/matrix-os",
+        status: "running" as const,
+        revision: 1,
+        order: 0,
+        createdAt: workspace.createdAt,
+        updatedAt: workspace.updatedAt,
+      })),
+      paneAction: vi.fn(async () => undefined),
+      updateTabUiState: vi.fn(async (
+        _ref: { workspaceId: string; tabId: string },
+        input: { pinned?: boolean },
+      ) => ({
+        id: "tt_0123456789abcdef0123456789abcdef",
+        workspaceId: workspace.id,
+        name: "main",
+        cwd: "projects/matrix-os",
+        status: "running" as const,
+        revision: 2,
+        order: 0,
+        uiState: { placement: "active" as const, lastSeenSeq: null, pinned: input.pinned },
+        createdAt: workspace.createdAt,
+        updatedAt: workspace.updatedAt,
+      })),
+      deletionImpact: vi.fn(async () => ({ runningTabs: 1, tabs: [] })),
+      deleteWorkspace: vi.fn(async () => undefined),
+    };
+    const app = new Hono().route("/api/terminal", createTerminalWorkspaceRoutes({ runtime, ...ownerOptions }));
+
+    expect((await app.request("/api/terminal/workspaces")).status).toBe(200);
+    expect((await app.request("/api/terminal/workspaces/ensure", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ projectId: "matrix-os" }),
+    })).status).toBe(200);
+    expect((await app.request(`/api/terminal/workspaces/${workspace.id}/tabs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "main",
+        cwd: "projects/matrix-os",
+        agent: { providerId: "codex", threadId: "thread_terminal_01" },
+      }),
+    })).status).toBe(201);
+    expect(runtime.createTab).toHaveBeenCalledWith(workspace.id, {
+      name: "main",
+      cwd: "projects/matrix-os",
+      agent: { providerId: "codex", threadId: "thread_terminal_01" },
+      accessScope: "owner",
+    });
+
+    expect((await app.request(`/api/terminal/workspaces/${workspace.id}/tabs/tt_0123456789abcdef0123456789abcdef/pane-actions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "split", direction: "right" }),
+    })).status).toBe(200);
+    expect(runtime.paneAction).toHaveBeenCalledWith(
+      { workspaceId: workspace.id, tabId: "tt_0123456789abcdef0123456789abcdef" },
+      { type: "split", direction: "right" },
+    );
+
+    expect((await app.request(`/api/terminal/workspaces/${workspace.id}/tabs/tt_0123456789abcdef0123456789abcdef/ui-state`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pinned: true, baseRevision: 1 }),
+    })).status).toBe(200);
+    expect(runtime.updateTabUiState).toHaveBeenCalledWith(
+      { workspaceId: workspace.id, tabId: "tt_0123456789abcdef0123456789abcdef" },
+      { pinned: true, baseRevision: 1 },
+    );
+
+    expect((await app.request(`/api/terminal/workspaces/${workspace.id}`, {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ confirmTerminate: false }),
+    })).status).toBe(409);
+    expect(runtime.deleteWorkspace).not.toHaveBeenCalled();
+    expect((await app.request(`/api/terminal/workspaces/${workspace.id}`, {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ confirmTerminate: true }),
+    })).status).toBe(204);
+  });
+
+  it("accepts one maximum-size image after JSON base64 expansion", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-workspace-paste-"));
+    const tab = {
+      id: "tt_0123456789abcdef0123456789abcdef",
+      workspaceId: workspace.id,
+      name: "main",
+      cwd: "projects/matrix-os",
+      status: "running" as const,
+      revision: 1,
+      order: 0,
+      createdAt: workspace.createdAt,
+      updatedAt: workspace.updatedAt,
+    };
+    const runtime = {
+      listWorkspaces: vi.fn(async () => [{ ...workspace, tabs: [tab] }]),
+      ensureWorkspace: vi.fn(async () => workspace),
+      createTab: vi.fn(async () => tab),
+      deletionImpact: vi.fn(async () => ({ runningTabs: 0, tabs: [] })),
+      deleteWorkspace: vi.fn(async () => undefined),
+    };
+    const app = new Hono().route("/api/terminal", createTerminalWorkspaceRoutes({
+      runtime,
+      homePath,
+      ...ownerOptions,
+    }));
+    const bytes = Buffer.alloc(10 * 1024 * 1024);
+    bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+    try {
+      const response = await app.request(
+        `/api/terminal/workspaces/${workspace.id}/tabs/${tab.id}/paste-assets`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            assets: [{ name: "capture.png", mimeType: "image/png", dataBase64: bytes.toString("base64") }],
+          }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        assets: [{ size: bytes.byteLength, mimeType: "image/png" }],
+      });
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("binds a Chat terminal by stable workspace/tab ref and cleans up failed bindings", async () => {
+    const tab = {
+      id: "tt_0123456789abcdef0123456789abcdef",
+      workspaceId: workspace.id,
+      name: "Chat terminal",
+      cwd: "projects/matrix-os",
+      status: "running" as const,
+      revision: 1,
+      order: 0,
+      createdAt: workspace.createdAt,
+      updatedAt: workspace.updatedAt,
+    };
+    const runtime = {
+      listWorkspaces: vi.fn(async () => [{ ...workspace, tabs: [tab] }]),
+      ensureWorkspace: vi.fn(async () => workspace),
+      createTab: vi.fn(async () => tab),
+      terminateTab: vi.fn(async () => undefined),
+      paneAction: vi.fn(async () => undefined),
+      deletionImpact: vi.fn(async () => ({ runningTabs: 0, tabs: [] })),
+      deleteWorkspace: vi.fn(async () => undefined),
+    };
+    const prepare = vi.fn(async () => ({ runId: "run_selected", cwd: "projects/matrix-os" }));
+    const bind = vi.fn(async () => undefined);
+    const authorizePaneAction = vi.fn(async () => true);
+    const listBoundSessionIds = vi.fn(async () => [`${workspace.id}:${tab.id}`]);
+    const app = new Hono().route("/api/terminal", createTerminalWorkspaceRoutes({
+      runtime,
+      getPrincipal: () => ({ userId: "user_selected", source: "jwt" }),
+      terminalOwnerIds: ["user_selected"],
+      chatTerminals: { prepare, bind, authorizePaneAction, listBoundSessionIds },
+    }));
+
+    const response = await app.request(`/api/terminal/workspaces/${workspace.id}/tabs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Chat terminal", cwd: "", chatId: "chat_selected" }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(runtime.createTab).toHaveBeenCalledWith(workspace.id, {
+      name: "Chat terminal",
+      cwd: "projects/matrix-os",
+      accessScope: "chat",
+    });
+    expect(bind).toHaveBeenCalledWith(
+      { userId: "user_selected", source: "jwt" },
+      {
+        chatId: "chat_selected",
+        runId: "run_selected",
+        sessionId: `${workspace.id}:${tab.id}`,
+        sessionCreatedAt: tab.createdAt,
+      },
+    );
+    expect(runtime.terminateTab).not.toHaveBeenCalled();
+
+    expect((await app.request(`/api/terminal/workspaces/${workspace.id}/tabs/${tab.id}/pane-actions?chatId=chat_selected`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "fullscreen" }),
+    })).status).toBe(200);
+    expect(authorizePaneAction).toHaveBeenCalledWith(
+      { userId: "user_selected", source: "jwt" },
+      {
+        chatId: "chat_selected",
+        sessionId: `${workspace.id}:${tab.id}`,
+        sessionCreatedAt: tab.createdAt,
+      },
+    );
+    expect(runtime.paneAction).toHaveBeenCalledWith(
+      { workspaceId: workspace.id, tabId: tab.id },
+      { type: "fullscreen" },
+    );
+
+    authorizePaneAction.mockResolvedValueOnce(false);
+    expect((await app.request(`/api/terminal/workspaces/${workspace.id}/tabs/${tab.id}/pane-actions?chatId=chat_selected`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "close" }),
+    })).status).toBe(404);
+    expect(runtime.paneAction).toHaveBeenCalledTimes(1);
+
+    expect((await app.request(`/api/terminal/workspaces/${workspace.id}/tabs/${tab.id}/pane-actions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "close" }),
+    })).status).toBe(404);
+    expect(listBoundSessionIds).toHaveBeenCalledWith(
+      { userId: "user_selected", source: "jwt" },
+      [`${workspace.id}:${tab.id}`],
+    );
+    expect(runtime.paneAction).toHaveBeenCalledTimes(1);
+
+    bind.mockRejectedValueOnce(new Error("database unavailable"));
+    expect((await app.request(`/api/terminal/workspaces/${workspace.id}/tabs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Chat terminal", cwd: "", chatId: "chat_selected" }),
+    })).status).toBe(500);
+    expect(runtime.terminateTab).toHaveBeenCalledWith({ workspaceId: workspace.id, tabId: tab.id });
+  });
+
+  it("rejects Chat terminal wiring that cannot clean up a failed binding", () => {
+    const runtime = {
+      listWorkspaces: vi.fn(async () => [workspace]),
+      ensureWorkspace: vi.fn(async () => workspace),
+      createTab: vi.fn(),
+      deletionImpact: vi.fn(async () => ({ runningTabs: 0, tabs: [] })),
+      deleteWorkspace: vi.fn(async () => undefined),
+    };
+
+    expect(() => createTerminalWorkspaceRoutes({
+      runtime,
+      ...ownerOptions,
+      chatTerminals: {
+        prepare: vi.fn(async () => ({})),
+        bind: vi.fn(async () => undefined),
+      },
+    })).toThrow("Chat terminal cleanup is unavailable");
+  });
+
+  it("keeps deletion confirmation authoritative inside the serialized runtime mutation", async () => {
+    const deleteWorkspace = vi.fn(async (
+      _workspaceId: string,
+      input: { confirmTerminate: boolean },
+    ) => {
+      if (!input.confirmTerminate) throw new TerminalRuntimeError("confirmation_required");
+    });
+    const runtime = {
+      listWorkspaces: vi.fn(async () => [workspace]),
+      ensureWorkspace: vi.fn(async () => workspace),
+      createTab: vi.fn(),
+      deletionImpact: vi.fn(async () => ({ runningTabs: 0, tabs: [] })),
+      deleteWorkspace,
+    };
+    const app = new Hono().route("/api/terminal", createTerminalWorkspaceRoutes({ runtime, ...ownerOptions }));
+
+    const response = await app.request(`/api/terminal/workspaces/${workspace.id}`, {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ confirmTerminate: false }),
+    });
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "terminal_termination_confirmation_required",
+    });
+    expect(deleteWorkspace).toHaveBeenCalledWith(workspace.id, { confirmTerminate: false });
+  });
+
+  it("maps typed runtime not-found and revision-conflict errors to bounded HTTP responses", async () => {
+    const runtime = {
+      listWorkspaces: vi.fn(async () => { throw new TerminalRuntimeError("not_found"); }),
+      ensureWorkspace: vi.fn(async () => workspace),
+      createTab: vi.fn(),
+      reorderTabs: vi.fn(async () => { throw new TerminalRuntimeError("conflict"); }),
+      deletionImpact: vi.fn(async () => ({ runningTabs: 0, tabs: [] })),
+      deleteWorkspace: vi.fn(async () => undefined),
+    };
+    const app = new Hono().route("/api/terminal", createTerminalWorkspaceRoutes({ runtime, ...ownerOptions }));
+
+    const missing = await app.request("/api/terminal/workspaces");
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toEqual({ error: "Terminal operation failed" });
+
+    const conflict = await app.request(`/api/terminal/workspaces/${workspace.id}/tabs/order`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tabIds: [], baseRevision: 1 }),
+    });
+    expect(conflict.status).toBe(409);
+    await expect(conflict.json()).resolves.toEqual({ error: "terminal_revision_conflict" });
+  });
+
+  it("rejects a principal that does not own the local terminal runtime", async () => {
+    const runtime = {
+      listWorkspaces: vi.fn(async () => [workspace]),
+      ensureWorkspace: vi.fn(async () => workspace),
+      createTab: vi.fn(),
+      deletionImpact: vi.fn(),
+      deleteWorkspace: vi.fn(),
+    };
+    const app = new Hono().route("/api/terminal", createTerminalWorkspaceRoutes({
+      runtime,
+      getPrincipal: () => ({ userId: "user_other", source: "jwt" }),
+      terminalOwnerIds: ["user_owner"],
+    }));
+
+    expect((await app.request("/api/terminal/workspaces")).status).toBe(404);
+    expect(runtime.listWorkspaces).not.toHaveBeenCalled();
+  });
+});

--- a/tests/terminal-runtime/runtime.test.ts
+++ b/tests/terminal-runtime/runtime.test.ts
@@ -188,6 +188,26 @@ class FakeZellij implements ZellijRuntimeAdapter {
 }
 
 describe("project-scoped terminal runtime", () => {
+  it("persists the trusted access scope supplied for a chat terminal", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const runtime = new TerminalRuntime({
+      store: new TerminalWorkspaceStore({ homePath }),
+      zellij: new FakeZellij(),
+    });
+    const workspace = await runtime.ensureWorkspace({ projectId: "matrix-os" });
+
+    const tab = await runtime.createTab(workspace.id, {
+      name: "chat",
+      cwd: "projects/matrix-os",
+      accessScope: "chat",
+    });
+
+    expect(tab.accessScope).toBe("chat");
+    expect((await runtime.listWorkspaces())[0]?.tabs[0]?.accessScope).toBe("chat");
+    await runtime.shutdown();
+  });
+
   it("rejects an attachment when its pane exits while the adapter is opening it", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
     homes.push(homePath);
@@ -225,16 +245,16 @@ describe("project-scoped terminal runtime", () => {
     const firstTab = await limited.createTab(firstWorkspace.id, { name: "one", cwd: "projects/first" });
     await limited.createTab(firstWorkspace.id, { name: "two", cwd: "projects/first" });
     await expect(limited.createTab(firstWorkspace.id, { name: "three", cwd: "projects/first" }))
-      .rejects.toThrow("Terminal workspace tab capacity reached");
+      .rejects.toMatchObject({ code: "capacity" });
     await limited.createTab(secondWorkspace.id, { name: "three", cwd: "projects/second" });
     await expect(limited.createTab(secondWorkspace.id, { name: "four", cwd: "projects/second" }))
-      .rejects.toThrow("Terminal runtime tab capacity reached");
+      .rejects.toMatchObject({ code: "capacity" });
 
     expect((await limited.listWorkspaces()).flatMap((workspace) => workspace.tabs)).toHaveLength(3);
     await limited.terminateTab({ workspaceId: firstWorkspace.id, tabId: firstTab.id });
     await limited.createTab(firstWorkspace.id, { name: "replacement", cwd: "projects/first" });
     await expect(limited.createTab(secondWorkspace.id, { name: "still-full", cwd: "projects/second" }))
-      .rejects.toThrow("Terminal runtime tab capacity reached");
+      .rejects.toMatchObject({ code: "capacity" });
     expect((await limited.listWorkspaces()).flatMap((workspace) => workspace.tabs)).toHaveLength(4);
     expect(zellij.closedTabs).toHaveLength(1);
     expect(zellij.deletedSessions).toEqual([]);
@@ -559,7 +579,7 @@ describe("project-scoped terminal runtime", () => {
     await expect(runtime.createTab(second.id, {
       name: "second",
       cwd: "projects/second",
-    })).rejects.toThrow("Terminal observer capacity reached");
+    })).rejects.toMatchObject({ code: "capacity" });
 
     expect(zellij.observers.has(firstRuntimeWorkspace!.zellijSessionName)).toBe(true);
     expect(zellij.observers.has(secondRuntimeWorkspace!.zellijSessionName)).toBe(false);
@@ -776,7 +796,7 @@ describe("project-scoped terminal runtime", () => {
     ]);
     releaseDeletion();
     await deletion;
-    await expect(creation).rejects.toThrow("Terminal workspace not found");
+    await expect(creation).rejects.toMatchObject({ code: "not_found" });
 
     expect(tabCreatedBeforeDeletionFinished).toBe(false);
     expect(zellij.sessions.size).toBe(0);
@@ -803,7 +823,7 @@ describe("project-scoped terminal runtime", () => {
     await new Promise<void>((resolve) => { setImmediate(resolve); });
     releaseDeletion();
     await deletion;
-    await expect(reconciliation).rejects.toThrow("Terminal workspace not found");
+    await expect(reconciliation).rejects.toMatchObject({ code: "not_found" });
     expect(zellij.sessions.size).toBe(0);
     await runtime.shutdown();
   });
@@ -1116,7 +1136,7 @@ describe("project-scoped terminal runtime", () => {
     expect(zellij.attachments.size).toBe(0);
   });
 
-  it("reconciles stable Matrix tab IDs after the Zellij server restarts", async () => {
+  it("marks a lost running tab exited instead of replacing its process with an empty shell", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
     homes.push(homePath);
     const store = new TerminalWorkspaceStore({ homePath });
@@ -1134,9 +1154,9 @@ describe("project-scoped terminal runtime", () => {
     await restartedRuntime.restoreAll();
 
     const restored = (await restartedRuntime.listWorkspaces())[0]!;
-    expect(restored.tabs[0]?.id).toBe(tab.id);
+    expect(restored.tabs[0]).toMatchObject({ id: tab.id, status: "exited" });
     expect(restartedZellij.sessions.size).toBe(1);
-    expect([...restartedZellij.sessions.values()][0]?.size).toBe(1);
+    expect([...restartedZellij.sessions.values()][0]?.size).toBe(0);
     await restartedRuntime.shutdown();
   });
 

--- a/tests/terminal-runtime/service-shutdown.test.ts
+++ b/tests/terminal-runtime/service-shutdown.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from "vitest";
+import { runBestEffortTerminalShutdown } from "../../packages/terminal-runtime/src/service-shutdown.js";
+
+describe("terminal runtime service shutdown", () => {
+  it("logs a bounded runtime close failure without rejecting signal shutdown", async () => {
+    const log = vi.fn();
+
+    await expect(runBestEffortTerminalShutdown(
+      async () => { throw new Error("Terminal observer close timed out"); },
+      log,
+    )).resolves.toBeUndefined();
+    expect(log).toHaveBeenCalledWith("[terminal-runtime] graceful shutdown incomplete:", "Error");
+  });
+});

--- a/tests/terminal-runtime/socket-api.test.ts
+++ b/tests/terminal-runtime/socket-api.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TerminalRuntimeSocketClient } from "../../packages/terminal-runtime/src/socket-client.js";
+import { TerminalRuntimeError } from "../../packages/terminal-runtime/src/errors.js";
 import { TerminalRuntimeSocketServer } from "../../packages/terminal-runtime/src/socket-server.js";
 import { encodeSocketFrame, SocketFrameDecoder } from "../../packages/terminal-runtime/src/socket-framing.js";
 import {
@@ -156,6 +157,50 @@ describe("terminal runtime Unix socket API", () => {
       { workspaceId: workspace.id, tabId: created.id },
       { pinned: true, baseRevision: created.revision },
     )).resolves.toMatchObject({ uiState: { pinned: true } });
+
+    await server.close();
+  });
+
+  it("preserves typed domain failures across the socket boundary", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "matrix-terminal-socket-errors-"));
+    directories.push(directory);
+    const socketPath = join(directory, "terminal-runtime.sock");
+    const deleteWorkspace = vi.fn(async (_workspaceId: string, input: { confirmTerminate: boolean }) => {
+      if (!input.confirmTerminate) throw new TerminalRuntimeError("confirmation_required");
+    });
+    const server = new TerminalRuntimeSocketServer({
+      socketPath,
+      runtime: {
+        listWorkspaces: async () => { throw new TerminalRuntimeError("not_found"); },
+        ensureWorkspace: async () => { throw new TerminalRuntimeError("not_found"); },
+        createTab: async () => { throw new TerminalRuntimeError("not_found"); },
+        getSnapshot: async () => undefined,
+        resize: async () => { throw new TerminalRuntimeError("not_found"); },
+        attach: async () => { throw new TerminalRuntimeError("not_found"); },
+        updateTabUiState: async () => { throw new TerminalRuntimeError("conflict"); },
+        deleteWorkspace,
+      },
+    });
+    await server.start();
+    const client = new TerminalRuntimeSocketClient({ socketPath });
+
+    await expect(client.listWorkspaces()).rejects.toMatchObject({
+      name: "TerminalRuntimeError",
+      code: "not_found",
+      message: "Terminal operation failed",
+    });
+    await expect(client.deleteWorkspace(
+      "tws_0123456789abcdef0123456789abcdef",
+      { confirmTerminate: false },
+    )).rejects.toMatchObject({
+      name: "TerminalRuntimeError",
+      code: "confirmation_required",
+      message: "Terminal termination confirmation required",
+    });
+    expect(deleteWorkspace).toHaveBeenCalledWith(
+      "tws_0123456789abcdef0123456789abcdef",
+      expect.objectContaining({ confirmTerminate: false }),
+    );
 
     await server.close();
   });

--- a/tests/ui/chat-collaboration-sharing.test.tsx
+++ b/tests/ui/chat-collaboration-sharing.test.tsx
@@ -374,6 +374,60 @@ describe("Chat collaboration sharing", () => {
     expect(screen.queryByText("Stale message")).toBeNull();
   });
 
+  it("keeps a newer recovery visible when it supersedes the refresh after send", async () => {
+    const scope = {
+      id: scopeId, ownerId: "user_owner", kind: "chat", resourceId: chatId,
+      membershipMode: "direct", lifecycle: "shared", revision: "1", authEpoch: "1",
+      authorityGeneration: "1", role: "editor",
+      capabilities: { read: true, discuss: true, manageMembers: false, requestAi: false },
+    };
+    const message = (text: string) => ({
+      id: "msg_1", chatId, sequence: "1", role: "user", state: "committed", purpose: "discussion",
+      actor: { actorId: "user_owner", displayName: "Nima" }, parts: [{ type: "text", text }],
+      createdAt: "2026-09-07T12:00:00.000Z",
+    });
+    let refresh!: () => Promise<void>;
+    let resolveSendRecovery!: (value: unknown) => void;
+    let messageReads = 0;
+    const api = {
+      baseUrl: "https://app.matrix-os.com",
+      get: vi.fn(async (path: string) => {
+        if (path.includes("/messages?")) {
+          messageReads += 1;
+          if (messageReads === 2) {
+            return new Promise((resolve) => { resolveSendRecovery = resolve; });
+          }
+          return { messages: [message(messageReads === 1 ? "Initial message" : "Newest message")] };
+        }
+        if (path.endsWith("/chat")) {
+          return { id: chatId, scopeId, title: "Send recovery race", lifecycle: "active", revision: "1", messageCount: "1" };
+        }
+        return scope;
+      }),
+      post: vi.fn(async () => ({ ok: true })),
+      delete: vi.fn(),
+      subscribe: vi.fn((_scopeId: string, onEvent: () => Promise<void>) => {
+        refresh = onEvent;
+        return () => undefined;
+      }),
+    };
+    render(<ChatCollaboration view={{ kind: "chat", scopeId }} api={api} actorId="user_editor" />);
+    expect(await screen.findByText("Initial message")).toBeVisible();
+    fireEvent.change(screen.getByLabelText("Message everyone"), { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => expect(resolveSendRecovery).toBeTypeOf("function"));
+
+    await act(async () => { await refresh(); });
+    expect(screen.getByText("Newest message")).toBeVisible();
+    await act(async () => {
+      resolveSendRecovery({ messages: [message("Stale message")] });
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Newest message")).toBeVisible();
+    expect(screen.queryByText("Shared Chat unavailable")).toBeNull();
+  });
+
   it("keeps viewer discussion controls read-only", async () => {
     const api = {
       baseUrl: "https://app.matrix-os.com",


### PR DESCRIPTION
## Summary

- add the authenticated HTTP contract for project terminal workspaces and tabs
- expose split, focus, resize, scroll, fullscreen, and close controls through stable workspace/tab references
- require exact owner, Chat binding, and tab-incarnation authorization for Chat pane actions
- validate identifiers, query context, and action-specific bodies at the route boundary with bounded request bodies
- preserve serialized destructive confirmation and map typed runtime failures to client-safe errors
- treat a missing previously running Zellij tab as an exited process instead of recreating an empty shell that masks a dead agent

Layer 6 of 14. Depends on #1581; #1431 follows.

## Tests

- gateway and terminal-runtime TypeScript checks
- 7 terminal workspace route tests, including pane controls and Chat binding/incarnation denial
- 24 terminal-runtime tests, including lost-running-tab reconciliation
- 14 agent-session-manager tests, including explicit exit degradation and lease release
- existing runtime/socket/gateway contract and route-inventory coverage
- full stack pattern scan: 0 violations
- diff hygiene
- PR size: 876 additions across 14 files

## Review/Monitoring

- GitHub CI and Greptile are being monitored on the exact latest head; merge readiness requires current-head CI, Greptile 5/5, and zero unresolved threads.

## Invariants

### Source of truth

- The owner-local terminal runtime workspace store is canonical; HTTP responses are validated projections.
- Chat's stored terminal binding plus the canonical tab creation timestamp define the authorized incarnation.

### Lock/transaction scope

- Routes authorize and validate before delegating one bounded mutation to the terminal runtime.
- Destructive confirmation is evaluated by the serialized runtime mutation, not a separate route preflight.
- Workspace/tab serialization is owned by the runtime; this layer adds no database transaction or parallel store.

### Acceptable orphan states

- If a client disconnects after create, the canonical tab remains discoverable.
- Incomplete bulk inventory is not proof of process loss and does not mutate durable agent ownership.
- Complete workspace reconciliation marks a missing previously running stable tab exited; gateway startup reconciliation can then close the durable agent session and release its worktree lease.
- A staged `starting` tab may be completed idempotently because no prior running process is being replaced.
- Runtime unavailability returns a generic bounded failure and does not mutate gateway-local ownership state.
- Missing or stale Chat binding denies the pane action without dispatching it.

### Auth source of truth

- Gateway request-principal authentication and configured owner-local runtime membership are authoritative.
- Chat pane actions require matching owner, chat, stable terminal ref, and tab incarnation.
- Omitting Chat context cannot be used to control a Chat-bound terminal.

### Deferred scope

- WebSocket attachment and compatibility cutover remain in #1431.
- CLI, browser, desktop, native, deployment, and documentation changes remain subsequent layers.
