### PR TITLE
feat(chat): execute saved Hermes agents with durable context

### DIFF
--- a/packages/contracts/src/canonical-chat-api.ts
+++ b/packages/contracts/src/canonical-chat-api.ts
@@ -1,4 +1,4 @@
-import { ChatRunContextSchema } from "./chat-agent-context.js";
+import { ChatRunContextSchema } from "#chat-agent-context";
 import { z } from "zod/v4";
 import {
   CanonicalChatMessagePartSchema,

--- a/packages/contracts/src/canonical-chat-api.ts
+++ b/packages/contracts/src/canonical-chat-api.ts
@@ -1,3 +1,4 @@
+import { ChatRunContextSchema } from "./chat-agent-context.js";
 import { z } from "zod/v4";
 import {
   CanonicalChatMessagePartSchema,
@@ -180,6 +181,7 @@ export const CanonicalChatRunSteeringResponseSchema = z.object({
 });
 
 export const CanonicalChatQueuedTurnSchema = z.object({
+  context: ChatRunContextSchema.optional(),
   id: CanonicalChatQueuedTurnIdSchema,
   chatId: CanonicalChatSchema.shape.id,
   clientRequestId: CanonicalChatRequestIdSchema,

--- a/packages/contracts/src/canonical-chat-surface.ts
+++ b/packages/contracts/src/canonical-chat-surface.ts
@@ -204,7 +204,7 @@ export const CanonicalChatSnapshotSchema = z.object({
     if (bindingTurn === undefined) {
       ctx.addIssue({ code: "custom", path: ["chat", "providerBinding", "lockedAtTurnId"], message: "Provider binding Turn is not in the snapshot" });
     } else {
-      const firstTurn = [...snapshot.turns].sort((left, right) => (
+      const firstTurn = snapshot.turns.filter((turn) => snapshot.runs.some((run) => run.turnId === turn.id && !run.context?.agent)).sort((left, right) => (
         left.baseMessageSeq - right.baseMessageSeq
         || left.createdAt.localeCompare(right.createdAt)
         || left.id.localeCompare(right.id)
@@ -215,9 +215,9 @@ export const CanonicalChatSnapshotSchema = z.object({
     }
   }
   snapshot.runs.forEach((run, index) => {
-    if (binding === undefined
+    if (!run.context?.agent && (binding === undefined
       || run.driverKind !== binding.driverKind
-      || run.instanceId !== binding.instanceId) {
+      || run.instanceId !== binding.instanceId)) {
       ctx.addIssue({
         code: "custom",
         path: ["runs", index, "instanceId"],

--- a/packages/contracts/src/chat-agents.ts
+++ b/packages/contracts/src/chat-agents.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { CanonicalChatModelSelectionSchema, CanonicalChatRequestIdSchema } from "#canonical-chat";
+import { CanonicalChatModelSelectionSchema, CanonicalChatRequestIdSchema, CanonicalChatResourceReferenceSchema } from "#canonical-chat";
 import { IsoTimestampSchema } from "#contract-primitives";
 import { canonicalBoundedText, canonicalSafeLabel } from "#canonical-chat-primitives";
 import { ChatAgentIdSchema } from "#chat-agent-context";
@@ -32,3 +32,9 @@ export type ChatAgent = z.infer<typeof ChatAgentSchema>;
 export type CreateChatAgentRequest = z.infer<typeof CreateChatAgentRequestSchema>;
 export type UpdateChatAgentRequest = z.infer<typeof UpdateChatAgentRequestSchema>;
 export type ChatAgentListResponse = z.infer<typeof ChatAgentListResponseSchema>;
+
+export const ChatMentionSearchResponseSchema = z.object({
+  enabled: z.boolean(),
+  resources: z.array(CanonicalChatResourceReferenceSchema).max(40),
+}).strict();
+export type ChatMentionSearchResponse = z.infer<typeof ChatMentionSearchResponseSchema>;

--- a/packages/gateway/src/chat/agent-context.ts
+++ b/packages/gateway/src/chat/agent-context.ts
@@ -26,7 +26,7 @@ export function chatContextRequestHash(input: CanonicalCreateChatTurnRequest): s
   })).digest("hex");
 }
 
-function transcript(messages: CanonicalChatMessage[], limit: number): { text: string; truncated: boolean } {
+export function transcript(messages: CanonicalChatMessage[], limit: number): { text: string; truncated: boolean } {
   const lines = messages.filter((message) => message.state === "committed"
     && (message.role === "user" || message.role === "assistant"))
     .flatMap((message) => {
@@ -113,6 +113,11 @@ export class ChatAgentContext {
       permissionMode: input.permissionMode,
       ...(context ? { context } : {}),
     };
+  }
+
+  async preview(owner: ChatOwner, chatId: string): Promise<ChatContextSnapshot> {
+    if (!this.options.enabled()) throw new ChatAgentContextError("feature_disabled");
+    return this.snapshot(owner, chatId, 8_000);
   }
 
   async revalidate(owner: ChatOwner, chatId: string, context?: ChatRunContext): Promise<void> {

--- a/packages/gateway/src/chat/agent-routes.ts
+++ b/packages/gateway/src/chat/agent-routes.ts
@@ -1,0 +1,108 @@
+import {
+  ChatAgentIdSchema, ChatAgentSchema, ChatAgentListResponseSchema, ChatMentionSearchResponseSchema,
+  ChatContextSnapshotSchema, CreateChatAgentRequestSchema, UpdateChatAgentRequestSchema,
+  CanonicalChatIdSchema, type CanonicalChatModelSelection,
+} from "@matrix-os/contracts";
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import { isRequestPrincipalError, mapRequestPrincipalError, type RequestPrincipal } from "../request-principal.js";
+import { ChatAgentStoreError, type ChatAgentStore } from "./agent-store.js";
+import { ChatAgentContextError, type ChatAgentContext } from "./agent-context.js";
+import type { ChatRepository } from "./repository.js";
+import { validateChatProviderSelection, type ChatProviderCatalogService } from "./provider-catalog.js";
+
+const SearchSchema = z.object({
+  query: z.string().trim().max(200).default(""),
+  chatId: CanonicalChatIdSchema.optional(),
+}).strict();
+
+export function createChatAgentRoutes(options: {
+  agents?: ChatAgentStore;
+  repository?: ChatRepository;
+  context?: ChatAgentContext;
+  enabled(): boolean;
+  catalog: Pick<ChatProviderCatalogService, "getCatalog">;
+  getPrincipal(context: Context): RequestPrincipal;
+}): Hono {
+  const routes = new Hono();
+  const limit = bodyLimit({ maxSize: 40 * 1024, onError: (c) => c.json({ error: "Request too large" }, 413) });
+  const owner = (context: Context) => ({ type: "personal" as const, ownerId: options.getPrincipal(context).userId });
+  routes.onError((error: unknown, context) => {
+    if (isRequestPrincipalError(error)) {
+      const mapped = mapRequestPrincipalError(error);
+      if (mapped.log) console.warn("[chat-agents] Principal context unavailable:", error.name);
+      return context.json(mapped.body, mapped.status);
+    }
+    if (error instanceof Error && error.name === "BodyLimitError") return context.json({ error: "Request too large" }, 413);
+    if (error instanceof z.ZodError || error instanceof SyntaxError) return context.json({ error: "Invalid request" }, 400);
+    if (error instanceof ChatAgentStoreError && error.code === "agent_not_found"
+      || error instanceof ChatAgentContextError && error.code === "context_unavailable") {
+      return context.json({ error: "Agent or Chat not found" }, 404);
+    }
+    if (error instanceof ChatAgentStoreError && error.code === "agent_conflict") {
+      return context.json({ error: "Agent changed. Refresh and try again." }, 409);
+    }
+    console.warn("[chat-agents] Request failed:", error instanceof Error ? error.name : "UnknownError");
+    return context.json({ error: "Agents are temporarily unavailable." }, 503);
+  });
+  function requireServices() {
+    if (!options.agents || !options.repository || !options.context) throw new Error("Chat Agent services unavailable");
+    return { agents: options.agents, repository: options.repository, context: options.context };
+  }
+  async function validSelection(principal: RequestPrincipal, selection: CanonicalChatModelSelection): Promise<boolean> {
+    const catalog = await options.catalog.getCatalog(principal);
+    const checked = validateChatProviderSelection({ catalog, selection,
+      requirements: { interactionMode: "default", permissionMode: "full_access" },
+    });
+    return checked.ok && checked.instance.driverKind === "hermes";
+  }
+  routes.get("/api/chat-agents", async (c) => {
+    const scope = owner(c);
+    if (!options.enabled()) return c.json({ enabled: false, agents: [] });
+    const { agents } = requireServices();
+    return c.json(ChatAgentListResponseSchema.parse({ enabled: true, agents: await agents.list(scope) }));
+  });
+  routes.post("/api/chat-agents", limit, async (c) => {
+    const principal = options.getPrincipal(c);
+    if (!options.enabled()) return c.json({ error: "Agents are disabled." }, 409);
+    const { agents } = requireServices();
+    const input = CreateChatAgentRequestSchema.parse(await c.req.json());
+    if (!await validSelection(principal, input.selection)) return c.json({ error: "Choose an available Hermes model." }, 400);
+    return c.json(ChatAgentSchema.parse(await agents.create({ type: "personal", ownerId: principal.userId }, input)), 201);
+  });
+  routes.patch("/api/chat-agents/:agentId", limit, async (c) => {
+    const principal = options.getPrincipal(c);
+    const id = ChatAgentIdSchema.parse(c.req.param("agentId"));
+    if (!options.enabled()) return c.json({ error: "Agents are disabled." }, 409);
+    const { agents } = requireServices();
+    const input = UpdateChatAgentRequestSchema.parse(await c.req.json());
+    if (input.selection && !await validSelection(principal, input.selection)) return c.json({ error: "Choose an available Hermes model." }, 400);
+    return c.json(ChatAgentSchema.parse(await agents.update({ type: "personal", ownerId: principal.userId }, id, input)));
+  });
+  routes.get("/api/chat-mentions", async (c) => {
+    const scope = owner(c);
+    const input = SearchSchema.parse(c.req.query());
+    if (!options.enabled()) return c.json({ enabled: false, resources: [] });
+    const { agents, repository } = requireServices();
+    const roles = (await agents.list(scope)).filter((agent) =>
+      `${agent.name} ${agent.description}`.toLowerCase().includes(input.query.toLowerCase())).slice(0, 20);
+    let query = repository.kysely.selectFrom("chats").select(["id", "title"])
+      .where("owner_type", "=", scope.type).where("owner_id", "=", scope.ownerId)
+      .where("lifecycle", "=", "active").where("collaboration", "is", null);
+    if (input.chatId) query = query.where("id", "!=", input.chatId);
+    if (input.query) query = query.where("title", "ilike", `%${input.query.replace(/[\\%_]/g, "\\$&")}%`);
+    const chats = await query.orderBy("updated_at", "desc").orderBy("id").limit(20).execute();
+    return c.json(ChatMentionSearchResponseSchema.parse({ enabled: true, resources: [
+      ...roles.map((agent) => ({ kind: "agent", id: agent.id, label: agent.name, revision: String(agent.revision) })),
+      ...chats.map((chat) => ({ kind: "chat", id: chat.id, label: chat.title })),
+    ] }));
+  });
+  routes.get("/api/chat-context/:chatId", async (c) => {
+    const scope = owner(c);
+    const chatId = CanonicalChatIdSchema.parse(c.req.param("chatId"));
+    if (!options.enabled()) return c.json({ error: "Chat references are disabled." }, 409);
+    return c.json(ChatContextSnapshotSchema.parse(await requireServices().context.preview(scope, chatId)));
+  });
+  return routes;
+}

--- a/packages/gateway/src/chat/database.ts
+++ b/packages/gateway/src/chat/database.ts
@@ -104,6 +104,7 @@ export interface ChatRunsTable {
   started_at: NullableTimestamp;
   completed_at: NullableTimestamp;
   history_boundary_seq: number;
+  context_snapshot: Generated<unknown>;
   capability_snapshot: JsonValue;
   created_at: Timestamp;
   updated_at: Timestamp;
@@ -123,6 +124,7 @@ export interface ChatQueuedTurnsTable {
   permission_mode: string;
   execution_root: JsonValue | null;
   execution_root_fingerprint: string | null;
+  context_snapshot: Generated<unknown>;
   capability_snapshot: JsonValue;
   claimed_turn_id: string | null;
   claimed_run_id: string | null;
@@ -385,6 +387,7 @@ export async function bootstrapChatDatabase<Database extends ChatDatabase>(
       UNIQUE (turn_id, attempt)
     )
   `.execute(db);
+  await sql`ALTER TABLE chat_runs ADD COLUMN IF NOT EXISTS context_snapshot JSONB`.execute(db);
   await sql`
     ALTER TABLE chat_runs
     ADD COLUMN IF NOT EXISTS execution_root_fingerprint TEXT
@@ -436,6 +439,7 @@ export async function bootstrapChatDatabase<Database extends ChatDatabase>(
       UNIQUE (chat_id, client_request_id)
     )
   `.execute(db);
+  await sql`ALTER TABLE chat_queued_turns ADD COLUMN IF NOT EXISTS context_snapshot JSONB`.execute(db);
   await sql`
     CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_queued_turns_position
     ON chat_queued_turns(chat_id, position)

--- a/packages/gateway/src/chat/orchestration-input.ts
+++ b/packages/gateway/src/chat/orchestration-input.ts
@@ -1,4 +1,5 @@
 import { CanonicalChatSafeErrorSchema, type CanonicalChatSafeError, type CanonicalCreateChatTurnRequest, type CanonicalChatMessage } from "@matrix-os/contracts";
+import { ChatAgentContextError } from "./agent-context.js";
 import { ChatNotFoundError, ChatBusyError, ChatProviderInstanceLockedError, ChatRunNotAcknowledgeableError, ChatRunNotActiveError, ChatConflictError } from "./errors.js";
 
 export class CanonicalChatOrchestrationError extends Error {
@@ -75,6 +76,13 @@ export function requirementsFor(input: CanonicalCreateChatTurnRequest) {
 }
 
 export function mapRepositoryError(error: unknown): never {
+  if (error instanceof ChatAgentContextError) {
+    throw new CanonicalChatOrchestrationError(error.code === "context_unavailable"
+      ? safeError("resource_unavailable", "The selected Agent or Chat is unavailable.")
+      : safeError("capability_mismatch", error.code === "agent_permission_required"
+        ? "This Agent requires Full access. Select it before sending."
+        : "Agents and Chat references are disabled."), 400);
+  }
   if (error instanceof ChatNotFoundError) {
     throw new CanonicalChatOrchestrationError(safeError("chat_not_found", "Chat not found."), 404);
   }

--- a/packages/gateway/src/chat/orchestration-input.ts
+++ b/packages/gateway/src/chat/orchestration-input.ts
@@ -1,0 +1,109 @@
+import { CanonicalChatSafeErrorSchema, type CanonicalChatSafeError, type CanonicalCreateChatTurnRequest, type CanonicalChatMessage } from "@matrix-os/contracts";
+import { ChatNotFoundError, ChatBusyError, ChatProviderInstanceLockedError, ChatRunNotAcknowledgeableError, ChatRunNotActiveError, ChatConflictError } from "./errors.js";
+
+export class CanonicalChatOrchestrationError extends Error {
+  constructor(readonly safeError: CanonicalChatSafeError, readonly status: 400 | 404 | 409 | 503) {
+    super(safeError.safeMessage);
+    this.name = "CanonicalChatOrchestrationError";
+  }
+}
+
+export function safeError(
+  code: CanonicalChatSafeError["code"],
+  safeMessage: string,
+  retryable = false,
+  recoveryActions?: CanonicalChatSafeError["recoveryActions"],
+): CanonicalChatSafeError {
+  return CanonicalChatSafeErrorSchema.parse({
+    code,
+    safeMessage,
+    retryable,
+    ...(recoveryActions ? { recoveryActions } : {}),
+  });
+}
+
+export function promptFor(parts: CanonicalCreateChatTurnRequest["parts"]): string {
+  const lines = parts.flatMap((part) => {
+    if (part.type === "text") return [part.text];
+    if (part.type === "invocation_reference") {
+      return [`${part.invocation.invocation}${part.invocation.arguments ? ` ${part.invocation.arguments}` : ""}`];
+    }
+    if (part.type === "resource_reference") return [`@${part.resource.label}`];
+    if (part.type === "attachment_reference" && !part.ownerReference) return [`@${part.label}`];
+    return [];
+  });
+  const attachmentReferences = parts.flatMap((part) => (
+    part.type === "attachment_reference" && part.ownerReference
+      ? [`- ${JSON.stringify(part.label)}: ${shellQuotedOwnerReference(part.ownerReference)}`]
+      : []
+  ));
+  if (attachmentReferences.length > 0) {
+    lines.push(
+      "",
+      "Attached files (available on this Matrix computer):",
+      ...attachmentReferences,
+    );
+  }
+  const prompt = lines.join("\n").trim();
+  if (!prompt) throw new CanonicalChatOrchestrationError(
+    safeError("capability_mismatch", "The message does not contain supported input."),
+    400,
+  );
+  return prompt;
+}
+
+export function retryPromptFor(messages: CanonicalChatMessage[]): string {
+  return messages.map((message) => promptFor(message.parts)).join("\n\n");
+}
+
+function shellQuotedOwnerReference(ownerReference: string): string {
+  return `"$MATRIX_HOME"/'${ownerReference.replaceAll("'", "'\\''")}'`;
+}
+
+export function requirementsFor(input: CanonicalCreateChatTurnRequest) {
+  return {
+    attachments: input.parts.flatMap((part) =>
+      part.type === "attachment_reference" ? [part.kind] : []
+    ),
+    resources: input.parts.flatMap((part) =>
+      part.type === "resource_reference" ? [part.resource.kind] : []
+    ),
+    interactionMode: input.interactionMode,
+    permissionMode: input.permissionMode,
+    worktree: input.executionRoot?.kind === "worktree",
+  };
+}
+
+export function mapRepositoryError(error: unknown): never {
+  if (error instanceof ChatNotFoundError) {
+    throw new CanonicalChatOrchestrationError(safeError("chat_not_found", "Chat not found."), 404);
+  }
+  if (error instanceof ChatBusyError) {
+    throw new CanonicalChatOrchestrationError(safeError("chat_busy", "This Chat already has an active Run."), 409);
+  }
+  if (error instanceof ChatProviderInstanceLockedError) {
+    throw new CanonicalChatOrchestrationError(safeError(
+      "provider_instance_locked",
+      "This Chat is already bound to another Provider instance.",
+      false,
+      ["fork_chat", "start_new_chat"],
+    ), 409);
+  }
+  if (error instanceof ChatRunNotAcknowledgeableError) {
+    throw new CanonicalChatOrchestrationError(safeError(
+      "run_unavailable",
+      "Only a successful completed Run can be acknowledged.",
+    ), 409);
+  }
+  if (error instanceof ChatRunNotActiveError) {
+    throw new CanonicalChatOrchestrationError(
+      safeError("run_unavailable", "The Run is no longer active."),
+      409,
+    );
+  }
+  if (error instanceof ChatConflictError) {
+    throw new CanonicalChatOrchestrationError(safeError("chat_conflict", "Chat changed. Refresh and try again.", true, ["retry"]), 409);
+  }
+  throw error;
+}
+

--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -1,4 +1,5 @@
 import { admitCanonicalTurn } from "./turn-admission.js";
+import { contextPrompt, type ChatAgentContext } from "./agent-context.js";
 import { CanonicalChatOrchestrationError, mapRepositoryError, safeError, promptFor, retryPromptFor, requirementsFor } from "./orchestration-input.js";
 export { CanonicalChatOrchestrationError, mapRepositoryError } from "./orchestration-input.js";
 import { createHash, randomUUID } from "node:crypto";
@@ -188,6 +189,7 @@ export class CanonicalChatOrchestrator {
     catalog: Pick<ChatProviderCatalogService, "getCatalog">;
     adapters: CanonicalChatProviderRegistry;
     executionRoots?: ChatExecutionRootResolver;
+    agentContext?: ChatAgentContext;
     collaborationGuard?: {
       assertPersonalExecutionAllowed(owner: ChatOwner, chatId: string): Promise<void>;
     };
@@ -277,6 +279,7 @@ export class CanonicalChatOrchestrator {
         chatId,
         input: CanonicalQueueChatTurnRequestSchema.parse(inputValue),
         repository: this.options.repository,
+        agentContext: this.options.agentContext,
         catalog: this.options.catalog,
         adapters: this.options.adapters,
         ...(this.options.executionRoots ? { executionRoots: this.options.executionRoots } : {}),
@@ -305,6 +308,8 @@ export class CanonicalChatOrchestrator {
     if (!context) {
       throw new CanonicalChatOrchestrationError(safeError("run_not_found", "Run not found."), 404);
     }
+    try { await this.options.agentContext?.revalidate(owner, chatId, context.latestRun.context); }
+    catch (error: unknown) { return mapRepositoryError(error); }
     const catalog = await this.options.catalog.getCatalog(principal);
     const validated = validateChatProviderSelection({
       catalog,
@@ -342,7 +347,7 @@ export class CanonicalChatOrchestrator {
         );
       }
     }
-    const resumeState = await loadChatResumeState({
+    const resumeState = context.latestRun.context?.history ? undefined : await loadChatResumeState({
       repository: this.options.repository, owner, chatId, adapter,
       instanceId: context.latestRun.instanceId,
       executionRootFingerprint: resolvedRoot?.fingerprint ?? null,
@@ -372,6 +377,7 @@ export class CanonicalChatOrchestrator {
       selection: validated.selection,
       interactionMode: context.latestRun.interactionMode,
       permissionMode: context.latestRun.permissionMode,
+      ...(context.latestRun.context ? { context: context.latestRun.context } : {}),
       ...(resolvedRoot ? {
         executionRoot: resolvedRoot.ref,
         executionRootFingerprint: resolvedRoot.fingerprint,
@@ -522,7 +528,7 @@ export class CanonicalChatOrchestrator {
               throw new Error("Queued execution root provenance changed");
             }
           }
-          resumeState = await loadChatResumeState({
+          resumeState = claimed.run.context?.history ? undefined : await loadChatResumeState({
             repository: this.options.repository, owner, chatId, adapter,
             instanceId: claimed.run.instanceId,
             executionRootFingerprint: resolvedRoot?.fingerprint ?? null,
@@ -573,6 +579,7 @@ export class CanonicalChatOrchestrator {
     let failureStage: ChatRunFailureDiagnostic["stage"] = "preparation";
     try {
       await this.assertPersonalExecutionAllowed(owner, run.chatId);
+      await this.options.agentContext?.revalidate(owner, run.chatId, run.context);
       if (resolvedRoot && this.options.executionRoots) {
         const provenance: ChatExecutionRootProvenance = {
           ref: resolvedRoot.ref!,
@@ -592,7 +599,7 @@ export class CanonicalChatOrchestrator {
         chatId: run.chatId,
         turnId: run.turnId,
         runId: run.id,
-        prompt: promptOverride ?? promptFor(message.parts),
+        prompt: contextPrompt(promptOverride ?? promptFor(message.parts), run.context),
         parts: message.parts,
         selection: run.selection,
         interactionMode: run.interactionMode,

--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -1,3 +1,6 @@
+import { admitCanonicalTurn } from "./turn-admission.js";
+import { CanonicalChatOrchestrationError, mapRepositoryError, safeError, promptFor, retryPromptFor, requirementsFor } from "./orchestration-input.js";
+export { CanonicalChatOrchestrationError, mapRepositoryError } from "./orchestration-input.js";
 import { createHash, randomUUID } from "node:crypto";
 import {
   CanonicalChatMessageSchema,
@@ -74,13 +77,6 @@ const MAX_ACTIVE_RUNS_PER_OWNER = 8;
 const MAX_ASSISTANT_TEXT = 96 * 1024;
 const STEER_FINALIZE_ATTEMPTS = 2;
 
-export class CanonicalChatOrchestrationError extends Error {
-  constructor(readonly safeError: CanonicalChatSafeError, readonly status: 400 | 404 | 409 | 503) {
-    super(safeError.safeMessage);
-    this.name = "CanonicalChatOrchestrationError";
-  }
-}
-
 interface ActiveRun {
   controller: AbortController;
   adapter: CanonicalChatProviderAdapter;
@@ -153,105 +149,6 @@ function assistantMessageId(runId: string, providerMessageId?: string): string {
   if (!providerMessageId) return `msg_${runId.slice("run_".length)}_assistant`;
   const digest = createHash("sha256").update(`${runId}\0${providerMessageId}`).digest("hex").slice(0, 32);
   return `msg_${digest}`;
-}
-
-function safeError(
-  code: CanonicalChatSafeError["code"],
-  safeMessage: string,
-  retryable = false,
-  recoveryActions?: CanonicalChatSafeError["recoveryActions"],
-): CanonicalChatSafeError {
-  return CanonicalChatSafeErrorSchema.parse({
-    code,
-    safeMessage,
-    retryable,
-    ...(recoveryActions ? { recoveryActions } : {}),
-  });
-}
-
-function promptFor(parts: CanonicalCreateChatTurnRequest["parts"]): string {
-  const lines = parts.flatMap((part) => {
-    if (part.type === "text") return [part.text];
-    if (part.type === "invocation_reference") {
-      return [`${part.invocation.invocation}${part.invocation.arguments ? ` ${part.invocation.arguments}` : ""}`];
-    }
-    if (part.type === "resource_reference") return [`@${part.resource.label}`];
-    if (part.type === "attachment_reference" && !part.ownerReference) return [`@${part.label}`];
-    return [];
-  });
-  const attachmentReferences = parts.flatMap((part) => (
-    part.type === "attachment_reference" && part.ownerReference
-      ? [`- ${JSON.stringify(part.label)}: ${shellQuotedOwnerReference(part.ownerReference)}`]
-      : []
-  ));
-  if (attachmentReferences.length > 0) {
-    lines.push(
-      "",
-      "Attached files (available on this Matrix computer):",
-      ...attachmentReferences,
-    );
-  }
-  const prompt = lines.join("\n").trim();
-  if (!prompt) throw new CanonicalChatOrchestrationError(
-    safeError("capability_mismatch", "The message does not contain supported input."),
-    400,
-  );
-  return prompt;
-}
-
-function retryPromptFor(messages: CanonicalChatMessage[]): string {
-  return messages.map((message) => promptFor(message.parts)).join("\n\n");
-}
-
-function shellQuotedOwnerReference(ownerReference: string): string {
-  return `"$MATRIX_HOME"/'${ownerReference.replaceAll("'", "'\\''")}'`;
-}
-
-function requirementsFor(input: CanonicalCreateChatTurnRequest) {
-  return {
-    attachments: input.parts.flatMap((part) =>
-      part.type === "attachment_reference" ? [part.kind] : []
-    ),
-    resources: input.parts.flatMap((part) =>
-      part.type === "resource_reference" ? [part.resource.kind] : []
-    ),
-    interactionMode: input.interactionMode,
-    permissionMode: input.permissionMode,
-    worktree: input.executionRoot?.kind === "worktree",
-  };
-}
-
-export function mapRepositoryError(error: unknown): never {
-  if (error instanceof ChatNotFoundError) {
-    throw new CanonicalChatOrchestrationError(safeError("chat_not_found", "Chat not found."), 404);
-  }
-  if (error instanceof ChatBusyError) {
-    throw new CanonicalChatOrchestrationError(safeError("chat_busy", "This Chat already has an active Run."), 409);
-  }
-  if (error instanceof ChatProviderInstanceLockedError) {
-    throw new CanonicalChatOrchestrationError(safeError(
-      "provider_instance_locked",
-      "This Chat is already bound to another Provider instance.",
-      false,
-      ["fork_chat", "start_new_chat"],
-    ), 409);
-  }
-  if (error instanceof ChatRunNotAcknowledgeableError) {
-    throw new CanonicalChatOrchestrationError(safeError(
-      "run_unavailable",
-      "Only a successful completed Run can be acknowledged.",
-    ), 409);
-  }
-  if (error instanceof ChatRunNotActiveError) {
-    throw new CanonicalChatOrchestrationError(
-      safeError("run_unavailable", "The Run is no longer active."),
-      409,
-    );
-  }
-  if (error instanceof ChatConflictError) {
-    throw new CanonicalChatOrchestrationError(safeError("chat_conflict", "Chat changed. Refresh and try again.", true, ["retry"]), 409);
-  }
-  throw error;
 }
 
 export class CanonicalChatOrchestrator {
@@ -350,183 +247,19 @@ export class CanonicalChatOrchestrator {
   }
 
   async admitTurn(
-    principal: RequestPrincipal,
-    owner: ChatOwner,
-    chatId: string,
+    principal: RequestPrincipal, owner: ChatOwner, chatId: string,
     inputValue: CanonicalCreateChatTurnRequest,
   ): Promise<CanonicalChatTurnAdmissionResponse> {
-    this.assertOpen();
-    await this.assertPersonalExecutionAllowed(owner, chatId);
-    await this.reconcileActiveRuns(owner);
-    const input = CanonicalCreateChatTurnRequestSchema.parse(inputValue);
-    const record = await this.options.repository.get(owner, chatId);
-    if (!record) return mapRepositoryError(new ChatNotFoundError(chatId));
-    const catalog = await this.options.catalog.getCatalog(principal);
-    const validated = validateChatProviderSelection({
-      catalog,
-      selection: input.selection,
-      ...(record.providerBinding ? { boundInstanceId: record.providerBinding.instanceId } : {}),
-      requirements: requirementsFor(input),
-    });
-    if (!validated.ok) {
-      throw new CanonicalChatOrchestrationError(validated.error, validated.error.code === "provider_instance_locked" ? 409 : 400);
-    }
-    const adapter = this.options.adapters.get(validated.instance.driverKind);
-    if (!adapter) {
-      throw new CanonicalChatOrchestrationError(
-        safeError("provider_unavailable", "The selected Provider cannot run yet.", false, ["select_provider"]),
-        503,
-      );
-    }
-    const rootRef = input.executionRoot
-      ?? (record.projectId ? { kind: "project" as const, projectId: record.projectId } : undefined);
-    if (input.executionRoot && record.projectId && input.executionRoot.projectId !== record.projectId) {
-      throw new CanonicalChatOrchestrationError(
-        safeError("project_unavailable", "The selected workspace does not belong to this Chat's Project."),
-        400,
-      );
-    }
-    if (validated.instance.workspaceRequirement === "project_required" && rootRef === undefined) {
-      throw new CanonicalChatOrchestrationError(
-        safeError("project_required", "This Provider requires a Project.", false, ["return_to_project"]),
-        400,
-      );
-    }
-    let resolvedRoot: Awaited<ReturnType<ChatExecutionRootResolver["resolve"]>> | undefined;
-    if (rootRef !== undefined) {
-      if (!this.options.executionRoots) {
-        throw new CanonicalChatOrchestrationError(
-          safeError("project_unavailable", "The Project workspace is unavailable.", true, ["retry"]),
-          503,
-        );
-      }
-      try {
-        resolvedRoot = await this.options.executionRoots.resolve(owner, rootRef);
-      } catch (error: unknown) {
-        console.warn("[chat/orchestrator] Execution root resolution failed:", error instanceof Error ? error.name : "UnknownError");
-        throw new CanonicalChatOrchestrationError(
-          safeError("project_unavailable", "The Project workspace is unavailable.", true, ["retry"]),
-          503,
-        );
-      }
-    }
-    const resumeState = await loadChatResumeState({
-      repository: this.options.repository, owner, chatId, adapter,
-      instanceId: validated.instance.id,
-      executionRootFingerprint: resolvedRoot?.fingerprint ?? null,
-      mode: "follow_up",
-    });
-    const adapterState = resumeState === undefined ? undefined : {
-      schemaVersion: adapter.stateSchemaVersion,
-      state: adapter.serializeState(resumeState),
-    };
-
-    const timestamp = (this.options.now ?? (() => new Date()))().toISOString();
-    const turnId = id("cturn_");
-    const message = CanonicalChatMessageSchema.parse({
-      id: id("msg_"),
-      chatId,
-      seq: record.chat.messageCount + 1,
-      role: "user",
-      state: "committed",
-      turnId,
-      parts: input.parts,
-      createdAt: timestamp,
-    });
-    const turn = CanonicalChatTurnSchema.parse({
-      id: turnId,
-      chatId,
-      clientRequestId: input.clientRequestId,
-      baseMessageSeq: record.chat.messageCount,
-      inputMessageId: message.id,
-      status: "accepted",
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    });
-    const run = CanonicalChatRunSchema.parse({
-      id: id("run_"),
-      chatId,
-      turnId,
-      attempt: 1,
-      driverKind: validated.instance.driverKind,
-      instanceId: validated.instance.id,
-      selection: validated.selection,
-      interactionMode: input.interactionMode,
-      permissionMode: input.permissionMode,
-      ...(resolvedRoot ? {
-        executionRoot: resolvedRoot.ref,
-        executionRootFingerprint: resolvedRoot.fingerprint,
-      } : {}),
-      status: "accepted",
-      historyBoundarySeq: turn.baseMessageSeq,
-      capabilitySnapshot: {
-        revision: validated.instance.catalogRevision,
-        rootChat: validated.instance.supports.rootChat,
-        attachments: validated.instance.supports.attachments,
-        resources: validated.instance.supports.resources,
-        tools: validated.instance.supports.tools,
-        approvals: validated.instance.supports.approvals,
-        userInput: validated.instance.supports.userInput,
-        resume: validated.instance.supports.resume,
-        cancellation: validated.instance.supports.cancellation,
-        steering: validated.instance.supports.steering ?? "none",
-        worktrees: validated.instance.supports.worktrees,
-        interactionModes: validated.instance.supports.interactionModes,
-        permissionModes: validated.instance.supports.permissionModes,
-      },
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    });
-    let admitted;
-    this.reservePendingDispatch(run.id);
-    try {
-      this.assertOpen();
-      admitted = await this.options.repository.admitTurn(owner, {
-        chatId,
-        baseRevision: input.baseRevision,
-        message,
-        turn,
-        run,
-        ...(adapterState ? { adapterState } : {}),
-      });
-    } catch (error: unknown) {
-      this.pendingDispatch.delete(run.id);
-      return mapRepositoryError(error);
-    }
-
-    try {
-      if (!admitted.alreadyAccepted) {
-        if (this.atCapacity(owner)) {
-          await this.options.repository.finishRun(owner, {
-            chatId,
-            runId: admitted.run.id,
-            outcome: "failed",
-            completedAt: timestamp,
-          });
-          throw new CanonicalChatOrchestrationError(
-            safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
-            503,
-          );
-        }
-        this.startDispatch(
-          owner,
-          admitted.message,
-          admitted.run,
-          adapter,
-          resolvedRoot,
-          resumeState,
-        );
-      }
-      return CanonicalChatTurnAdmissionResponseSchema.parse({
-        record: admitted.chat,
-        message: admitted.message,
-        turn: admitted.turn,
-        run: admitted.run,
-        admission: admitted.alreadyAccepted ? "already_accepted" : "accepted",
-      });
-    } finally {
-      this.pendingDispatch.delete(run.id);
-    }
+    return admitCanonicalTurn({
+      ...this.options,
+      assertOpen: () => this.assertOpen(),
+      assertPersonalExecutionAllowed: (scope, id) => this.assertPersonalExecutionAllowed(scope, id),
+      reconcileActiveRuns: (scope) => this.reconcileActiveRuns(scope),
+      reservePendingDispatch: (id) => this.reservePendingDispatch(id),
+      releasePendingDispatch: (id) => { this.pendingDispatch.delete(id); },
+      atCapacity: (scope) => this.atCapacity(scope),
+      startDispatch: (...args) => this.startDispatch(...args),
+    }, principal, owner, chatId, inputValue);
   }
 
   async enqueueQueuedTurn(

--- a/packages/gateway/src/chat/queue-admission.ts
+++ b/packages/gateway/src/chat/queue-admission.ts
@@ -1,3 +1,4 @@
+import type { ChatAgentContext } from "./agent-context.js";
 import { randomUUID } from "node:crypto";
 import {
   CanonicalChatQueueAdmissionResponseSchema,
@@ -61,6 +62,7 @@ export async function enqueueCanonicalQueuedTurn(options: {
   catalog: Pick<ChatProviderCatalogService, "getCatalog">;
   adapters: Pick<CanonicalChatProviderRegistry, "get">;
   executionRoots?: ChatExecutionRootResolver;
+  agentContext?: ChatAgentContext;
   now: () => Date;
 }): Promise<CanonicalChatQueueAdmissionResponse> {
   const input = CanonicalQueueChatTurnRequestSchema.parse(options.input);
@@ -77,12 +79,15 @@ export async function enqueueCanonicalQueuedTurn(options: {
       409,
     );
   }
+  const prepared = await options.agentContext?.prepare(options.owner, options.chatId, input);
+  const effective = { ...input, ...prepared };
   const catalog = await options.catalog.getCatalog(options.principal);
   const validated = validateChatProviderSelection({
     catalog,
-    selection: input.selection,
-    ...(record.providerBinding ? { boundInstanceId: record.providerBinding.instanceId } : {}),
-    requirements: requirementsFor(input),
+    selection: effective.selection,
+    ...(!prepared?.context?.agent && record.providerBinding ? { boundInstanceId: record.providerBinding.instanceId } : {}),
+    requirements: requirementsFor({ ...effective, parts: prepared ? input.parts.filter((part) =>
+      part.type !== "resource_reference" || !["agent", "chat"].includes(part.resource.kind)) : input.parts }),
   });
   if (!validated.ok) {
     throw new CanonicalQueueAdmissionError(
@@ -139,8 +144,9 @@ export async function enqueueCanonicalQueuedTurn(options: {
     parts: input.parts,
     driverKind: validated.instance.driverKind,
     selection: validated.selection,
-    interactionMode: input.interactionMode,
+    interactionMode: effective.interactionMode,
     permissionMode: input.permissionMode,
+    ...(prepared?.context ? { context: prepared.context } : {}),
     ...(resolvedRoot ? {
       executionRoot: resolvedRoot.ref,
       executionRootFingerprint: resolvedRoot.fingerprint,

--- a/packages/gateway/src/chat/queue-repository.ts
+++ b/packages/gateway/src/chat/queue-repository.ts
@@ -1,4 +1,6 @@
+import { queuedRunContext } from "./queued-context.js";
 import {
+  ChatRunContextSchema,
   CanonicalChatIdSchema,
   CanonicalChatMessageSchema,
   CanonicalChatModelSelectionSchema,
@@ -51,6 +53,7 @@ export interface EnqueueQueuedTurnInput {
   executionRoot?: CanonicalChatExecutionRootRef;
   executionRootFingerprint?: string;
   capabilitySnapshot: CanonicalChatRun["capabilitySnapshot"];
+  context?: CanonicalChatRun["context"];
   createdAt: string;
 }
 
@@ -108,6 +111,7 @@ export function toQueuedTurn(row: Selectable<ChatQueuedTurnsTable>): CanonicalCh
     clientRequestId: row.client_request_id,
     position: Number(row.position),
     parts: parseJson(row.parts),
+    ...(row.context_snapshot == null ? {} : { context: parseJson(row.context_snapshot) }),
     selection: parseJson(row.selection),
     interactionMode: row.interaction_mode,
     permissionMode: row.permission_mode,
@@ -156,6 +160,8 @@ export class ChatQueueRepository {
     const capabilitySnapshot = CanonicalChatRunSchema.shape.capabilitySnapshot.parse(
       input.capabilitySnapshot,
     );
+    const context = ChatRunContextSchema.optional().parse(input.context);
+    if (context?.agent && input.driverKind !== "hermes") throw new ChatConflictError(chatId, input.baseRevision);
     const createdAt = new Date(input.createdAt).toISOString();
 
     return this.transact(async (trx) => {
@@ -166,7 +172,7 @@ export class ChatQueueRepository {
         .where("client_request_id", "=", clientRequestId)
         .executeTakeFirst();
       if (duplicate) {
-        if (duplicate.status !== "queued") {
+        if (duplicate.status !== "queued" || toQueuedTurn(duplicate).context?.requestHash !== context?.requestHash) {
           throw new ChatConflictError(chatId, Number(chat.revision));
         }
         const depth = await this.queueDepth(trx, chatId);
@@ -178,6 +184,8 @@ export class ChatQueueRepository {
       if (chat.collaboration !== null) {
         throw new ChatConflictError(chatId, Number(chat.revision));
       }
+      if (!context?.agent && chat.bound_instance_id && (chat.bound_instance_id !== selection.instanceId
+        || chat.bound_driver_kind !== input.driverKind)) throw new ChatConflictError(chatId, Number(chat.revision));
       const activeRun = await trx.selectFrom("chat_runs").select("id")
         .where("chat_id", "=", chatId)
         .where("status", "in", [...ACTIVE_RUNS])
@@ -200,6 +208,7 @@ export class ChatQueueRepository {
         permission_mode: input.permissionMode,
         execution_root: input.executionRoot ? jsonb(input.executionRoot) : null,
         execution_root_fingerprint: input.executionRootFingerprint ?? null,
+        context_snapshot: context ? jsonb(context) : null,
         capability_snapshot: jsonb(capabilitySnapshot),
         claimed_turn_id: null,
         claimed_run_id: null,
@@ -397,6 +406,11 @@ export class ChatQueueRepository {
         .where("status", "=", "pending")
         .executeTakeFirst();
       const existingParts = CanonicalChatQueuedTurnSchema.shape.parts.parse(parseJson(queued.parts));
+      const mentions = (value: typeof parts) => value.filter((part) => part.type === "resource_reference"
+        && (part.resource.kind === "agent" || part.resource.kind === "chat"));
+      if (JSON.stringify(mentions(existingParts)) !== JSON.stringify(mentions(parts))) {
+        throw new ChatConflictError(chatId, Number(chat.revision));
+      }
       if (!pendingSteer && queued.status === "queued"
         && JSON.stringify(existingParts) === JSON.stringify(parts)) {
         return { queuedTurn: toQueuedTurn(queued) };
@@ -490,6 +504,7 @@ export class ChatQueueRepository {
         createdAt: claimedAt,
         updatedAt: claimedAt,
       });
+      const context = await queuedRunContext(trx, queuedTurn, chat.title, Number(chat.message_count));
       const run = CanonicalChatRunSchema.parse({
         id: runId,
         chatId,
@@ -507,6 +522,7 @@ export class ChatQueueRepository {
         status: "accepted",
         historyBoundarySeq: Number(chat.message_count),
         capabilitySnapshot,
+        ...(context ? { context } : {}),
         createdAt: claimedAt,
         updatedAt: claimedAt,
       });
@@ -565,6 +581,7 @@ export class ChatQueueRepository {
         started_at: null,
         completed_at: null,
         history_boundary_seq: run.historyBoundarySeq,
+        context_snapshot: run.context ? jsonb(run.context) : null,
         capability_snapshot: jsonb(run.capabilitySnapshot),
         created_at: claimedAt,
         updated_at: claimedAt,
@@ -582,7 +599,12 @@ export class ChatQueueRepository {
       const updatedChat = await trx.updateTable("chats").set({
         revision,
         message_count: sql<number>`message_count + 1`,
-        current_selection: jsonb(selection),
+        ...(!run.context?.agent ? {
+          current_selection: jsonb(selection),
+          bound_driver_kind: chat.bound_driver_kind ?? run.driverKind,
+          bound_instance_id: chat.bound_instance_id ?? run.instanceId,
+          bound_at_turn_id: chat.bound_at_turn_id ?? turn.id,
+        } : {}),
         attention: "none",
         last_message_preview: message.parts.find((part) => part.type === "text")?.text.slice(0, 280) ?? null,
         updated_at: claimedAt,

--- a/packages/gateway/src/chat/queued-context.ts
+++ b/packages/gateway/src/chat/queued-context.ts
@@ -1,0 +1,33 @@
+import { ChatRunContextSchema, type ChatRunContext, type CanonicalChatQueuedTurn } from "@matrix-os/contracts";
+import type { Kysely, Transaction } from "kysely";
+import type { ChatDatabase } from "./database.js";
+import { parseJson, toMessage } from "./records.js";
+import { chatContextRequestHash, transcript } from "./agent-context.js";
+
+/** Called under the Chat row lock, before its queued input is committed. */
+export async function queuedRunContext(
+  db: Kysely<ChatDatabase> | Transaction<ChatDatabase>, queued: CanonicalChatQueuedTurn,
+  title: string, messageCount: number,
+): Promise<ChatRunContext | undefined> {
+  const previous = await db.selectFrom("chat_runs").select("context_snapshot")
+    .where("chat_id", "=", queued.chatId).orderBy("history_boundary_seq", "desc")
+    .orderBy("attempt", "desc").limit(1).executeTakeFirst();
+  const previousContext = previous?.context_snapshot == null ? undefined
+    : ChatRunContextSchema.parse(parseJson(previous.context_snapshot));
+  if (!queued.context?.history && !previousContext?.agent) return queued.context;
+  const rows = await db.selectFrom("chat_messages").selectAll()
+    .where("chat_id", "=", queued.chatId).orderBy("seq", "desc").limit(41).execute();
+  const history = transcript(rows.slice(0, 40).reverse().map(toMessage), 12_000);
+  return ChatRunContextSchema.parse({
+    version: 1,
+    requestHash: queued.context?.requestHash ?? chatContextRequestHash({
+      ...queued, baseRevision: 0,
+    }),
+    ...queued.context,
+    chats: queued.context?.chats ?? [],
+    history: {
+      chatId: queued.chatId, title, throughSeq: messageCount,
+      ...history, truncated: history.truncated || rows.length > 40,
+    },
+  });
+}

--- a/packages/gateway/src/chat/records.ts
+++ b/packages/gateway/src/chat/records.ts
@@ -249,6 +249,7 @@ export function toRun(row: Selectable<ChatRunsTable>): CanonicalChatRun {
     ...(row.started_at === null ? {} : { startedAt: asIso(row.started_at) }),
     ...(row.completed_at === null ? {} : { completedAt: asIso(row.completed_at) }),
     historyBoundarySeq: Number(row.history_boundary_seq),
+    ...(row.context_snapshot == null ? {} : { context: parseJson(row.context_snapshot) }),
     capabilitySnapshot: parseJson(row.capability_snapshot),
     createdAt: asIso(row.created_at),
     updatedAt: asIso(row.updated_at),

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -1033,7 +1033,7 @@ export class ChatRepository {
         || run.driverKind !== latest.driver_kind || run.instanceId !== latest.instance_id) {
         throw new ChatConflictError(chatId, Number(current.revision));
       }
-      if (current.bound_driver_kind !== run.driverKind || current.bound_instance_id !== run.instanceId) {
+      if (!run.context?.agent && (current.bound_driver_kind !== run.driverKind || current.bound_instance_id !== run.instanceId)) {
         throw new ChatProviderInstanceLockedError(chatId);
       }
       await trx.insertInto("chat_runs").values({
@@ -1054,6 +1054,7 @@ export class ChatRepository {
         started_at: null,
         completed_at: null,
         history_boundary_seq: run.historyBoundarySeq,
+        context_snapshot: run.context ? jsonb(run.context) : null,
         capability_snapshot: jsonb(run.capabilitySnapshot),
         created_at: run.createdAt,
         updated_at: run.updatedAt,
@@ -1073,7 +1074,7 @@ export class ChatRepository {
       const revision = input.baseRevision + 1;
       const updated = await trx.updateTable("chats").set({
         revision,
-        current_selection: jsonb(run.selection),
+        ...(!run.context?.agent ? { current_selection: jsonb(run.selection) } : {}),
         attention: "none",
         updated_at: run.updatedAt,
       }).where("id", "=", chatId).where("revision", "=", input.baseRevision)

--- a/packages/gateway/src/chat/repository.ts
+++ b/packages/gateway/src/chat/repository.ts
@@ -1,3 +1,4 @@
+import { admitChatTurn } from "./turn-admission-repository.js";
 import { randomUUID } from "node:crypto";
 import { captureChatContent } from "./content-projection.js";
 import { captureChatFailureMetadata } from "./failure-telemetry.js";
@@ -880,152 +881,11 @@ export class ChatRepository {
   }
 
   async admitTurn(ownerInput: ChatOwner, input: AdmitTurnInput): Promise<AdmittedTurn> {
-    const owner = validateOwner(ownerInput);
-    CanonicalChatIdSchema.parse(input.chatId);
-    const message = CanonicalChatMessageSchema.parse(input.message);
-    const turn = CanonicalChatTurnSchema.parse(input.turn);
-    const run = CanonicalChatRunSchema.parse(input.run);
-    if (message.chatId !== input.chatId || turn.chatId !== input.chatId || run.chatId !== input.chatId
-      || turn.inputMessageId !== message.id || message.turnId !== turn.id || message.runId !== undefined
-      || message.role !== "user" || message.state !== "committed" || run.turnId !== turn.id) {
-      throw new ChatConflictError(input.chatId, input.baseRevision);
-    }
-    if (turn.status !== "accepted" || run.status !== "accepted") throw new ChatConflictError(input.chatId, input.baseRevision);
-    const stateBytes = input.adapterState ? encoded.encode(JSON.stringify(input.adapterState.state)).byteLength : 0;
-    if (input.adapterState && (!Number.isInteger(input.adapterState.schemaVersion)
-      || input.adapterState.schemaVersion < 1 || stateBytes > 64 * 1024)) {
-      throw new ChatConflictError(input.chatId, input.baseRevision);
-    }
-
-    return this.transact(async (trx) => {
-      const current = await selectOwnedChat(trx, owner, input.chatId, true);
-      if (!current) throw new ChatNotFoundError(input.chatId);
-      const duplicate = await trx.selectFrom("chat_turns").selectAll()
-        .where("chat_id", "=", input.chatId)
-        .where("client_request_id", "=", turn.clientRequestId)
-        .executeTakeFirst();
-      if (duplicate) return hydrateAdmission(trx, owner, toTurn(duplicate));
-      if (current.lifecycle !== "active") {
-        throw new ChatConflictError(input.chatId, Number(current.revision));
-      }
-      if (current.collaboration !== null) {
-        throw new ChatConflictError(input.chatId, Number(current.revision));
-      }
-      if (Number(current.revision) !== input.baseRevision) {
-        throw new ChatConflictError(input.chatId, Number(current.revision));
-      }
-      if (await activeRunQuery(trx, input.chatId)) throw new ChatBusyError(input.chatId);
-      if (current.bound_instance_id && (current.bound_instance_id !== run.instanceId
-        || current.bound_driver_kind !== run.driverKind)) {
-        throw new ChatProviderInstanceLockedError(input.chatId);
-      }
-      const latest = await trx.selectFrom("chat_messages")
-        .select(({ fn }) => fn.max("seq").as("seq"))
-        .where("chat_id", "=", input.chatId).executeTakeFirst();
-      const lastSeq = Number(latest?.seq ?? 0);
-      if (message.seq !== lastSeq + 1 || turn.baseMessageSeq !== lastSeq) {
-        throw new ChatConflictError(input.chatId, Number(current.revision));
-      }
-
-      await trx.insertInto("chat_messages").values({
-        id: message.id,
-        chat_id: input.chatId,
-        seq: message.seq,
-        role: message.role,
-        state: message.state,
-        turn_id: message.turnId ?? null,
-        run_id: message.runId ?? null,
-        parts: jsonb(message.parts),
-        byte_count: encoded.encode(JSON.stringify(message)).byteLength,
-        search_text: messageSearchText(message),
-        ...messageAttribution(message),
-        created_at: message.createdAt,
-      }).execute();
-      for (const part of message.parts) {
-        if (part.type !== "attachment_reference") continue;
-        await trx.insertInto("chat_attachments").values({
-          id: part.attachmentId,
-          chat_id: input.chatId,
-          message_id: message.id,
-          kind: part.kind,
-          label: part.label,
-          mime_type: part.mimeType ?? null,
-          size_bytes: part.sizeBytes ?? null,
-          owner_reference: part.ownerReference ?? null,
-        }).execute();
-      }
-      await trx.insertInto("chat_turns").values({
-        id: turn.id,
-        chat_id: input.chatId,
-        client_request_id: turn.clientRequestId,
-        base_message_seq: turn.baseMessageSeq,
-        input_message_id: turn.inputMessageId,
-        status: turn.status,
-        created_at: turn.createdAt,
-        updated_at: turn.updatedAt,
-      }).execute();
-      await trx.insertInto("chat_runs").values({
-        id: run.id,
-        chat_id: input.chatId,
-        turn_id: run.turnId,
-        client_request_id: turn.clientRequestId,
-        attempt: run.attempt,
-        driver_kind: run.driverKind,
-        instance_id: run.instanceId,
-        selection: jsonb(run.selection),
-        interaction_mode: run.interactionMode,
-        permission_mode: run.permissionMode,
-        execution_root: run.executionRoot ? jsonb(run.executionRoot) : null,
-        execution_root_fingerprint: run.executionRootFingerprint ?? null,
-        status: run.status,
-        outcome: run.outcome ?? null,
-        started_at: run.startedAt ?? null,
-        completed_at: run.completedAt ?? null,
-        history_boundary_seq: run.historyBoundarySeq,
-        capability_snapshot: jsonb(run.capabilitySnapshot),
-        created_at: run.createdAt,
-        updated_at: run.updatedAt,
-      }).execute();
-      if (input.adapterState) {
-        await trx.insertInto("chat_run_adapter_state").values({
-          run_id: run.id,
-          driver_kind: run.driverKind,
-          instance_id: run.instanceId,
-          schema_version: input.adapterState.schemaVersion,
-          state: jsonb(input.adapterState.state),
-          byte_count: stateBytes,
-        }).execute();
-      }
-
-      const revision = input.baseRevision + 1;
-      const updated = await trx.updateTable("chats").set({
-        revision,
-        message_count: sql<number>`message_count + 1`,
-        last_message_preview: preview(message),
-        current_selection: jsonb(run.selection),
-        bound_driver_kind: current.bound_driver_kind ?? run.driverKind,
-        bound_instance_id: current.bound_instance_id ?? run.instanceId,
-        bound_at_turn_id: current.bound_at_turn_id ?? turn.id,
-        updated_at: sql`now()`,
-      }).where("id", "=", input.chatId).where("revision", "=", input.baseRevision)
-        .returningAll().executeTakeFirst();
-      if (!updated) throw new ChatConflictError(input.chatId, Number(current.revision));
-      await this.appendOutbox(trx, owner, input.chatId, revision, "turn.accepted", { runId: run.id, turnId: turn.id });
-      return {
-        chat: await toPrincipalRecord(trx, owner, updated),
-        message,
-        turn,
-        run,
-        alreadyAccepted: false,
-      };
-    }).catch((error: unknown) => {
-      if (error instanceof ChatNotFoundError || error instanceof ChatConflictError
-        || error instanceof ChatBusyError || error instanceof ChatProviderInstanceLockedError) throw error;
-      const constraint = postgresUniqueConstraint(error);
-      if (constraint === "idx_chat_runs_one_active") throw new ChatBusyError(input.chatId);
-      if (constraint !== null) throw new ChatConflictError(input.chatId, input.baseRevision);
-      throw error;
-    });
+    return admitChatTurn({
+      transact: (operation) => this.transact(operation),
+      appendOutbox: (...args) => this.appendOutbox(...args),
+      selectOwnedChat, hydrateAdmission, toPrincipalRecord, activeRunQuery, postgresUniqueConstraint, preview,
+    }, ownerInput, input);
   }
 
   async enqueueQueuedTurn(

--- a/packages/gateway/src/chat/run-lifecycle-repository.ts
+++ b/packages/gateway/src/chat/run-lifecycle-repository.ts
@@ -176,6 +176,7 @@ export class ChatRunLifecycleRepository {
       .where("chat_runs.chat_id", "=", input.chatId)
       .where("chat_runs.driver_kind", "=", input.driverKind)
       .where("chat_runs.instance_id", "=", input.instanceId)
+      .where(sql<boolean>`chat_runs.context_snapshot -> 'agent' IS NULL`)
       // A new user turn continues the native conversation even when its last
       // run failed. Explicit retry callers retain the completed-only boundary.
       .where("chat_runs.status", "in", input.includeInterrupted

--- a/packages/gateway/src/chat/runtime.ts
+++ b/packages/gateway/src/chat/runtime.ts
@@ -1,0 +1,22 @@
+import { CanonicalChatOrchestrator } from "./orchestrator.js";
+import { ChatAgentStore } from "./agent-store.js";
+import { ChatAgentContext } from "./agent-context.js";
+import type { ChatRepository } from "./repository.js";
+
+export function chatAgentsEnabled(): boolean {
+  return process.env.MATRIX_CHAT_AGENTS_ENABLED === "1";
+}
+
+/** Agent configuration shares the canonical database lock lifecycle; it owns no pool. */
+export async function createCanonicalChatRuntime(options: Omit<ConstructorParameters<typeof CanonicalChatOrchestrator>[0], "agentContext"> & {
+  repository: ChatRepository;
+  homePath: string;
+  enabled?: () => boolean;
+}) {
+  const agents = new ChatAgentStore({ homePath: options.homePath, db: options.repository.kysely });
+  await agents.bootstrap();
+  const context = new ChatAgentContext({
+    repository: options.repository, agents, enabled: options.enabled ?? chatAgentsEnabled,
+  });
+  return { agents, context, orchestrator: new CanonicalChatOrchestrator({ ...options, agentContext: context }) };
+}

--- a/packages/gateway/src/chat/steering-repository.ts
+++ b/packages/gateway/src/chat/steering-repository.ts
@@ -221,6 +221,10 @@ export class ChatSteeringRepository {
       const parts = CanonicalChatQueuedTurnSchema.shape.parts.parse(
         typeof queued.parts === "string" ? JSON.parse(queued.parts) : queued.parts,
       );
+      if (parts.some((part) => part.type === "resource_reference"
+        && (part.resource.kind === "agent" || part.resource.kind === "chat"))) {
+        throw new ChatConflictError(chatId, Number(chat.revision));
+      }
       await trx.insertInto("chat_run_steers").values({
         id: input.steerId,
         chat_id: chatId,

--- a/packages/gateway/src/chat/turn-admission-repository.ts
+++ b/packages/gateway/src/chat/turn-admission-repository.ts
@@ -48,7 +48,13 @@ export async function admitChatTurn(deps: TurnAdmissionDependencies, ownerInput:
         .where("chat_id", "=", input.chatId)
         .where("client_request_id", "=", turn.clientRequestId)
         .executeTakeFirst();
-      if (duplicate) return deps.hydrateAdmission(trx, owner, toTurn(duplicate));
+      if (duplicate) {
+        const accepted = await deps.hydrateAdmission(trx, owner, toTurn(duplicate));
+        if (accepted.run.context?.requestHash !== run.context?.requestHash) {
+          throw new ChatConflictError(input.chatId, Number(current.revision));
+        }
+        return accepted;
+      }
       if (current.lifecycle !== "active") {
         throw new ChatConflictError(input.chatId, Number(current.revision));
       }
@@ -59,7 +65,7 @@ export async function admitChatTurn(deps: TurnAdmissionDependencies, ownerInput:
         throw new ChatConflictError(input.chatId, Number(current.revision));
       }
       if (await deps.activeRunQuery(trx, input.chatId)) throw new ChatBusyError(input.chatId);
-      if (current.bound_instance_id && (current.bound_instance_id !== run.instanceId
+      if (!run.context?.agent && current.bound_instance_id && (current.bound_instance_id !== run.instanceId
         || current.bound_driver_kind !== run.driverKind)) {
         throw new ChatProviderInstanceLockedError(input.chatId);
       }
@@ -126,6 +132,7 @@ export async function admitChatTurn(deps: TurnAdmissionDependencies, ownerInput:
         started_at: run.startedAt ?? null,
         completed_at: run.completedAt ?? null,
         history_boundary_seq: run.historyBoundarySeq,
+        context_snapshot: run.context ? jsonb(run.context) : null,
         capability_snapshot: jsonb(run.capabilitySnapshot),
         created_at: run.createdAt,
         updated_at: run.updatedAt,
@@ -146,10 +153,12 @@ export async function admitChatTurn(deps: TurnAdmissionDependencies, ownerInput:
         revision,
         message_count: sql<number>`message_count + 1`,
         last_message_preview: deps.preview(message),
-        current_selection: jsonb(run.selection),
-        bound_driver_kind: current.bound_driver_kind ?? run.driverKind,
-        bound_instance_id: current.bound_instance_id ?? run.instanceId,
-        bound_at_turn_id: current.bound_at_turn_id ?? turn.id,
+        ...(!run.context?.agent ? {
+          current_selection: jsonb(run.selection),
+          bound_driver_kind: current.bound_driver_kind ?? run.driverKind,
+          bound_instance_id: current.bound_instance_id ?? run.instanceId,
+          bound_at_turn_id: current.bound_at_turn_id ?? turn.id,
+        } : {}),
         updated_at: sql`now()`,
       }).where("id", "=", input.chatId).where("revision", "=", input.baseRevision)
         .returningAll().executeTakeFirst();

--- a/packages/gateway/src/chat/turn-admission-repository.ts
+++ b/packages/gateway/src/chat/turn-admission-repository.ts
@@ -1,0 +1,173 @@
+import {
+  CanonicalChatIdSchema, CanonicalChatMessageSchema, CanonicalChatRunSchema,
+  CanonicalChatTurnSchema, CanonicalOwnerScopeSchema,
+  type CanonicalChatMessage, type CanonicalChatTurn,
+} from "@matrix-os/contracts";
+import { sql, type Kysely, type Selectable, type Transaction } from "kysely";
+import type { ChatDatabase, ChatRunsTable, ChatsTable } from "./database.js";
+import { ChatBusyError, ChatConflictError, ChatNotFoundError, ChatProviderInstanceLockedError } from "./errors.js";
+import { jsonb, messageAttribution, messageSearchText, toTurn, type ChatOwner, type ChatRecord, type ChatOutboxEventType } from "./records.js";
+import type { AdmitTurnInput, AdmittedTurn } from "./repository.js";
+
+type Executor = Kysely<ChatDatabase> | Transaction<ChatDatabase>;
+const encoded = new TextEncoder();
+export interface TurnAdmissionDependencies {
+  transact<T>(operation: (trx: Executor) => Promise<T>): Promise<T>;
+  appendOutbox(executor: Executor, owner: ChatOwner, chatId: string, revision: number, eventType: ChatOutboxEventType, payload?: Record<string, unknown>): Promise<void>;
+  selectOwnedChat(executor: Executor, owner: ChatOwner, chatId: string, lock?: boolean): Promise<Selectable<ChatsTable> | undefined>;
+  hydrateAdmission(executor: Executor, owner: ChatOwner, turn: CanonicalChatTurn): Promise<AdmittedTurn>;
+  toPrincipalRecord(executor: Executor, owner: ChatOwner, row: Selectable<ChatsTable>): Promise<ChatRecord>;
+  activeRunQuery(executor: Executor, chatId: string): Promise<Selectable<ChatRunsTable> | undefined>;
+  postgresUniqueConstraint(error: unknown): string | null;
+  preview(message: CanonicalChatMessage): string | null;
+}
+
+/** The Chat row lock, related writes and outbox share one transaction. */
+export async function admitChatTurn(deps: TurnAdmissionDependencies, ownerInput: ChatOwner, input: AdmitTurnInput): Promise<AdmittedTurn> {
+    const owner = CanonicalOwnerScopeSchema.parse(ownerInput);
+    CanonicalChatIdSchema.parse(input.chatId);
+    const message = CanonicalChatMessageSchema.parse(input.message);
+    const turn = CanonicalChatTurnSchema.parse(input.turn);
+    const run = CanonicalChatRunSchema.parse(input.run);
+    if (message.chatId !== input.chatId || turn.chatId !== input.chatId || run.chatId !== input.chatId
+      || turn.inputMessageId !== message.id || message.turnId !== turn.id || message.runId !== undefined
+      || message.role !== "user" || message.state !== "committed" || run.turnId !== turn.id) {
+      throw new ChatConflictError(input.chatId, input.baseRevision);
+    }
+    if (turn.status !== "accepted" || run.status !== "accepted") throw new ChatConflictError(input.chatId, input.baseRevision);
+    const stateBytes = input.adapterState ? encoded.encode(JSON.stringify(input.adapterState.state)).byteLength : 0;
+    if (input.adapterState && (!Number.isInteger(input.adapterState.schemaVersion)
+      || input.adapterState.schemaVersion < 1 || stateBytes > 64 * 1024)) {
+      throw new ChatConflictError(input.chatId, input.baseRevision);
+    }
+
+    return deps.transact(async (trx) => {
+      const current = await deps.selectOwnedChat(trx, owner, input.chatId, true);
+      if (!current) throw new ChatNotFoundError(input.chatId);
+      const duplicate = await trx.selectFrom("chat_turns").selectAll()
+        .where("chat_id", "=", input.chatId)
+        .where("client_request_id", "=", turn.clientRequestId)
+        .executeTakeFirst();
+      if (duplicate) return deps.hydrateAdmission(trx, owner, toTurn(duplicate));
+      if (current.lifecycle !== "active") {
+        throw new ChatConflictError(input.chatId, Number(current.revision));
+      }
+      if (current.collaboration !== null) {
+        throw new ChatConflictError(input.chatId, Number(current.revision));
+      }
+      if (Number(current.revision) !== input.baseRevision) {
+        throw new ChatConflictError(input.chatId, Number(current.revision));
+      }
+      if (await deps.activeRunQuery(trx, input.chatId)) throw new ChatBusyError(input.chatId);
+      if (current.bound_instance_id && (current.bound_instance_id !== run.instanceId
+        || current.bound_driver_kind !== run.driverKind)) {
+        throw new ChatProviderInstanceLockedError(input.chatId);
+      }
+      const latest = await trx.selectFrom("chat_messages")
+        .select(({ fn }) => fn.max("seq").as("seq"))
+        .where("chat_id", "=", input.chatId).executeTakeFirst();
+      const lastSeq = Number(latest?.seq ?? 0);
+      if (message.seq !== lastSeq + 1 || turn.baseMessageSeq !== lastSeq) {
+        throw new ChatConflictError(input.chatId, Number(current.revision));
+      }
+
+      await trx.insertInto("chat_messages").values({
+        id: message.id,
+        chat_id: input.chatId,
+        seq: message.seq,
+        role: message.role,
+        state: message.state,
+        turn_id: message.turnId ?? null,
+        run_id: message.runId ?? null,
+        parts: jsonb(message.parts),
+        byte_count: encoded.encode(JSON.stringify(message)).byteLength,
+        search_text: messageSearchText(message),
+        ...messageAttribution(message),
+        created_at: message.createdAt,
+      }).execute();
+      for (const part of message.parts) {
+        if (part.type !== "attachment_reference") continue;
+        await trx.insertInto("chat_attachments").values({
+          id: part.attachmentId,
+          chat_id: input.chatId,
+          message_id: message.id,
+          kind: part.kind,
+          label: part.label,
+          mime_type: part.mimeType ?? null,
+          size_bytes: part.sizeBytes ?? null,
+          owner_reference: part.ownerReference ?? null,
+        }).execute();
+      }
+      await trx.insertInto("chat_turns").values({
+        id: turn.id,
+        chat_id: input.chatId,
+        client_request_id: turn.clientRequestId,
+        base_message_seq: turn.baseMessageSeq,
+        input_message_id: turn.inputMessageId,
+        status: turn.status,
+        created_at: turn.createdAt,
+        updated_at: turn.updatedAt,
+      }).execute();
+      await trx.insertInto("chat_runs").values({
+        id: run.id,
+        chat_id: input.chatId,
+        turn_id: run.turnId,
+        client_request_id: turn.clientRequestId,
+        attempt: run.attempt,
+        driver_kind: run.driverKind,
+        instance_id: run.instanceId,
+        selection: jsonb(run.selection),
+        interaction_mode: run.interactionMode,
+        permission_mode: run.permissionMode,
+        execution_root: run.executionRoot ? jsonb(run.executionRoot) : null,
+        execution_root_fingerprint: run.executionRootFingerprint ?? null,
+        status: run.status,
+        outcome: run.outcome ?? null,
+        started_at: run.startedAt ?? null,
+        completed_at: run.completedAt ?? null,
+        history_boundary_seq: run.historyBoundarySeq,
+        capability_snapshot: jsonb(run.capabilitySnapshot),
+        created_at: run.createdAt,
+        updated_at: run.updatedAt,
+      }).execute();
+      if (input.adapterState) {
+        await trx.insertInto("chat_run_adapter_state").values({
+          run_id: run.id,
+          driver_kind: run.driverKind,
+          instance_id: run.instanceId,
+          schema_version: input.adapterState.schemaVersion,
+          state: jsonb(input.adapterState.state),
+          byte_count: stateBytes,
+        }).execute();
+      }
+
+      const revision = input.baseRevision + 1;
+      const updated = await trx.updateTable("chats").set({
+        revision,
+        message_count: sql<number>`message_count + 1`,
+        last_message_preview: deps.preview(message),
+        current_selection: jsonb(run.selection),
+        bound_driver_kind: current.bound_driver_kind ?? run.driverKind,
+        bound_instance_id: current.bound_instance_id ?? run.instanceId,
+        bound_at_turn_id: current.bound_at_turn_id ?? turn.id,
+        updated_at: sql`now()`,
+      }).where("id", "=", input.chatId).where("revision", "=", input.baseRevision)
+        .returningAll().executeTakeFirst();
+      if (!updated) throw new ChatConflictError(input.chatId, Number(current.revision));
+      await deps.appendOutbox(trx, owner, input.chatId, revision, "turn.accepted", { runId: run.id, turnId: turn.id });
+      return {
+        chat: await deps.toPrincipalRecord(trx, owner, updated),
+        message,
+        turn,
+        run,
+        alreadyAccepted: false,
+      };
+    }).catch((error: unknown) => {
+      if (error instanceof ChatNotFoundError || error instanceof ChatConflictError
+        || error instanceof ChatBusyError || error instanceof ChatProviderInstanceLockedError) throw error;
+      const constraint = deps.postgresUniqueConstraint(error);
+      if (constraint === "idx_chat_runs_one_active") throw new ChatBusyError(input.chatId);
+      if (constraint !== null) throw new ChatConflictError(input.chatId, input.baseRevision);
+      throw error;
+    });
+  }

--- a/packages/gateway/src/chat/turn-admission.ts
+++ b/packages/gateway/src/chat/turn-admission.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from "node:crypto";
+import {
+  CanonicalCreateChatTurnRequestSchema, CanonicalChatMessageSchema, CanonicalChatTurnSchema,
+  CanonicalChatRunSchema, CanonicalChatTurnAdmissionResponseSchema,
+  type CanonicalCreateChatTurnRequest, type CanonicalChatMessage, type CanonicalChatRun,
+  type CanonicalChatTurnAdmissionResponse,
+} from "@matrix-os/contracts";
+import type { RequestPrincipal } from "../request-principal.js";
+import type { ChatOwner } from "./records.js";
+import type { ChatRepository } from "./repository.js";
+import { ChatNotFoundError } from "./errors.js";
+import { validateChatProviderSelection, type ChatProviderCatalogService } from "./provider-catalog.js";
+import type { CanonicalChatProviderRegistry, CanonicalChatProviderAdapter } from "./provider-adapter.js";
+import type { ChatExecutionRootResolver, ResolvedChatExecutionRoot } from "./execution-root.js";
+import { CanonicalChatOrchestrationError, mapRepositoryError, safeError, requirementsFor } from "./orchestration-input.js";
+import { loadChatResumeState } from "./resume-checkpoint.js";
+
+export interface TurnAdmissionOptions {
+  repository: Pick<ChatRepository, "get" | "getLatestAdapterStateForChat" | "admitTurn" | "finishRun">;
+  catalog: Pick<ChatProviderCatalogService, "getCatalog">;
+  adapters: CanonicalChatProviderRegistry;
+  executionRoots?: ChatExecutionRootResolver;
+  now?: () => Date;
+  assertOpen(): void;
+  assertPersonalExecutionAllowed(owner: ChatOwner, chatId: string): Promise<void>;
+  reconcileActiveRuns(owner: ChatOwner): Promise<unknown>;
+  reservePendingDispatch(runId: string): void;
+  releasePendingDispatch(runId: string): void;
+  atCapacity(owner: ChatOwner): boolean;
+  startDispatch(owner: ChatOwner, message: CanonicalChatMessage, run: CanonicalChatRun,
+    adapter: CanonicalChatProviderAdapter, root?: ResolvedChatExecutionRoot, resumeState?: unknown): void;
+}
+
+const id = (prefix: string) => `${prefix}${randomUUID().replaceAll("-", "")}`;
+
+export async function admitCanonicalTurn(
+  deps: TurnAdmissionOptions, principal: RequestPrincipal, owner: ChatOwner,
+  chatId: string, inputValue: CanonicalCreateChatTurnRequest,
+): Promise<CanonicalChatTurnAdmissionResponse> {
+    deps.assertOpen();
+    await deps.assertPersonalExecutionAllowed(owner, chatId);
+    await deps.reconcileActiveRuns(owner);
+    const input = CanonicalCreateChatTurnRequestSchema.parse(inputValue);
+    const record = await deps.repository.get(owner, chatId);
+    if (!record) return mapRepositoryError(new ChatNotFoundError(chatId));
+    const catalog = await deps.catalog.getCatalog(principal);
+    const validated = validateChatProviderSelection({
+      catalog,
+      selection: input.selection,
+      ...(record.providerBinding ? { boundInstanceId: record.providerBinding.instanceId } : {}),
+      requirements: requirementsFor(input),
+    });
+    if (!validated.ok) {
+      throw new CanonicalChatOrchestrationError(validated.error, validated.error.code === "provider_instance_locked" ? 409 : 400);
+    }
+    const adapter = deps.adapters.get(validated.instance.driverKind);
+    if (!adapter) {
+      throw new CanonicalChatOrchestrationError(
+        safeError("provider_unavailable", "The selected Provider cannot run yet.", false, ["select_provider"]),
+        503,
+      );
+    }
+    const rootRef = input.executionRoot
+      ?? (record.projectId ? { kind: "project" as const, projectId: record.projectId } : undefined);
+    if (input.executionRoot && record.projectId && input.executionRoot.projectId !== record.projectId) {
+      throw new CanonicalChatOrchestrationError(
+        safeError("project_unavailable", "The selected workspace does not belong to this Chat's Project."),
+        400,
+      );
+    }
+    if (validated.instance.workspaceRequirement === "project_required" && rootRef === undefined) {
+      throw new CanonicalChatOrchestrationError(
+        safeError("project_required", "This Provider requires a Project.", false, ["return_to_project"]),
+        400,
+      );
+    }
+    let resolvedRoot: Awaited<ReturnType<ChatExecutionRootResolver["resolve"]>> | undefined;
+    if (rootRef !== undefined) {
+      if (!deps.executionRoots) {
+        throw new CanonicalChatOrchestrationError(
+          safeError("project_unavailable", "The Project workspace is unavailable.", true, ["retry"]),
+          503,
+        );
+      }
+      try {
+        resolvedRoot = await deps.executionRoots.resolve(owner, rootRef);
+      } catch (error: unknown) {
+        console.warn("[chat/orchestrator] Execution root resolution failed:", error instanceof Error ? error.name : "UnknownError");
+        throw new CanonicalChatOrchestrationError(
+          safeError("project_unavailable", "The Project workspace is unavailable.", true, ["retry"]),
+          503,
+        );
+      }
+    }
+    const resumeState = await loadChatResumeState({
+      repository: deps.repository, owner, chatId, adapter,
+      instanceId: validated.instance.id,
+      executionRootFingerprint: resolvedRoot?.fingerprint ?? null,
+      mode: "follow_up",
+    });
+    const adapterState = resumeState === undefined ? undefined : {
+      schemaVersion: adapter.stateSchemaVersion,
+      state: adapter.serializeState(resumeState),
+    };
+
+    const timestamp = (deps.now ?? (() => new Date()))().toISOString();
+    const turnId = id("cturn_");
+    const message = CanonicalChatMessageSchema.parse({
+      id: id("msg_"),
+      chatId,
+      seq: record.chat.messageCount + 1,
+      role: "user",
+      state: "committed",
+      turnId,
+      parts: input.parts,
+      createdAt: timestamp,
+    });
+    const turn = CanonicalChatTurnSchema.parse({
+      id: turnId,
+      chatId,
+      clientRequestId: input.clientRequestId,
+      baseMessageSeq: record.chat.messageCount,
+      inputMessageId: message.id,
+      status: "accepted",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    const run = CanonicalChatRunSchema.parse({
+      id: id("run_"),
+      chatId,
+      turnId,
+      attempt: 1,
+      driverKind: validated.instance.driverKind,
+      instanceId: validated.instance.id,
+      selection: validated.selection,
+      interactionMode: input.interactionMode,
+      permissionMode: input.permissionMode,
+      ...(resolvedRoot ? {
+        executionRoot: resolvedRoot.ref,
+        executionRootFingerprint: resolvedRoot.fingerprint,
+      } : {}),
+      status: "accepted",
+      historyBoundarySeq: turn.baseMessageSeq,
+      capabilitySnapshot: {
+        revision: validated.instance.catalogRevision,
+        rootChat: validated.instance.supports.rootChat,
+        attachments: validated.instance.supports.attachments,
+        resources: validated.instance.supports.resources,
+        tools: validated.instance.supports.tools,
+        approvals: validated.instance.supports.approvals,
+        userInput: validated.instance.supports.userInput,
+        resume: validated.instance.supports.resume,
+        cancellation: validated.instance.supports.cancellation,
+        steering: validated.instance.supports.steering ?? "none",
+        worktrees: validated.instance.supports.worktrees,
+        interactionModes: validated.instance.supports.interactionModes,
+        permissionModes: validated.instance.supports.permissionModes,
+      },
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    let admitted;
+    deps.reservePendingDispatch(run.id);
+    try {
+      deps.assertOpen();
+      admitted = await deps.repository.admitTurn(owner, {
+        chatId,
+        baseRevision: input.baseRevision,
+        message,
+        turn,
+        run,
+        ...(adapterState ? { adapterState } : {}),
+      });
+    } catch (error: unknown) {
+      deps.releasePendingDispatch(run.id);
+      return mapRepositoryError(error);
+    }
+
+    try {
+      if (!admitted.alreadyAccepted) {
+        if (deps.atCapacity(owner)) {
+          await deps.repository.finishRun(owner, {
+            chatId,
+            runId: admitted.run.id,
+            outcome: "failed",
+            completedAt: timestamp,
+          });
+          throw new CanonicalChatOrchestrationError(
+            safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
+            503,
+          );
+        }
+        deps.startDispatch(
+          owner,
+          admitted.message,
+          admitted.run,
+          adapter,
+          resolvedRoot,
+          resumeState,
+        );
+      }
+      return CanonicalChatTurnAdmissionResponseSchema.parse({
+        record: admitted.chat,
+        message: admitted.message,
+        turn: admitted.turn,
+        run: admitted.run,
+        admission: admitted.alreadyAccepted ? "already_accepted" : "accepted",
+      });
+    } finally {
+      deps.releasePendingDispatch(run.id);
+    }
+}

--- a/packages/gateway/src/chat/turn-admission.ts
+++ b/packages/gateway/src/chat/turn-admission.ts
@@ -1,3 +1,4 @@
+import { type ChatAgentContext } from "./agent-context.js";
 import { randomUUID } from "node:crypto";
 import {
   CanonicalCreateChatTurnRequestSchema, CanonicalChatMessageSchema, CanonicalChatTurnSchema,
@@ -20,6 +21,7 @@ export interface TurnAdmissionOptions {
   catalog: Pick<ChatProviderCatalogService, "getCatalog">;
   adapters: CanonicalChatProviderRegistry;
   executionRoots?: ChatExecutionRootResolver;
+  agentContext?: ChatAgentContext;
   now?: () => Date;
   assertOpen(): void;
   assertPersonalExecutionAllowed(owner: ChatOwner, chatId: string): Promise<void>;
@@ -43,12 +45,17 @@ export async function admitCanonicalTurn(
     const input = CanonicalCreateChatTurnRequestSchema.parse(inputValue);
     const record = await deps.repository.get(owner, chatId);
     if (!record) return mapRepositoryError(new ChatNotFoundError(chatId));
+    let prepared;
+    try { prepared = await deps.agentContext?.prepare(owner, chatId, input); }
+    catch (error: unknown) { return mapRepositoryError(error); }
+    const effective = { ...input, ...prepared };
     const catalog = await deps.catalog.getCatalog(principal);
     const validated = validateChatProviderSelection({
       catalog,
-      selection: input.selection,
-      ...(record.providerBinding ? { boundInstanceId: record.providerBinding.instanceId } : {}),
-      requirements: requirementsFor(input),
+      selection: effective.selection,
+      ...(!prepared?.context?.agent && record.providerBinding ? { boundInstanceId: record.providerBinding.instanceId } : {}),
+      requirements: requirementsFor({ ...effective, parts: prepared ? input.parts.filter((part) =>
+        part.type !== "resource_reference" || !["agent", "chat"].includes(part.resource.kind)) : input.parts }),
     });
     if (!validated.ok) {
       throw new CanonicalChatOrchestrationError(validated.error, validated.error.code === "provider_instance_locked" ? 409 : 400);
@@ -92,7 +99,7 @@ export async function admitCanonicalTurn(
         );
       }
     }
-    const resumeState = await loadChatResumeState({
+    const resumeState = prepared?.context?.history ? undefined : await loadChatResumeState({
       repository: deps.repository, owner, chatId, adapter,
       instanceId: validated.instance.id,
       executionRootFingerprint: resolvedRoot?.fingerprint ?? null,
@@ -133,7 +140,8 @@ export async function admitCanonicalTurn(
       driverKind: validated.instance.driverKind,
       instanceId: validated.instance.id,
       selection: validated.selection,
-      interactionMode: input.interactionMode,
+      interactionMode: effective.interactionMode,
+      ...(prepared?.context ? { context: prepared.context } : {}),
       permissionMode: input.permissionMode,
       ...(resolvedRoot ? {
         executionRoot: resolvedRoot.ref,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -170,6 +170,8 @@ import {
   type CanonicalChatProviderAdapter,
 } from "./chat/provider-adapter.js";
 import { CanonicalChatOrchestrator } from "./chat/orchestrator.js";
+import { createCanonicalChatRuntime, chatAgentsEnabled } from "./chat/runtime.js";
+import { createChatAgentRoutes } from "./chat/agent-routes.js";
 import {
   createCanonicalChatService,
   createUnavailableCanonicalChatService,
@@ -1001,6 +1003,7 @@ export async function createGateway(config: GatewayConfig) {
   let chatIdleReaper: ReturnType<typeof createChatIdleReaper> | null = null;
   let canonicalChatEventStream: ReturnType<typeof createGatewayChatEventStream> | null = null;
   let canonicalChatOrchestrator: CanonicalChatOrchestrator | null = null;
+  let canonicalChatRuntime: Awaited<ReturnType<typeof createCanonicalChatRuntime>> | null = null;
   let canonicalChatExecutionRoots: ChatExecutionRootResolver | null = null;
   let canonicalChatCollaborationGuard: ReturnType<typeof createDiscussionOnlyChatExecutionGuard> | null = null;
   let gatewayCollaboration: GatewayCollaborationRuntime | null = null;
@@ -4356,7 +4359,8 @@ export async function createGateway(config: GatewayConfig) {
         }));
       }
     }
-    canonicalChatOrchestrator = new CanonicalChatOrchestrator({
+    canonicalChatRuntime = await createCanonicalChatRuntime({
+      homePath,
       repository: chatRepository,
       catalog: canonicalChatProviderCatalog,
       adapters: new CanonicalChatProviderRegistry(canonicalAdapters),
@@ -4364,6 +4368,7 @@ export async function createGateway(config: GatewayConfig) {
       ...(canonicalChatCollaborationGuard ? { collaborationGuard: canonicalChatCollaborationGuard } : {}),
       onAiGeneration: recordAiGeneration,
     });
+    canonicalChatOrchestrator = canonicalChatRuntime.orchestrator;
     for (const ownerId of new Set(codingAgentOwnerIds)) {
       await canonicalChatOrchestrator.reconcileActiveRuns({ type: "personal", ownerId });
     }
@@ -4407,6 +4412,14 @@ export async function createGateway(config: GatewayConfig) {
           ...(canonicalChatCollaborationGuard ? { collaborationGuard: canonicalChatCollaborationGuard } : {}),
         })
       : createUnavailableCanonicalChatService(),
+    getPrincipal: (c) => requireRequestPrincipal(c),
+  }));
+  app.route("/", createChatAgentRoutes({
+    ...(canonicalChatRuntime && chatRepository ? {
+      agents: canonicalChatRuntime.agents, context: canonicalChatRuntime.context, repository: chatRepository,
+    } : {}),
+    enabled: chatAgentsEnabled,
+    catalog: canonicalChatProviderCatalog,
     getPrincipal: (c) => requireRequestPrincipal(c),
   }));
   app.route("/", createChatProviderRoutes({
@@ -4755,6 +4768,8 @@ export async function createGateway(config: GatewayConfig) {
       gatewayCollaboration = null;
       await canonicalChatOrchestrator?.close();
       canonicalChatOrchestrator = null;
+      await canonicalChatRuntime?.agents.close();
+      canonicalChatRuntime = null;
       await codingAgentWorkspaceRuntime?.close();
       codingAgentWorkspaceRuntime = null;
       await agentRuntimeServices.controller.close();

--- a/specs/121-chat-agent-templates/implementation.md
+++ b/specs/121-chat-agent-templates/implementation.md
@@ -20,7 +20,7 @@ References carry typed stable IDs, never trusted labels or client-supplied trans
 
 An Agent invocation runs Hermes in a fresh session, using the current request and bounded current-Chat history. It does not borrow another Bot's provider checkpoint or alter the parent Chat binding. Ordinary follow-ups after an invocation receive intervening canonical conversation context rather than resuming an unaware checkpoint. Results and activities use the existing canonical pipeline and carry Agent attribution; completion is not Task completion.
 
-Queued work keeps references and resolved snapshots durable. Dispatch rechecks feature availability, Agent archival and source access. Retry reuses the accepted snapshot and rechecks authority. New references cannot be steered into an active Run; the UI uses Queue next for them. Normal steering remains unchanged.
+Queued work keeps references and resolved snapshots durable. Current-Chat history is refreshed under the claim transaction so the just-completed reply is included; referenced Chats and Agent definitions stay pinned. Queue text edits retain typed references; changing references requires cancelling and re-queuing. Dispatch rechecks feature availability, Agent archival and source access. Retry reuses the accepted snapshot and rechecks authority. New references cannot be steered into an active Run; the UI uses Queue next for them. Normal steering remains unchanged.
 
 ## Security and failure boundaries
 
@@ -29,7 +29,8 @@ Queued work keeps references and resolved snapshots durable. Dispatch rechecks f
 | GET `/api/chat-agents` | Existing request principal; personal owner only | Server flag; bounded Agent list; coarse readiness |
 | POST `/api/chat-agents` | Same owner | Body limit; bounded strict schema; idempotency key |
 | PATCH `/api/chat-agents/:agentId` | Same owner | Body limit; safe ID; revision compare; explicit fields |
-| GET `/api/chat-agents/mentions` | Same owner | Bounded query; current Chat exclusion; max results |
+| GET `/api/chat-mentions` | Same owner | Bounded query; current Chat exclusion; max results |
+| GET `/api/chat-context/:chatId` | Same owner; private active Chat only | Safe ID; 40 messages / 8 KB text; no tools or attachments |
 | Existing create/queue/retry turn APIs | Existing owner / collaboration guard | Flag, one Agent / three Chats, no forged snapshot, current catalog readiness |
 | Dispatch / resumed queue | Server-owned snapshot | Recheck archival, reference access, flag and execution root |
 
@@ -61,3 +62,14 @@ Use Graphite for stack operations. Each layer must remain deploy-safe with the s
 - [ ] Required typecheck, patterns, tests, React audit and production builds recorded.
 - [ ] Exact-head real Hermes / streaming evidence and Human Review environment prepared.
 - [ ] Public docs prepared with an accurate feature-switch boundary.
+
+### Backend checkpoint (2026-09-10)
+
+The first two layers implement file definitions, authenticated CRUD/search/preview,
+server feature gating, runtime startup/shutdown wiring, canonical persistence,
+one-request Hermes routing, default-binding preservation, retry/queue snapshots,
+and steering guards. Gateway TypeScript passes; 80 focused Agent/contract/Hermes
+adapter tests pass, and the 93 existing repository/orchestrator regressions passed
+after the admission changes. Pattern scan: zero violations, five existing warning
+categories. These are automated tests with protocol doubles, not live Hermes or
+Human Review evidence. UI and exact-head Preview verification remain pending.

--- a/tests/gateway/chat-agent-execution.test.ts
+++ b/tests/gateway/chat-agent-execution.test.ts
@@ -1,0 +1,263 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { KyselyPGlite } from "kysely-pglite";
+import { z } from "zod/v4";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type CanonicalCreateChatTurnRequest } from "@matrix-os/contracts";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository.js";
+import { ChatAgentStore } from "../../packages/gateway/src/chat/agent-store.js";
+import { createCanonicalChatRuntime } from "../../packages/gateway/src/chat/runtime.js";
+import { CanonicalChatOrchestrator } from "../../packages/gateway/src/chat/orchestrator.js";
+import { CanonicalChatProviderRegistry, type CanonicalChatProviderAdapter, type CanonicalProviderRunInput } from "../../packages/gateway/src/chat/provider-adapter.js";
+import { createCanonicalProviderCatalogFixture } from "../contracts/fixtures/canonical-chat";
+
+const owner = { type: "personal" as const, ownerId: "owner_bot_runs" };
+const principal = { userId: owner.ownerId, source: "jwt" as const };
+const selection = { instanceId: "codex_fixture", model: "gpt-5.6-sol" };
+const agentSelection = { instanceId: "hermes_default", model: "openai:gpt-5.6-sol" };
+const mention = (kind: "agent" | "chat", id: string) => ({
+  type: "resource_reference" as const, resource: { kind, id, label: "Selected reference" },
+});
+
+describe("Hermes Agent invocation through canonical Chat", () => {
+  let home: string;
+  let repository: ChatRepository;
+  let agents: ChatAgentStore;
+  let orchestrator: CanonicalChatOrchestrator;
+  let calls: Array<{ driver: string; resumed: boolean; input: CanonicalProviderRunInput }>;
+  let enabled: boolean;
+  let release: (() => void) | undefined;
+  let hold: Promise<void> | undefined;
+  let failHermes: boolean;
+  let agentId: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "matrix-agent-execution-"));
+    repository = new ChatRepository((await KyselyPGlite.create()).dialect);
+    await repository.bootstrap();
+    enabled = true; failHermes = false; calls = []; release = undefined; hold = undefined;
+    const catalog = createCanonicalProviderCatalogFixture();
+    const hermes = { ...catalog.instances[0]!, id: "hermes_default", driverKind: "hermes" as const,
+      models: [{ ...catalog.instances[0]!.models[0]!, id: agentSelection.model }],
+      supports: { ...catalog.instances[0]!.supports, resources: [], permissionModes: ["full_access"] },
+    };
+    catalog.drivers.push({ ...catalog.drivers[0]!, kind: "hermes", displayName: "Hermes" });
+    catalog.instances.push(hermes);
+    const adapter = (driver: "codex" | "hermes"): CanonicalChatProviderAdapter => {
+      const execute = async function* (input: CanonicalProviderRunInput, resumed: boolean) {
+        calls.push({ driver, resumed, input });
+        const pending = hold; hold = undefined;
+        if (pending) await pending;
+        yield { type: "state.updated" as const, state: { sessionId: `${driver}_${input.runId}` } };
+        yield { type: "assistant.delta" as const, delta: driver === "hermes" ? "Agent result: Thursday review." : "Original Chat response." };
+        yield { type: "run.completed" as const, outcome: driver === "hermes" && failHermes ? "failed" as const : "completed" as const };
+      };
+      return {
+        driverKind: driver, stateSchemaVersion: 1,
+        parseState: (value) => z.object({ sessionId: z.string() }).parse(value), serializeState: (value) => value,
+        start: (input) => execute(input, false), resume: (input) => execute(input, true),
+      };
+    };
+    const runtime = await createCanonicalChatRuntime({
+      homePath: home, enabled: () => enabled,
+      repository, catalog: { getCatalog: async () => catalog },
+      adapters: new CanonicalChatProviderRegistry([adapter("codex"), adapter("hermes")]),
+    });
+    agents = runtime.agents;
+    orchestrator = runtime.orchestrator;
+    await repository.create(owner, { id: "chat_parent", clientRequestId: "req_parent", title: "Original Chat", currentSelection: selection });
+    agentId = (await agents.create(owner, {
+      clientRequestId: "req_agent", name: "Partner helper", description: "Prepare partner decisions",
+      instructions: "Separate decisions from open questions.", selection: agentSelection,
+    })).id;
+  });
+  afterEach(async () => {
+    release?.();
+    await orchestrator.close();
+    await agents.close();
+    await repository.kysely.destroy();
+    await rm(home, { recursive: true, force: true });
+  });
+
+  async function input(requestId: string, parts: CanonicalCreateChatTurnRequest["parts"]) {
+    return {
+      clientRequestId: requestId, baseRevision: (await repository.get(owner, "chat_parent"))!.chat.revision,
+      selection, interactionMode: "default", permissionMode: "full_access", parts,
+    };
+  }
+  async function complete() {
+    await vi.waitFor(() => expect(orchestrator.activeCount).toBe(0), { timeout: 5_000 });
+  }
+  async function send(requestId: string, parts: CanonicalCreateChatTurnRequest["parts"]) {
+    const result = await orchestrator.admitTurn(principal, owner, "chat_parent", await input(requestId, parts));
+    await complete();
+    return result;
+  }
+
+  it("runs Hermes in place, preserves the default binding and transcript, and returns to the original harness", async () => {
+    await send("req_normal", [{ type: "text", text: "Keep this original conversation" }]);
+    const before = await repository.getDetailPage(owner, "chat_parent", { limit: 100 });
+    const admitted = await send("req_bot_turn", [{ type: "text", text: "Prepare the partner review" }, mention("agent", agentId)]);
+    expect(admitted.run.driverKind).toBe("hermes");
+    expect(admitted.run.context?.agent).toMatchObject({ id: agentId, name: "Partner helper", revision: 1 });
+    expect(admitted.record.providerBinding).toEqual(before!.record.providerBinding);
+    expect(admitted.record.chat.currentSelection).toEqual(selection);
+    const after = await repository.getDetailPage(owner, "chat_parent", { limit: 100 });
+    expect(after!.messages.slice(0, before!.messages.length)).toEqual(before!.messages);
+    expect(after!.runs.at(-1)?.context?.agent?.id).toBe(agentId);
+    const invoked = calls.find((call) => call.driver === "hermes")!;
+    expect(invoked.resumed).toBe(false);
+    expect(invoked.input.prompt).toContain("Separate decisions from open questions.");
+    expect(invoked.input.prompt).toContain("Keep this original conversation");
+    await send("req_after_bot", [{ type: "text", text: "Continue with the result" }]);
+    expect(calls.at(-1)?.driver).toBe("codex");
+    expect(calls.at(-1)?.input.prompt).toContain("Agent result: Thursday review.");
+    expect((await repository.get(owner, "chat_parent"))!.chat.currentSelection).toEqual(selection);
+  });
+
+  it("does not bind a new Chat to an invoked Bot before its first ordinary turn", async () => {
+    const invoked = await send("req_bot_first", [{ type: "text", text: "First task" }, mention("agent", agentId)]);
+    expect(invoked.record.providerBinding).toBeUndefined();
+    expect(invoked.record.chat.currentSelection).toEqual(selection);
+    const normal = await send("req_regular_second", [{ type: "text", text: "Continue normally" }]);
+    expect(normal.record.providerBinding?.driverKind).toBe("codex");
+  });
+
+  it("commits context before dispatch and keeps its contents stable on retry", async () => {
+    failHermes = true;
+    const admitted = await send("req_bot_failed", [{ type: "text", text: "Draft a review" }, mention("agent", agentId)]);
+    await agents.update(owner, agentId, { baseRevision: 1, instructions: "A different role for future work" });
+    failHermes = false;
+    const retry = await orchestrator.retryTurn(principal, owner, "chat_parent", admitted.turn.id, {
+      clientRequestId: "req_retry_bot", baseRevision: (await repository.get(owner, "chat_parent"))!.chat.revision,
+    });
+    await complete();
+    expect(retry.run.context).toEqual(admitted.run.context);
+    expect(calls.at(-1)?.input.prompt).toContain("Separate decisions from open questions.");
+    expect(calls.at(-1)?.input.prompt).not.toContain("A different role for future work");
+    expect(calls.at(-1)?.resumed).toBe(false);
+  });
+
+  it("deduplicates an accepted Agent turn and rejects a changed request with its idempotency key", async () => {
+    const request = await input("req_idempotent_bot", [{ type: "text", text: "One job" }, mention("agent", agentId)]);
+    const first = await orchestrator.admitTurn(principal, owner, "chat_parent", request);
+    await complete();
+    const duplicate = await orchestrator.admitTurn(principal, owner, "chat_parent", request);
+    expect(duplicate.run.id).toBe(first.run.id);
+    expect(calls).toHaveLength(1);
+    await expect(orchestrator.admitTurn(principal, owner, "chat_parent", {
+      ...request, parts: [{ type: "text", text: "Changed job" }, mention("agent", agentId)],
+    })).rejects.toMatchObject({ safeError: { code: "chat_conflict" } });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("keeps Agent identity and snapshot across durable queue admission and dispatch", async () => {
+    hold = new Promise<void>((resolve) => { release = resolve; });
+    await orchestrator.admitTurn(principal, owner, "chat_parent", await input("req_running", [{ type: "text", text: "Original work" }]));
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    const queued = await orchestrator.enqueueQueuedTurn(principal, owner, "chat_parent", await input("req_queued_bot", [
+      { type: "text", text: "Then prepare review" }, mention("agent", agentId),
+    ]));
+    expect(queued.queuedTurn.context?.agent?.id).toBe(agentId);
+    await agents.update(owner, agentId, { baseRevision: 1, instructions: "Later version" });
+    release!();
+    await vi.waitFor(() => expect(calls).toHaveLength(2), { timeout: 5_000 });
+    await complete();
+    expect(calls[1]!.driver).toBe("hermes");
+    expect(calls[1]!.input.prompt).toContain("Separate decisions from open questions.");
+    expect(calls[1]!.input.prompt).toContain("Original Chat response.");
+    expect((await repository.get(owner, "chat_parent"))!.chat.currentSelection).toEqual(selection);
+  });
+
+
+  it("snapshots another owned Chat and keeps its text stable after the source changes", async () => {
+    await repository.create(owner, { id: "chat_source", clientRequestId: "req_source", title: "Source", currentSelection: selection });
+    await orchestrator.admitTurn(principal, owner, "chat_source", {
+      clientRequestId: "req_source_text", baseRevision: (await repository.get(owner, "chat_source"))!.chat.revision, selection, interactionMode: "default", permissionMode: "full_access",
+      parts: [{ type: "text", text: "Budget is 400 units" }],
+    });
+    await complete();
+    failHermes = true;
+    const first = await send("req_reference", [{ type: "text", text: "Prepare review" }, mention("agent", agentId), mention("chat", "chat_source")]);
+    expect(calls.at(-1)?.input.prompt).toContain("Budget is 400 units");
+    expect(first.run.context?.chats[0]?.title).toBe("Source");
+    await orchestrator.admitTurn(principal, owner, "chat_source", {
+      clientRequestId: "req_source_changed", baseRevision: (await repository.get(owner, "chat_source"))!.chat.revision,
+      selection, interactionMode: "default", permissionMode: "full_access", parts: [{ type: "text", text: "Budget changed to 900 units" }],
+    });
+    await complete();
+    failHermes = false;
+    const retried = await orchestrator.retryTurn(principal, owner, "chat_parent", first.turn.id, {
+      clientRequestId: "req_reference_retry", baseRevision: (await repository.get(owner, "chat_parent"))!.chat.revision,
+    });
+    await complete();
+    expect(retried.run.context).toEqual(first.run.context);
+    expect(calls.at(-1)?.input.prompt).not.toContain("Budget changed to 900 units");
+  });
+
+  it("rechecks the switch before dispatching an already queued Agent", async () => {
+    hold = new Promise<void>((resolve) => { release = resolve; });
+    await orchestrator.admitTurn(principal, owner, "chat_parent", await input("req_hold", [{ type: "text", text: "Current work" }]));
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    await orchestrator.enqueueQueuedTurn(principal, owner, "chat_parent", await input("req_later", [mention("agent", agentId)]));
+    enabled = false;
+    release!();
+    await vi.waitFor(async () => expect((await repository.getDetailPage(owner, "chat_parent", { limit: 100 }))!.runs).toHaveLength(2));
+    await complete();
+    expect(calls).toHaveLength(1);
+    expect((await repository.getDetailPage(owner, "chat_parent", { limit: 100 }))!.runs.at(-1)?.status).toBe("failed");
+  });
+
+  it("resumes an ordinary queued turn after an Agent with the newly completed Agent result", async () => {
+    hold = new Promise<void>((resolve) => { release = resolve; });
+    await orchestrator.admitTurn(principal, owner, "chat_parent", await input("req_hold_bot", [mention("agent", agentId)]));
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    await orchestrator.enqueueQueuedTurn(principal, owner, "chat_parent", await input("req_later_normal", [{ type: "text", text: "Continue normally" }]));
+    release!();
+    await vi.waitFor(() => expect(calls).toHaveLength(2));
+    await complete();
+    expect(calls[1]?.driver).toBe("codex");
+    expect(calls[1]?.input.prompt).toContain("Agent result: Thursday review.");
+    expect((await repository.get(owner, "chat_parent"))!.providerBinding?.driverKind).toBe("codex");
+  });
+
+
+  it("preserves references during queue text edits and cannot steer an Agent into the active Run", async () => {
+    hold = new Promise<void>((resolve) => { release = resolve; });
+    const active = await orchestrator.admitTurn(principal, owner, "chat_parent", await input("req_edit_running", [{ type: "text", text: "Working" }]));
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    const queued = (await orchestrator.enqueueQueuedTurn(principal, owner, "chat_parent", await input("req_edit_queued", [
+      { type: "text", text: "Draft one" }, mention("agent", agentId),
+    ]))).queuedTurn;
+    const change = { chatId: "chat_parent", queuedTurnId: queued.id, clientRequestId: "req_edit_queue", updatedAt: new Date().toISOString(),
+      baseRevision: (await repository.get(owner, "chat_parent"))!.chat.revision };
+    await expect(repository.updateQueuedTurn(owner, { ...change, parts: [{ type: "text", text: "Lose reference" }] }))
+      .rejects.toMatchObject({ name: "ChatConflictError" });
+    const edited = await repository.updateQueuedTurn(owner, { ...change, parts: [{ type: "text", text: "Draft two" }, mention("agent", agentId)] });
+    expect(edited.queuedTurn.context).toEqual(queued.context);
+    // Simulate a harness supporting same-run steering; mention semantics must still forbid this path.
+    await repository.kysely.updateTable("chat_runs").set({ capability_snapshot: JSON.stringify({ ...active.run.capabilitySnapshot, steering: "same_run" }) })
+      .where("id", "=", active.run.id).execute();
+    await expect(repository.beginQueuedTurnSteer(owner, {
+      ...change, clientRequestId: "req_forbidden_steer", runId: active.run.id, expectedTurnId: active.turn.id,
+      steerId: "steer_agent_queue", messageId: "msg_agent_steer", createdAt: change.updatedAt,
+    })).rejects.toMatchObject({ name: "ChatConflictError" });
+    release!();
+    await vi.waitFor(() => expect(calls).toHaveLength(2));
+    await complete();
+    expect(calls[1]?.input.prompt).toContain("Draft two");
+    expect(calls[1]?.driver).toBe("hermes");
+  });
+
+  it("rejects disabled and archived Agent invocations before changing Chat state", async () => {
+    enabled = false;
+    await expect(send("req_disabled", [mention("agent", agentId)])).rejects.toMatchObject({ safeError: { code: "capability_mismatch" } });
+    expect((await repository.get(owner, "chat_parent"))!.chat.messageCount).toBe(0);
+    expect(calls).toEqual([]);
+    enabled = true;
+    await agents.update(owner, agentId, { baseRevision: 1, archived: true });
+    await expect(send("req_archived", [mention("agent", agentId)])).rejects.toMatchObject({ safeError: { code: "resource_unavailable" } });
+    expect(calls).toEqual([]);
+  });
+});

--- a/tests/gateway/chat-agent-routes.test.ts
+++ b/tests/gateway/chat-agent-routes.test.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { KyselyPGlite } from "kysely-pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository.js";
+import { ChatAgentStore } from "../../packages/gateway/src/chat/agent-store.js";
+import { ChatAgentContext } from "../../packages/gateway/src/chat/agent-context.js";
+import { createChatAgentRoutes } from "../../packages/gateway/src/chat/agent-routes.js";
+import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
+import { createCanonicalProviderCatalogFixture } from "../contracts/fixtures/canonical-chat";
+
+const owner = { type: "personal" as const, ownerId: "owner_agent_routes" };
+const fields = {
+  clientRequestId: "req_route_agent", name: "Meeting helper", description: "Prepare a meeting",
+  instructions: "Summarize decisions and questions.", selection: { instanceId: "hermes_default", model: "openai:gpt-5.6-sol" },
+};
+
+describe("Chat Agent HTTP boundary", () => {
+  let repository: ChatRepository;
+  let agents: ChatAgentStore;
+  let home: string;
+  let enabled: boolean;
+  let user: string | null;
+  let app: ReturnType<typeof createChatAgentRoutes>;
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "matrix-agent-routes-"));
+    repository = new ChatRepository((await KyselyPGlite.create()).dialect);
+    await repository.bootstrap();
+    agents = new ChatAgentStore({ homePath: home, db: repository.kysely });
+    await agents.bootstrap();
+    enabled = true; user = owner.ownerId;
+    const catalog = createCanonicalProviderCatalogFixture();
+    catalog.drivers.push({ ...catalog.drivers[0]!, kind: "hermes", displayName: "Hermes" });
+    catalog.instances.push({ ...catalog.instances[0]!, id: "hermes_default", driverKind: "hermes",
+      models: [{ ...catalog.instances[0]!.models[0]!, id: fields.selection.model }],
+      supports: { ...catalog.instances[0]!.supports, permissionModes: ["full_access"] },
+    });
+    app = createChatAgentRoutes({ agents, repository,
+      context: new ChatAgentContext({ repository, agents, enabled: () => enabled }),
+      catalog: { getCatalog: async () => catalog }, enabled: () => enabled,
+      getPrincipal: () => { if (!user) throw new MissingRequestPrincipalError(); return { userId: user, source: "jwt" }; },
+    });
+  });
+  afterEach(async () => {
+    await agents.close(); await repository.kysely.destroy(); await rm(home, { recursive: true, force: true });
+  });
+  const json = (method: string, body: unknown) => ({ method, headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+
+  it("defaults to a quiet disabled feature and rejects mutations when switched off", async () => {
+    enabled = false;
+    expect(await (await app.request("/api/chat-agents")).json()).toEqual({ enabled: false, agents: [] });
+    expect(await (await app.request("/api/chat-mentions")).json()).toEqual({ enabled: false, resources: [] });
+    expect((await app.request("/api/chat-agents", json("POST", fields))).status).toBe(409);
+    expect(await agents.list(owner)).toEqual([]);
+  });
+
+  it("creates and edits a durable Hermes role using the authenticated owner only", async () => {
+    const created = await app.request("/api/chat-agents", json("POST", fields));
+    expect(created.status).toBe(201);
+    const agent = await created.json();
+    const duplicate = await (await app.request("/api/chat-agents", json("POST", fields))).json();
+    expect(duplicate.id).toBe(agent.id);
+    const updated = await app.request(`/api/chat-agents/${agent.id}`, json("PATCH", { baseRevision: agent.revision, name: "Partner helper" }));
+    expect(updated.status).toBe(200);
+    expect((await updated.json()).name).toBe("Partner helper");
+    expect((await app.request(`/api/chat-agents/${agent.id}`, json("PATCH", { baseRevision: 1, archived: true }))).status).toBe(409);
+    user = "someone_else";
+    expect(await (await app.request("/api/chat-agents")).json()).toEqual({ enabled: true, agents: [] });
+    expect((await app.request(`/api/chat-agents/${agent.id}`, json("PATCH", { baseRevision: 2, archived: true }))).status).toBe(404);
+  });
+
+  it("rejects missing identity, forged owner/context, oversized bodies, and non-Hermes selections", async () => {
+    user = null;
+    expect((await app.request("/api/chat-agents")).status).toBe(401);
+    user = owner.ownerId;
+    expect((await app.request("/api/chat-agents", json("POST", { ...fields, owner: { ownerId: "someone_else" } }))).status).toBe(400);
+    expect((await app.request("/api/chat-agents", json("POST", { ...fields, selection: { instanceId: "codex_fixture", model: "gpt-5.6-sol" } }))).status).toBe(400);
+    expect((await app.request("/api/chat-agents", json("POST", { ...fields, instructions: "x".repeat(70_000) }))).status).toBe(413);
+    expect((await app.request("/api/chat-mentions?query=" + "x".repeat(201))).status).toBe(400);
+    expect(await agents.list(owner)).toEqual([]);
+  });
+
+  it("searches only owned active Chat titles and Agent names, excluding the current Chat", async () => {
+    await agents.create(owner, fields);
+    await repository.create(owner, { id: "chat_current", clientRequestId: "req_current", title: "Meeting current" });
+    await repository.create(owner, { id: "chat_source", clientRequestId: "req_source", title: "Meeting notes" });
+    await repository.create({ ...owner, ownerId: "another_owner" }, { id: "chat_private", clientRequestId: "req_private", title: "Meeting private" });
+    const response = await app.request("/api/chat-mentions?query=meeting&chatId=chat_current");
+    expect(response.status).toBe(200);
+    const result = await response.json();
+    expect(result.resources.map((resource: { kind: string }) => resource.kind)).toEqual(["agent", "chat"]);
+    expect(result.resources.map((resource: { label: string }) => resource.label)).toEqual(["Meeting helper", "Meeting notes"]);
+    expect((await app.request("/api/chat-context/chat_private")).status).toBe(404);
+    expect((await app.request("/api/chat-context/chat_source")).status).toBe(200);
+  });
+
+  it("returns a coarse service error if configured without database-backed services", async () => {
+    const unavailable = createChatAgentRoutes({ enabled: () => true,
+      getPrincipal: () => ({ userId: owner.ownerId, source: "jwt" }),
+      catalog: { getCatalog: async () => { throw new Error("private db path"); } },
+    });
+    const response = await unavailable.request("/api/chat-agents");
+    expect(response.status).toBe(503);
+    expect(await response.text()).not.toContain("private db path");
+  });
+});


### PR DESCRIPTION
## Summary

Execute a saved Agent through Hermes for one canonical Chat request while retaining the Chat's default harness and existing transcript. Persist the Agent definition and bounded referenced-Chat snapshots with the Run, and include intervening Chat history on ordinary follow-ups. Queue/retry paths retain accepted context and recheck current authority; mentioned requests cannot steer an active Run.

Wire authenticated Agent CRUD/search/preview and startup/shutdown behind `MATRIX_CHAT_AGENTS_ENABLED=1` (default off). This layer depends on the Agent contracts/store layer; UI follows in the next layer.

## Tests

- 80 focused backend/contract/Hermes-adapter tests passed.
- 93 original repository/orchestrator regressions passed after admission extraction; expanded integration coverage exercised dispatch, queue, retry and bindings.
- Fixed a raw-TypeScript package import caught by the full suite; all 34 native-import/runtime tests then passed.
- TypeScript and pattern checks passed. Protocol doubles do not constitute live native Hermes validation.

## Invariants

- Source of truth: owner Markdown definitions; admitted immutable context and run/queue state in canonical Postgres.
- Lock/transaction scope: related turn/run/message/context/outbox writes are transactional; current-Chat history refreshes under queue claim. Native execution begins after commit.
- Acceptable orphan states: unused saved definitions are valid. Accepted work persists for recovery; failed native dispatch remains a visible failed Run. Shared DB resources close only through their owner.
- Auth source of truth: existing request principal and private personal-owner checks; dispatch rechecks Agent archival, source access and the server switch. Hermes/model readiness comes from the existing V3-backed catalog.
- Deferred scope: UI follows separately; Native Mobile controls, scheduling, publishing and shared-source Chats are excluded. Real Hermes and Human Review are required before enablement/merge.

## Stack

Depends on #1605. The shared Chat UI and complete Preview VPS are in #1607.
