### PR TITLE
fix(chat): preserve streamed output and safe startup recovery

### DIFF
--- a/.trellis/spec/gateway/backend/chat-startup-and-model-discovery.md
+++ b/.trellis/spec/gateway/backend/chat-startup-and-model-discovery.md
@@ -1,0 +1,124 @@
+# Canonical Chat startup, usage errors, and model discovery
+
+## 1. Scope / Trigger
+
+Use this contract when changing provider startup recovery, native error projection,
+or model inventory. These cross the native process, canonical run, HTTP SSE, and
+shared transcript boundaries. No new public event enum or database schema is needed.
+
+## 2. Signatures
+
+```ts
+retryUnadmittedStartup<T>({ signal, attempt, onRetry }): Promise<T>
+// onRetry({ retry: number, maxRetries: 5, label: string }): Promise<void>
+// attempt may throw RetryableProviderStartupTimeout only with both proofs below.
+
+// Dispatch-local lifecycle notifications, not client input:
+CanonicalProviderRunInput.onCleanupUnconfirmed?: () => void
+CanonicalProviderRunInput.onCleanupConfirmed?: () => void
+
+readClaudeModelInventory({ executable, cwd, env, signal }): Promise<unknown>
+createClaudeModelCatalogSource({ resolveContext, timeoutMs, cacheTtlMs })
+classifyClaudeUsageFailure(value: unknown)
+```
+
+## 3. Contracts
+
+- Retry proof requires **no prompt/session admission** plus **actual prior process
+  exit**. Codex `initialize` and Hermes `gateway.ready` are the verified boundaries.
+  Generic workspace readiness may happen after side effects and is not eligible.
+- One initial attempt plus five retries; backoff is 250/500/1000/2000/4000 ms.
+  A single logical run owns capacity throughout. Publish existing phase activity
+  `Reconnecting… n/5` before waiting; do not invent tool work or reasoning text.
+- Abort cancels scheduled retries. A cleanup deadline or sent kill signal is not
+  exit evidence. Keep the exact child supervised and retain execution capacity
+  until actual exit. Without explicit cancellation, pending cleanup stays
+  nonterminal. Existing `cancelRun` may persist/display aborted immediately on
+  user Stop; this is not cleanup proof and must not release execution ownership
+  or authorize another dispatch. Emit one terminal outcome overall. Hermes
+  confirmation clears only its dispatch-local unconfirmed flag. The persistent
+  Codex runner owns its corresponding child wait.
+- The Hermes async iterator owns its execution promise and cancellation signal.
+  Consumer `return()` or consumer failure must abort and await that execution's
+  cleanup before the iterator settles. An adapter-internal eventual-exit wait alone
+  is insufficient when the orchestrator stops consuming after an early Stop.
+- Persisted `activeRun` is not the only admission source of truth after Stop.
+  Direct turns and explicit Retry must also check retained same-Chat execution
+  ownership and recheck before dispatch, as queued work already does. A total or
+  per-owner count below its cap does not prove this Chat is free. Preserve reads
+  and idempotent replay of already-admitted requests without allowing new execution.
+- Claude usage classification accepts bounded native error envelopes only. Weekly
+  exhaustion maps to safe `run_failed`, `retryable: false`; explicit temporary
+  throttling remains distinct. Never retry quota as startup timeout. Only validated
+  explicit UTC reset dates in the next seven days are displayed.
+- Inventory uses SDK `supportedModels()` without a user message, tools, hooks,
+  MCP, persistence, or account-info reads; use the actual Chat executable and
+  credential launch environment. Combined stdout/stderr budget is 1 MiB before
+  SDK buffering; default deadline 5s; at most 64 validated/projected models.
+- Cache/pending maps are owner-isolated and capped at 32. Context includes a
+  private launch-environment digest and readiness/auth status. Explicit credentials:
+  60s cache and at most 5min same-context last-good retention. Profile credentials:
+  5s cache; explicit refresh discards it, including late pending writes. Do not
+  inspect credential stores to establish a cache generation.
+- Preserve default/opus/sonnet fallback. Offer native `value` or explicitly reported
+  valid `resolvedModel`; never strip qualifiers, rewrite saved IDs, or imply account
+  entitlement from metadata. Fable 5.1 is not a guaranteed fallback entry.
+- No new auth route or credential choice: existing authenticated catalog and Chat
+  routes retain principal/owner validation. No raw provider errors, paths, or
+  credential digests are exposed in canonical events.
+
+## 4. Validation & Error Matrix
+
+| Condition | Required outcome |
+| --- | --- |
+| Proven pre-admission timeout and actual exit | Retry within the one budget |
+| Sixth attempt times out | One safe final failure |
+| Stop during handshake/backoff | No further attempt; one abort, execution retained until cleanup |
+| Cleanup not confirmed | Retain ownership; no retry; no failure terminal absent explicit cancellation |
+| Auth/install/model/permanent failure | Safe failure, no startup retry |
+| Native weekly usage error | Usage-specific error, no Reconnecting loop |
+| Successful prose mentions limits | Not authoritative quota evidence |
+| Inventory invalid/unavailable/oversized | Bounded close and safe bounded fallback |
+| Model metadata visible | Selection may be offered; generation remains unproven |
+
+## 5. Good / Base / Bad Cases
+
+- Good: first child times out before prompt; close is observed; second initializes;
+  exactly one child receives `turn/start`, and SSE/rendering showed Reconnecting.
+- Base: immediate readiness admits normally with unchanged session identity.
+- Bad: a silent model or generic workspace timeout triggers duplicate tool execution.
+  Also bad: claiming lost streaming text when native output never contained it.
+
+## 6. Tests Required
+
+- Hold terminal result/exit pending while real HTTP SSE and shared transcript
+  assertions observe intermediate text/activity; frozen snapshot must not rescue it.
+- Exercise success after first/fifth retry, exhaustion, permanent failure, Stop in
+  handshake/backoff, late readiness, unknown cleanup, eventual real exit, and shutdown.
+  Cover Stop both before and after cleanup-pending activity is emitted. An already
+  aborted consumer must not detach the producer's eventual-exit ownership.
+  Assert one terminal outcome and no duplicate native prompt/session calls.
+- Feed real adapter quota envelopes through SSE/rendering, including assistant-only,
+  assistant-plus-result, invalid/absent reset time, and ordinary prose controls.
+- Exercise catalog refresh, owner/context changes, pending invalidation, fallback,
+  selection persistence, exact launch/resume handoff, and real SDK protocol fixtures
+  rejecting unintended user input and oversized output.
+- Verify built gateway contains/imports both new `.mjs` startup helpers. Source-only
+  TypeScript checks do not verify the packaging edge. Keep deterministic tests,
+  build evidence, account availability, and exact-head Human Review separate.
+
+## 7. Wrong vs Correct
+
+```ts
+// Wrong: timeout or a sent signal does not establish safe replay.
+if (String(error).includes("timeout")) return retry();
+
+// Correct: the adapter constructs the private proof only before prompt admission
+// and after confirmed actual exit; the shared owner limits retries and emits phase.
+if (error instanceof ReadyTimeout && stoppedBeforeAdmission) {
+  throw new RetryableProviderStartupTimeout();
+}
+```
+
+The owner must retain cleanup supervision even when the bounded stop attempt expires.
+Never convert an unconfirmed child into a retryable error or a released busy slot.

--- a/.trellis/spec/gateway/backend/index.md
+++ b/.trellis/spec/gateway/backend/index.md
@@ -1,8 +1,0 @@
-# Gateway backend code-specs
-
-| Guide | Scope |
-| --- | --- |
-| [Chat startup and model discovery](./chat-startup-and-model-discovery.md) | Retry admission, cleanup, usage errors, metadata discovery, and cross-layer tests |
-
-These task-local executable contracts complement the repository constitution and
-the canonical provider-neutral Chat architecture in `specs/113-provider-neutral-chat-architecture/`.

--- a/.trellis/spec/gateway/backend/index.md
+++ b/.trellis/spec/gateway/backend/index.md
@@ -1,0 +1,8 @@
+# Gateway backend code-specs
+
+| Guide | Scope |
+| --- | --- |
+| [Chat startup and model discovery](./chat-startup-and-model-discovery.md) | Retry admission, cleanup, usage errors, metadata discovery, and cross-layer tests |
+
+These task-local executable contracts complement the repository constitution and
+the canonical provider-neutral Chat architecture in `specs/113-provider-neutral-chat-architecture/`.

--- a/packages/gateway/src/chat/claude-provider-adapter.ts
+++ b/packages/gateway/src/chat/claude-provider-adapter.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { classifyClaudeUsageFailure } from "./claude-usage-failure.js";
 import { buildAgentLaunch } from "../agent-launcher.js";
 import {
   buildKernelCredentialLaunch,
@@ -274,6 +275,7 @@ export function createClaudeChatProviderAdapter(options: {
     let resultText = "";
     let sawResult = false;
     let resultFailed = false;
+    let usageFailure: ReturnType<typeof classifyClaudeUsageFailure>;
     let resultSubtype: "success" | "error" | "other" | undefined;
     let emittedState = resumeState;
     let steerPrompt: string | undefined;
@@ -339,6 +341,9 @@ export function createClaudeChatProviderAdapter(options: {
     const parseLine = (raw: string) => {
       if (!raw.trim()) return;
       const line = ClaudeStreamLineSchema.parse(JSON.parse(raw));
+      if (usageFailure?.category !== "quota_exhausted") {
+        usageFailure = classifyClaudeUsageFailure(line) ?? usageFailure;
+      }
       if (line.session_id && (
         line.session_id !== emittedState?.sessionId
         || (line.model !== undefined && line.model !== emittedState.model)
@@ -478,9 +483,9 @@ export function createClaudeChatProviderAdapter(options: {
       if (buffered.trim()) parseLine(buffered);
       flushPendingDelta();
       emitBufferedResult();
-      const classifiedFailure = resultFailed
+      const classifiedFailure = usageFailure ?? (resultFailed
         ? classifiedClaudeFailureEvidence(`${resultText}\n${stderrEvidence}`)
-        : undefined;
+        : undefined);
       if (!sawResult || resultFailed) {
         console.warn("[chat-claude] Claude CLI result did not complete the Run", {
           category: classifiedFailure?.category ?? (resultFailed ? "result_error" : "missing_result"),
@@ -538,7 +543,7 @@ export function createClaudeChatProviderAdapter(options: {
         queue.finish();
         return;
       }
-      const classifiedFailure = classifiedClaudeFailureEvidence(`${resultText}\n${stderrEvidence}`)
+      const classifiedFailure = usageFailure ?? classifiedClaudeFailureEvidence(`${resultText}\n${stderrEvidence}`)
         ?? classifiedClaudeCliFailure(error);
       if (!input.signal.aborted) {
         console.warn("[chat-claude] Claude CLI Run failed", {

--- a/packages/gateway/src/chat/claude-usage-failure.ts
+++ b/packages/gateway/src/chat/claude-usage-failure.ts
@@ -1,0 +1,75 @@
+import { z } from "zod/v4";
+
+const AssistantApiErrorSchema = z.object({
+  type: z.literal("assistant"),
+  error: z.literal("rate_limit"),
+  isApiErrorMessage: z.literal(true),
+  message: z.object({
+    role: z.literal("assistant"),
+    content: z.array(z.object({ type: z.literal("text"), text: z.string().max(4_000) })).min(1).max(4),
+  }),
+});
+
+const ResultErrorSchema = z.object({
+  type: z.literal("result"),
+  is_error: z.boolean().optional(),
+  subtype: z.string().max(128).optional(),
+  result: z.string().max(4_000).optional(),
+  errors: z.array(z.string().max(4_000)).max(4).optional(),
+}).refine((value) => value.is_error === true || value.subtype === "error");
+
+function validatedResetTime(text: string, observedAt: number): string | undefined {
+  // The native yearless format is meaningful only within the current weekly
+  // window. Do not guess local timezones, DST abbreviations or expired dates.
+  const match = /^You've hit your weekly limit · resets (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{1,2}), (\d{1,2})(?::([0-5]\d))?(am|pm) \(UTC\)$/.exec(text);
+  if (!match) return undefined;
+  const month = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"].indexOf(match[1]!);
+  const day = Number(match[2]);
+  const hour = Number(match[3]);
+  if (day < 1 || day > 31 || hour < 1 || hour > 12) return undefined;
+  const minute = Number(match[4] ?? 0);
+  const utcHour = hour % 12 + (match[5] === "pm" ? 12 : 0);
+  const year = new Date(observedAt).getUTCFullYear();
+  for (const candidateYear of [year, year + 1]) {
+    const timestamp = Date.UTC(candidateYear, month, day, utcHour, minute);
+    const date = new Date(timestamp);
+    if (date.getUTCMonth() !== month || date.getUTCDate() !== day) continue;
+    if (timestamp <= observedAt || timestamp - observedAt > 7 * 24 * 60 * 60_000) continue;
+    return `${date.toISOString().slice(0, 10)} ${date.toISOString().slice(11, 16)} UTC`;
+  }
+  return undefined;
+}
+
+// Only error envelopes may supply classification evidence. Ordinary generated
+// assistant text is not authoritative about account allowance.
+export function classifyClaudeUsageFailure(value: unknown) {
+  const assistant = AssistantApiErrorSchema.safeParse(value);
+  const result = ResultErrorSchema.safeParse(value);
+  const evidence = assistant.success
+    ? assistant.data.message.content.map((block) => block.text)
+    : result.success ? [result.data.result, ...(result.data.errors ?? [])].filter((text): text is string => text !== undefined) : [];
+  const quotaText = evidence.find((text) => /^You've hit your weekly limit(?:[ .·]|$)/i.test(text));
+  if (quotaText === undefined && assistant.success && evidence.some((text) => /^Too many requests\b/i.test(text))) {
+    return {
+      category: "rate_limited" as const,
+      safeError: {
+        code: "service_unavailable" as const,
+        safeMessage: "Requests are temporarily rate limited. Wait a moment and try again.",
+        retryable: true,
+        recoveryActions: ["retry" as const],
+      },
+    };
+  }
+  if (quotaText === undefined) return undefined;
+  const resetsAt = validatedResetTime(quotaText, Date.now());
+  return {
+    category: "quota_exhausted" as const,
+    safeError: {
+      code: "run_failed" as const,
+      safeMessage: resetsAt
+        ? `Your usage limit has been reached. Try again after ${resetsAt}.`
+        : "Your usage limit has been reached. Try again after your allowance resets.",
+      retryable: false,
+    },
+  };
+}

--- a/packages/gateway/src/chat/dispatch-ownership.ts
+++ b/packages/gateway/src/chat/dispatch-ownership.ts
@@ -1,0 +1,20 @@
+import type { ChatOwner } from "./records.js";
+
+export function dispatchAdmissionKey(kind: "turn" | "retry", clientRequestId: string, turnId?: string): string {
+  return JSON.stringify([kind, turnId ?? null, clientRequestId]);
+}
+
+/** Stop clears the durable activeRun for UX, not this process's execution ownership. */
+export function hasStoppingChatExecution(
+  executions: Iterable<{ owner: ChatOwner; chatId: string; controller: AbortController; admissionKey?: string }>,
+  owner: ChatOwner,
+  chatId: string,
+  replayKey?: string,
+): boolean {
+  for (const execution of executions) {
+    if (execution.chatId === chatId && execution.owner.type === owner.type
+      && execution.owner.ownerId === owner.ownerId && execution.controller.signal.aborted
+      && (replayKey === undefined || execution.admissionKey !== replayKey)) return true;
+  }
+  return false;
+}

--- a/packages/gateway/src/chat/hermes-provider-adapter.ts
+++ b/packages/gateway/src/chat/hermes-provider-adapter.ts
@@ -11,6 +11,8 @@ import {
   type CanonicalProviderRunInput,
 } from "./provider-adapter.js";
 import { createCanonicalCliEventQueue } from "./cli-process.js";
+import { startHermesGateway } from "./hermes-startup.js";
+import { CHAT_RUN_CLEANUP_UNCONFIRMED_MESSAGE } from "./failure-diagnostic.js";
 import {
   createHermesStdioClient,
   HermesGatewayProtocolError,
@@ -609,7 +611,7 @@ export function createHermesChatProviderAdapter(options: {
 
     const hermesRoot = join(options.homePath, ".hermes", "hermes-agent");
     const existingPythonPath = process.env.PYTHONPATH?.trim();
-    const client = createHermesStdioClient({
+    const clientOptions = {
       command: join(hermesRoot, "venv", "bin", "python"),
       args: ["-u", "-m", "tui_gateway.entry"],
       cwd: input.executionRoot ?? options.homePath,
@@ -623,27 +625,67 @@ export function createHermesChatProviderAdapter(options: {
       readyTimeoutMs: options.readyTimeoutMs,
       requestTimeoutMs: options.requestTimeoutMs,
       onEvent: handleEvent,
-      onFailure(error) {
+      onFailure(error: Error) {
         if (!completionSettled) {
           completionSettled = true;
           completion.resolve({ ok: false, error });
         }
       },
-    });
+    };
 
-    void (async () => {
+    const iteratorController = new AbortController();
+    const runSignal = AbortSignal.any([input.signal, iteratorController.signal]);
+    const execution = (async () => {
       let totalTimer: NodeJS.Timeout | undefined;
       let abortRun: (() => void) | undefined;
+      let client: ReturnType<typeof createHermesStdioClient> | undefined;
+      let terminal: Extract<CanonicalProviderRunEvent, { type: "run.completed" }> | undefined;
+      let reconnectLabel: string | undefined;
+      const deadlineController = new AbortController();
+      const startupSignal = AbortSignal.any([runSignal, deadlineController.signal]);
+      const finishReconnect = (status: "completed" | "failed" | "cancelled") => {
+        if (reconnectLabel) {
+          emitAgentActivity({ activityId: "startup_reconnect", kind: "phase", label: reconnectLabel, status });
+          reconnectLabel = undefined;
+        }
+      };
       try {
         const stopped = new Promise<never>((_resolve, reject) => {
           abortRun = () => reject(new Error("Hermes Run aborted"));
-          if (input.signal.aborted) return abortRun();
-          input.signal.addEventListener("abort", abortRun, { once: true });
-          totalTimer = setTimeout(() => reject(new HermesRunFailure("timeout", "Hermes Run timed out")), timeoutMs);
+          if (runSignal.aborted) return abortRun();
+          runSignal.addEventListener("abort", abortRun, { once: true });
+          totalTimer = setTimeout(() => {
+            const error = new HermesRunFailure("timeout", "Hermes Run timed out");
+            deadlineController.abort(error);
+            reject(error);
+          }, timeoutMs);
           totalTimer.unref?.();
         });
+        // Startup performs its own cancellation + confirmed cleanup before it
+        // returns. Do not let the overall deadline abandon an owned attempt.
+        void stopped.catch((error: unknown) => {
+          console.warn("[chat/hermes] Run deadline or cancellation observed:", error instanceof Error ? error.name : "UnknownError");
+        });
         const withinRun = <T>(operation: Promise<T>) => Promise.race([operation, stopped]);
-        await withinRun(client.ready());
+        client = await startHermesGateway({ client: clientOptions, signal: startupSignal,
+          async onRetry({ label }) {
+            reconnectLabel = label;
+            emitAgentActivity({ activityId: "startup_reconnect", kind: "phase", label, status: "running" });
+          },
+          onCleanupUnconfirmed() {
+            input.onCleanupUnconfirmed?.();
+            finishReconnect("cancelled");
+            emitAgentActivity({ activityId: "startup_cleanup", kind: "phase", label: "Stopping",
+              summary: CHAT_RUN_CLEANUP_UNCONFIRMED_MESSAGE, status: "running" });
+          },
+          onCleanupConfirmed() {
+            input.onCleanupConfirmed?.();
+            emitAgentActivity({ activityId: "startup_cleanup", kind: "phase", label: "Stopping",
+              summary: "The startup process stopped.", status: "completed" });
+          },
+        });
+        finishReconnect("completed");
+        startupSignal.throwIfAborted();
         const rawSession = resumeState
           ? await withinRun(client.request("session.resume", {
               session_id: resumeState.sessionId,
@@ -712,6 +754,7 @@ export function createHermesChatProviderAdapter(options: {
           value: "1",
           scope: "session",
         })));
+        startupSignal.throwIfAborted();
         HermesPromptResponseSchema.parse(await withinRun(client.request("prompt.submit", {
           session_id: liveSessionId,
           text: input.prompt,
@@ -749,10 +792,11 @@ export function createHermesChatProviderAdapter(options: {
         if (final.status === "interrupted" && !input.signal.aborted) {
           throw new HermesRunFailure("interrupted", "Hermes Run was interrupted");
         }
-        queue.push(CanonicalProviderRunEventSchema.parse({ type: "run.completed", outcome: "completed" }));
+        terminal = { type: "run.completed", outcome: "completed" };
       } catch (error: unknown) {
+        finishReconnect(input.signal.aborted ? "cancelled" : "failed");
         flushVisibleText(true);
-        if (input.signal.aborted && liveSessionId) {
+        if (runSignal.aborted && liveSessionId && client) {
           try {
             await client.request("session.interrupt", { session_id: liveSessionId }, 1_000);
           } catch (interruptError: unknown) {
@@ -781,7 +825,7 @@ export function createHermesChatProviderAdapter(options: {
               code: "provider_unavailable" as const,
               safeMessage: "The Hermes connection failed. Try again.",
             };
-        queue.push(CanonicalProviderRunEventSchema.parse({
+        terminal = {
           type: "run.completed",
           outcome: input.signal.aborted ? "aborted" : "failed",
           ...(input.signal.aborted ? {} : {
@@ -791,19 +835,36 @@ export function createHermesChatProviderAdapter(options: {
               recoveryActions: ["retry"],
             },
           }),
-        }));
+        };
       } finally {
         releaseSteerRun?.();
         releaseApprovalRun?.();
         if (deltaFlushTimer) clearTimeout(deltaFlushTimer);
         if (totalTimer) clearTimeout(totalTimer);
-        if (abortRun) input.signal.removeEventListener("abort", abortRun);
-        await client.close();
+        if (abortRun) runSignal.removeEventListener("abort", abortRun);
+        if (client && !await client.close()) {
+          input.onCleanupUnconfirmed?.();
+          emitAgentActivity({ activityId: "run_cleanup", kind: "phase", label: "Stopping",
+            summary: CHAT_RUN_CLEANUP_UNCONFIRMED_MESSAGE, status: "running" });
+          await client.whenExited();
+          input.onCleanupConfirmed?.();
+          emitAgentActivity({ activityId: "run_cleanup", kind: "phase", label: "Stopping",
+            summary: "The agent process stopped.", status: "completed" });
+        }
+        if (terminal) queue.push(CanonicalProviderRunEventSchema.parse(terminal));
         queue.finish();
       }
     })();
 
-    yield* queue.values();
+    try {
+      yield* queue.values();
+    } finally {
+      // The consumer may stop reading a cleanup activity after cancellation.
+      // Keep return() attached to the exact execution until startup's real-exit
+      // proof clears its dispatch-local cleanup flag; do not detach that work.
+      iteratorController.abort();
+      await execution;
+    }
   }
 
   return {

--- a/packages/gateway/src/chat/hermes-startup.ts
+++ b/packages/gateway/src/chat/hermes-startup.ts
@@ -1,0 +1,60 @@
+import {
+  createHermesStdioClient,
+  HermesGatewayReadyTimeout,
+  type HermesStdioClient,
+} from "./hermes-stdio-client.js";
+import { retryUnadmittedStartup, RetryableProviderStartupTimeout } from "../coding-agents/provider-startup-retry.mjs";
+
+export class HermesStartupCleanupUnconfirmed extends Error {
+  readonly name = "HermesStartupCleanupUnconfirmed";
+  constructor() { super("Hermes startup cleanup requires reconciliation"); }
+}
+
+/** Only gateway.ready is retried. No session or prompt RPC is sent here. */
+export async function startHermesGateway(options: {
+  client: Parameters<typeof createHermesStdioClient>[0];
+  signal: AbortSignal;
+  onRetry: (progress: { retry: number; maxRetries: 5; label: string }) => Promise<void>;
+  onCleanupUnconfirmed(): void;
+  onCleanupConfirmed(): void;
+}): Promise<HermesStdioClient> {
+  return retryUnadmittedStartup({
+    signal: options.signal,
+    onRetry: options.onRetry,
+    async attempt(signal) {
+      signal.throwIfAborted();
+      let admittedToCaller = false;
+      const client = createHermesStdioClient({ ...options.client,
+        onFailure(error) {
+          // A retired attempt must not settle the logical Run's completion.
+          if (admittedToCaller) options.client.onFailure(error);
+        },
+      });
+      let rejectAbort!: (error: unknown) => void;
+      const aborted = new Promise<never>((_resolve, reject) => { rejectAbort = reject; });
+      const abort = () => rejectAbort(signal.reason);
+      signal.addEventListener("abort", abort, { once: true });
+      try {
+        if (signal.aborted) abort();
+        await Promise.race([client.ready(), aborted]);
+        signal.throwIfAborted();
+        admittedToCaller = true;
+        return client;
+      } catch (error) {
+        if (!await client.close()) {
+          options.onCleanupUnconfirmed();
+          // Keep the existing adapter iterator and orchestrator capacity owned
+          // until actual exit. Abort/kill/deadline never grants retry permission.
+          await client.whenExited();
+          options.onCleanupConfirmed();
+          throw new HermesStartupCleanupUnconfirmed();
+        }
+        signal.throwIfAborted();
+        if (error instanceof HermesGatewayReadyTimeout) throw new RetryableProviderStartupTimeout();
+        throw error;
+      } finally {
+        signal.removeEventListener("abort", abort);
+      }
+    },
+  });
+}

--- a/packages/gateway/src/chat/hermes-stdio-client.ts
+++ b/packages/gateway/src/chat/hermes-stdio-client.ts
@@ -35,6 +35,7 @@ interface HermesGatewayReadable {
 }
 
 export interface HermesGatewayProcess {
+  readonly pid?: number;
   stdin: HermesGatewayWritable;
   stdout: HermesGatewayReadable;
   stderr: HermesGatewayReadable;
@@ -58,7 +59,15 @@ interface PendingRequest {
 export interface HermesStdioClient {
   ready(): Promise<void>;
   request(method: string, params: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
-  close(): Promise<void>;
+  /** Actual exit or definitive no-child spawn failure, never a kill timeout. */
+  whenExited(): Promise<void>;
+  /** Bounded cleanup; false means the process is still owned and must be tracked. */
+  close(): Promise<boolean>;
+}
+
+export class HermesGatewayReadyTimeout extends Error {
+  readonly name = "HermesGatewayReadyTimeout";
+  constructor() { super("Hermes gateway did not become ready"); }
 }
 
 const defaultSpawn: HermesGatewaySpawn = (command, args, options) => spawn(command, args, options);
@@ -118,6 +127,7 @@ export function createHermesStdioClient(options: {
   let failed: Error | undefined;
   let closing = false;
   let exited = false;
+  let closePromise: Promise<boolean> | undefined;
   let readySettled = false;
   let resolveReady!: () => void;
   let rejectReady!: (error: Error) => void;
@@ -136,7 +146,7 @@ export function createHermesStdioClient(options: {
   });
 
   const readyTimer = setTimeout(() => {
-    fail(safeError("Hermes gateway did not become ready"));
+    fail(new HermesGatewayReadyTimeout());
   }, options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS);
   readyTimer.unref?.();
 
@@ -162,7 +172,14 @@ export function createHermesStdioClient(options: {
     settleReady(error);
     rejectPending(error);
     options.onFailure(error);
-    child.kill("SIGTERM");
+    if (!exited) signalChild("SIGTERM");
+  }
+
+  function signalChild(signal: NodeJS.Signals): void {
+    try { child.kill(signal); }
+    catch (error: unknown) {
+      console.warn("[chat/hermes] Child termination signal failed:", error instanceof Error ? error.name : "UnknownError");
+    }
   }
 
   function handleFrame(line: string): void {
@@ -227,7 +244,15 @@ export function createHermesStdioClient(options: {
   child.stderr.on("data", (chunk) => {
     stderrBytes = Math.min(8_192, stderrBytes + chunk.byteLength);
   });
-  child.once("error", (error) => fail(safeError("Hermes gateway could not start", error)));
+  child.once("error", (error) => {
+    // Node reports an undefined PID when spawn itself failed. An absent PID
+    // property on an injected process is unknown, not proof of non-admission.
+    if ("pid" in child && child.pid === undefined) {
+      exited = true;
+      resolveExit();
+    }
+    fail(safeError("Hermes gateway could not start", error));
+  });
   child.once("exit", (code, signal) => {
     exited = true;
     resolveExit();
@@ -239,6 +264,7 @@ export function createHermesStdioClient(options: {
 
   return {
     ready: () => readyPromise,
+    whenExited: () => exitPromise,
     request(method, params, timeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS) {
       if (failed) return Promise.reject(failed);
       if (closing) return Promise.reject(safeError("Hermes gateway is closing"));
@@ -266,33 +292,48 @@ export function createHermesStdioClient(options: {
         }
       });
     },
-    async close() {
-      if (closing) return exitPromise;
+    close() {
+      if (closePromise) return closePromise;
       closing = true;
       clearTimeout(readyTimer);
       settleReady(safeError("Hermes gateway closed"));
       rejectPending(safeError("Hermes gateway closed"));
-      if (exited) return;
-      child.stdin.end();
-      let forceKillTimer: NodeJS.Timeout | undefined;
-      let forceSettleTimer: NodeJS.Timeout | undefined;
-      await Promise.race([
-        exitPromise,
-        new Promise<void>((resolve) => {
-          forceKillTimer = setTimeout(() => {
-            if (exited) return resolve();
-            child.kill("SIGTERM");
-            forceSettleTimer = setTimeout(() => {
-              if (!exited) child.kill("SIGKILL");
-              resolve();
-            }, FORCE_SETTLE_MS);
-            forceSettleTimer.unref?.();
-          }, TERMINATION_GRACE_MS);
-          forceKillTimer.unref?.();
-        }),
-      ]);
-      if (forceKillTimer) clearTimeout(forceKillTimer);
-      if (forceSettleTimer) clearTimeout(forceSettleTimer);
+      closePromise = (async () => {
+        if (exited) return true;
+        try { child.stdin.end(); }
+        catch (error: unknown) {
+          console.warn("[chat/hermes] Child input close failed:", error instanceof Error ? error.name : "UnknownError");
+        }
+        let terminateTimer: NodeJS.Timeout | undefined;
+        let killTimer: NodeJS.Timeout | undefined;
+        let settleTimer: NodeJS.Timeout | undefined;
+        try {
+          await Promise.race([
+            exitPromise,
+            new Promise<void>((resolve) => {
+              terminateTimer = setTimeout(() => {
+                if (exited) return resolve();
+                signalChild("SIGTERM");
+                killTimer = setTimeout(() => {
+                  if (!exited) signalChild("SIGKILL");
+                  // Sending SIGKILL is not proof of exit. Give the real exit
+                  // listener a bounded window, then report unknown cleanup.
+                  settleTimer = setTimeout(resolve, FORCE_SETTLE_MS);
+                  settleTimer.unref?.();
+                }, FORCE_SETTLE_MS);
+                killTimer.unref?.();
+              }, TERMINATION_GRACE_MS);
+              terminateTimer.unref?.();
+            }),
+          ]);
+          return exited;
+        } finally {
+          if (terminateTimer) clearTimeout(terminateTimer);
+          if (killTimer) clearTimeout(killTimer);
+          if (settleTimer) clearTimeout(settleTimer);
+        }
+      })();
+      return closePromise;
     },
   };
 }

--- a/packages/gateway/src/chat/orchestrator.ts
+++ b/packages/gateway/src/chat/orchestrator.ts
@@ -65,6 +65,7 @@ import {
 } from "./queue-admission.js";
 import { recoverOrphanedRun } from "./orphaned-run-recovery.js";
 import { retryAvailability } from "./retry-preflight.js";
+import { dispatchAdmissionKey, hasStoppingChatExecution } from "./dispatch-ownership.js";
 import { loadChatResumeState } from "./resume-checkpoint.js";
 import { boundedOperation } from "../bounded-operation.js";
 import { CHAT_RUN_CLEANUP_UNCONFIRMED_MESSAGE, diagnoseChatRunFailure, type ChatRunFailureDiagnostic } from "./failure-diagnostic.js";
@@ -82,6 +83,7 @@ export class CanonicalChatOrchestrationError extends Error {
 }
 
 interface ActiveRun {
+  admissionKey?: string;
   controller: AbortController;
   adapter: CanonicalChatProviderAdapter;
   owner: ChatOwner;
@@ -359,6 +361,10 @@ export class CanonicalChatOrchestrator {
     await this.assertPersonalExecutionAllowed(owner, chatId);
     await this.reconcileActiveRuns(owner);
     const input = CanonicalCreateChatTurnRequestSchema.parse(inputValue);
+    const admissionKey = dispatchAdmissionKey("turn", input.clientRequestId);
+    if (hasStoppingChatExecution(this.active.values(), owner, chatId, admissionKey)) {
+      return mapRepositoryError(new ChatBusyError(chatId));
+    }
     const record = await this.options.repository.get(owner, chatId);
     if (!record) return mapRepositoryError(new ChatNotFoundError(chatId));
     const catalog = await this.options.catalog.getCatalog(principal);
@@ -496,13 +502,15 @@ export class CanonicalChatOrchestrator {
 
     try {
       if (!admitted.alreadyAccepted) {
-        if (this.atCapacity(owner)) {
+        const stopping = hasStoppingChatExecution(this.active.values(), owner, chatId);
+        if (stopping || this.atCapacity(owner)) {
           await this.options.repository.finishRun(owner, {
             chatId,
             runId: admitted.run.id,
             outcome: "failed",
             completedAt: timestamp,
           });
+          if (stopping) return mapRepositoryError(new ChatBusyError(chatId));
           throw new CanonicalChatOrchestrationError(
             safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
             503,
@@ -515,6 +523,8 @@ export class CanonicalChatOrchestrator {
           adapter,
           resolvedRoot,
           resumeState,
+          undefined,
+          admissionKey,
         );
       }
       return CanonicalChatTurnAdmissionResponseSchema.parse({
@@ -568,6 +578,10 @@ export class CanonicalChatOrchestrator {
     await this.assertPersonalExecutionAllowed(owner, chatId);
     await this.reconcileActiveRuns(owner);
     const input = CanonicalRetryChatTurnRequestSchema.parse(inputValue);
+    const admissionKey = dispatchAdmissionKey("retry", input.clientRequestId, turnId);
+    if (hasStoppingChatExecution(this.active.values(), owner, chatId, admissionKey)) {
+      return mapRepositoryError(new ChatBusyError(chatId));
+    }
     const context = await this.options.repository.getTurnRunContext(owner, chatId, turnId);
     if (!context) {
       throw new CanonicalChatOrchestrationError(safeError("run_not_found", "Run not found."), 404);
@@ -681,13 +695,15 @@ export class CanonicalChatOrchestrator {
     }
     try {
       if (!admitted.alreadyAccepted) {
-        if (this.atCapacity(owner)) {
+        const stopping = hasStoppingChatExecution(this.active.values(), owner, chatId);
+        if (stopping || this.atCapacity(owner)) {
           await this.options.repository.finishRun(owner, {
             chatId,
             runId: admitted.run.id,
             outcome: "failed",
             completedAt: timestamp,
           });
+          if (stopping) return mapRepositoryError(new ChatBusyError(chatId));
           throw new CanonicalChatOrchestrationError(
             safeError("run_unavailable", "Chat execution is temporarily busy.", true, ["retry"]),
             503,
@@ -701,6 +717,7 @@ export class CanonicalChatOrchestrator {
           resolvedRoot,
           resumeState,
           retryPromptFor(context.userMessages),
+          admissionKey,
         );
       }
       return CanonicalChatRunAdmissionResponseSchema.parse({
@@ -722,6 +739,7 @@ export class CanonicalChatOrchestrator {
     resolvedRoot?: ResolvedChatExecutionRoot,
     resumeState?: unknown,
     promptOverride?: string,
+    admissionKey?: string,
   ): void {
     const controller = new AbortController();
     const completion = this.dispatch(owner, message, run, adapter, controller, resolvedRoot, resumeState, promptOverride)
@@ -741,6 +759,7 @@ export class CanonicalChatOrchestrator {
         }
       });
     this.active.set(run.id, {
+      admissionKey,
       controller,
       adapter,
       owner,
@@ -870,6 +889,7 @@ export class CanonicalChatOrchestrator {
         ...(resumeState === undefined ? {} : { resumeState }),
         signal: controller.signal,
         onCleanupUnconfirmed: () => { cleanupUnconfirmed = true; },
+        onCleanupConfirmed: () => { cleanupUnconfirmed = false; },
       };
       let text = "";
       let terminal: Extract<CanonicalProviderRunEvent, { type: "run.completed" }> | undefined;

--- a/packages/gateway/src/chat/provider-adapter.ts
+++ b/packages/gateway/src/chat/provider-adapter.ts
@@ -105,6 +105,8 @@ export interface CanonicalProviderRunInput<State = unknown> {
   signal: AbortSignal;
   /** Generator return() errors can be masked by a consumer throw; report unresolved cleanup explicitly. */
   onCleanupUnconfirmed?: () => void;
+  /** Clear unresolved cleanup only after this exact owned execution has exited. */
+  onCleanupConfirmed?: () => void;
 }
 
 export interface CanonicalChatProviderAdapter<State = unknown> {

--- a/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
+++ b/packages/gateway/src/coding-agents/codex-app-server-runner.mjs
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import { chmod, lstat, mkdir, open, rm } from "node:fs/promises";
@@ -12,6 +11,7 @@ import { createCodexSessionApprovalGrants } from "./codex-session-approvals.mjs"
 import { createCodexExecutionWatchdog } from "./codex-execution-watchdog.mjs";
 import { CodexHibernateControlSchema, createCodexIdleHibernation } from "./codex-idle-hibernation.mjs";
 import { createCodexMcpElicitations, rejectCodexServerRequest } from "./codex-mcp-elicitations.mjs";
+import { initializeCodexProvider, ProviderStartupCleanupUnconfirmed, signalCodexProviderChild } from "./codex-provider-startup.mjs";
 
 process.on("uncaughtException", () => {
   process.stderr.write("Codex app-server runner stopped unexpectedly.\n");
@@ -1101,23 +1101,13 @@ const cleanupTimer = setInterval(() => {
 }, 30_000);
 cleanupTimer.unref();
 
-const child = spawn(command, [...commandArgs, "app-server"], {
-  cwd: process.cwd(),
-  env: process.env,
-  stdio: ["pipe", "pipe", "pipe"],
-});
-const childExit = new Promise((resolve) => {
-  child.once("error", (error) => resolve({ code: null, signal: null, error }));
-  child.once("close", (code, signal) => {
-    if (stopTimer) clearTimeout(stopTimer);
-    for (const pending of pendingRpc.values()) {
-      clearTimeout(pending.timeout);
-      pending.reject(new Error("provider_stopped"));
-    }
-    pendingRpc.clear();
-    resolve({ code, signal });
-  });
-});
+const startupController = new AbortController();
+let child;
+let childExit = Promise.resolve({ code: null, signal: null });
+let providerOutput = Promise.resolve({ ok: true });
+let providerErrors = Promise.resolve({ ok: true });
+let startupReconnecting = false;
+let userStopped = false;
 
 function decodeTurnFrame(line) {
   if (Buffer.byteLength(line, "utf8") > MAX_TURN_FRAME_BYTES) return undefined;
@@ -1190,11 +1180,13 @@ input.on("close", () => {
 function stop() {
   if (stopping) return;
   stopping = true;
+  startupController.abort();
   input.close();
   wakeTurn?.();
   wakeTurn = undefined;
-  child.kill("SIGTERM");
-  stopTimer = setTimeout(() => child.kill("SIGKILL"), PROVIDER_STOP_TIMEOUT_MS);
+  if (!child) return;
+  signalCodexProviderChild(child, "SIGTERM");
+  stopTimer = setTimeout(() => signalCodexProviderChild(child, "SIGKILL"), PROVIDER_STOP_TIMEOUT_MS);
   stopTimer.unref();
 }
 
@@ -1206,8 +1198,8 @@ async function finishTurn(outcome) {
     startedToolItems.size > 0 ||
     toolItemsWithOutput.size > 0;
   if (!activeTurn && !hasUnsettledItems) {
-    if (outcome === "failed" && terminalEventCount === 0) {
-      await persist({ type: "turn.failed" });
+    if ((outcome === "failed" || outcome === "aborted") && terminalEventCount === 0) {
+      await persist({ type: outcome === "aborted" ? "turn.aborted" : "turn.failed" });
       terminalEventCount += 1;
     }
     return;
@@ -1290,29 +1282,40 @@ async function runTurn(threadId, turn) {
   }
 }
 
-const providerOutput = consumeProviderOutput(child.stdout).then(
-  () => ({ ok: true }),
-  (error) => {
-    stop();
-    return { ok: false, error };
-  },
-);
-const providerErrors = discardProviderErrors(child.stderr).then(
-  () => ({ ok: true }),
-  (error) => {
-    stop();
-    return { ok: false, error };
-  },
-);
-process.once("SIGTERM", stop);
-process.once("SIGINT", stop);
+process.once("SIGTERM", () => { userStopped = true; stop(); });
+process.once("SIGINT", () => { userStopped = true; stop(); });
 
 let exitCode = 0;
 try {
-  await request("initialize", {
-    clientInfo: { name: "matrix-os", title: "Matrix OS", version: "1" },
-    capabilities: { experimentalApi: true },
+  const initialized = await initializeCodexProvider({ command, args: commandArgs,
+    cwd: process.cwd(), env: process.env, signal: startupController.signal,
+    onRetry: async ({ label }) => {
+      startupReconnecting = true;
+      await persist({ type: "matrix.codex.tool.started", toolCallId: "startup_reconnect",
+        kind: "phase", displayName: label });
+    },
   });
+  child = initialized.child;
+  childExit = initialized.closed.then((exit) => {
+    if (stopTimer) clearTimeout(stopTimer);
+    for (const pending of pendingRpc.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error("provider_stopped"));
+    }
+    pendingRpc.clear();
+    return exit;
+  });
+  providerOutput = consumeProviderOutput(child.stdout).then(
+    () => ({ ok: true }), (error) => { stop(); return { ok: false, error }; },
+  );
+  providerErrors = discardProviderErrors(child.stderr).then(
+    () => ({ ok: true }), (error) => { stop(); return { ok: false, error }; },
+  );
+  if (startupReconnecting) {
+    await persist({ type: "matrix.codex.tool.completed", toolCallId: "startup_reconnect", outcome: "success" });
+    startupReconnecting = false;
+  }
+  startupController.signal.throwIfAborted();
   sendProvider({ method: "initialized", params: {} });
   const threadMethod = config.providerThreadId ? "thread/resume" : "thread/start";
   const started = await request(threadMethod, {
@@ -1369,9 +1372,25 @@ try {
   if (exit.error) throw exit.error;
   await new Promise((resolve) => setTimeout(resolve, SHUTDOWN_REPLAY_GRACE_MS));
   if (activeTurn || terminalEventCount === 0) exitCode = 1;
-} catch (_error) {
+} catch (error) {
   exitCode = 1;
-  await finishTurn("failed").catch(() => undefined);
+  if (error instanceof ProviderStartupCleanupUnconfirmed) {
+    // Keep the runner/thread supervised and non-terminal while its exact child
+    // remains unconfirmed. Never release canonical busy state or retry here.
+    child = error.child;
+    childExit = error.closed;
+    startupReconnecting = true;
+    await persist({ type: "matrix.codex.tool.started", toolCallId: "startup_reconnect",
+      kind: "phase", displayName: "Waiting for startup cleanup" });
+    await childExit;
+  }
+  if (startupReconnecting) {
+    await persist({ type: "matrix.codex.tool.completed", toolCallId: "startup_reconnect",
+      outcome: userStopped ? "cancelled" : "failed" });
+  }
+  await finishTurn(userStopped ? "aborted" : "failed").catch((error) => {
+    console.warn("[coding-agents] Terminal startup state could not be persisted:", error instanceof Error ? error.name : "UnknownError");
+  });
   stop();
   await Promise.allSettled([childExit, providerOutput, providerErrors]);
 } finally {

--- a/packages/gateway/src/coding-agents/codex-events.ts
+++ b/packages/gateway/src/coding-agents/codex-events.ts
@@ -137,7 +137,7 @@ const MatrixCodexRecordSchema = z.discriminatedUnion("type", [
     type: z.literal("matrix.codex.tool.started"),
     toolCallId: CodexItemIdSchema,
     displayName: SafeDisplayStringSchema,
-    kind: z.enum(["command", "file_change", "tool", "agent", "search", "plan", "reasoning"]),
+    kind: z.enum(["command", "file_change", "tool", "agent", "search", "plan", "reasoning", "phase"]),
     preview: SafeDisplayStringSchema.optional(),
     previewKind: z.enum(["command", "path", "text"]).optional(),
     detail: SafeDisplayStringSchema.optional(),

--- a/packages/gateway/src/coding-agents/codex-provider-startup.mjs
+++ b/packages/gateway/src/coding-agents/codex-provider-startup.mjs
@@ -1,0 +1,126 @@
+import { spawn } from "node:child_process";
+import { RetryableProviderStartupTimeout, retryUnadmittedStartup } from "./provider-startup-retry.mjs";
+
+const MAX_HANDSHAKE_BYTES = 1024 * 1024;
+const INITIALIZE_ID = "matrix_startup_initialize";
+class InitializationTimeout extends Error {}
+export class ProviderStartupCleanupUnconfirmed extends Error {
+  constructor(child, closed) {
+    super("Provider startup cleanup unconfirmed");
+    this.name = "ProviderStartupCleanupUnconfirmed";
+    this.child = child;
+    this.closed = closed;
+  }
+}
+
+function startupTimeout(env) {
+  const value = Number(env.MATRIX_CODEX_STARTUP_TIMEOUT_MS ?? 30_000);
+  if (!Number.isSafeInteger(value) || value < 1 || value > 30_000) throw new Error("Invalid startup timeout");
+  return value;
+}
+
+export function signalCodexProviderChild(child, signal) {
+  try { child.kill(signal); }
+  catch (error) {
+    // A failed signal does not prove the process stopped. Keep its close
+    // listener and the caller's cleanup ownership intact.
+    console.warn("[coding-agents] Provider termination signal failed:", error instanceof Error ? error.name : "UnknownError");
+  }
+}
+
+async function confirmedStop(child, closed) {
+  signalCodexProviderChild(child, "SIGTERM");
+  let forceTimer;
+  let deadline;
+  try {
+    forceTimer = setTimeout(() => signalCodexProviderChild(child, "SIGKILL"), 1_000);
+    // A signal or a timeout is not exit evidence. Only the child's close event
+    // can make this attempt eligible for another process.
+    await Promise.race([closed, new Promise((_, reject) => {
+      deadline = setTimeout(() => reject(new ProviderStartupCleanupUnconfirmed(child, closed)), 5_000);
+    })]);
+  } finally {
+    clearTimeout(forceTimer);
+    clearTimeout(deadline);
+  }
+}
+
+async function initializeAttempt({ command, args, cwd, env, signal }) {
+  signal.throwIfAborted();
+  const child = spawn(command, [...args, "app-server"], { cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+  const closed = new Promise((resolve) => child.once("close", (code, exitSignal) => resolve({ code, signal: exitSignal })));
+  // Suppress raw stderr during initialization; the owner takes over after ready.
+  const discard = () => undefined;
+  child.stderr.on("data", discard);
+  // Keep late pipe errors contained while cancellation drains the exact child.
+  child.stdin.on("error", discard);
+  child.on("error", discard);
+  let cleanup;
+  try {
+    await new Promise((resolve, reject) => {
+      let buffered = Buffer.alloc(0);
+      let seenBytes = 0;
+      const timeout = setTimeout(() => reject(new InitializationTimeout()), startupTimeout(env));
+      const abort = () => reject(signal.reason);
+      const failed = () => reject(new Error("Provider initialization unavailable"));
+      const data = (chunk) => {
+        seenBytes += chunk.byteLength;
+        if (seenBytes > MAX_HANDSHAKE_BYTES) { reject(new Error("Provider initialization response too large")); return; }
+        buffered = Buffer.concat([buffered, chunk]);
+        let newline;
+        while ((newline = buffered.indexOf(10)) >= 0) {
+          const line = buffered.subarray(0, newline).toString("utf8");
+          buffered = buffered.subarray(newline + 1);
+          let message;
+          try { message = JSON.parse(line); }
+          catch (error) { if (error instanceof SyntaxError) { reject(new Error("Invalid initialization response")); return; } throw error; }
+          if (message?.id !== INITIALIZE_ID || message.method !== undefined) continue;
+          if (message.error !== undefined || !Object.hasOwn(message, "result")) {
+            reject(new Error("Provider initialization rejected")); return;
+          }
+          child.stdout.pause();
+          child.stdout.off("data", data);
+          if (buffered.length > 0) child.stdout.unshift(buffered);
+          resolve();
+          return;
+        }
+      };
+      cleanup = () => {
+        clearTimeout(timeout);
+        signal.removeEventListener("abort", abort);
+        child.off("error", failed);
+        child.off("close", failed);
+        child.stdin.off("error", failed);
+        child.stdout.off("data", data);
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      child.once("error", failed);
+      child.once("close", failed);
+      child.stdin.once("error", failed);
+      child.stdout.on("data", data);
+      child.stdin.write(`${JSON.stringify({ id: INITIALIZE_ID, method: "initialize", params: {
+        clientInfo: { name: "matrix-os", title: "Matrix OS", version: "1" },
+        capabilities: { experimentalApi: true },
+      } })}\n`);
+    });
+    signal.throwIfAborted();
+    child.stderr.pause();
+    return { child, closed };
+  } catch (error) {
+    // No thread/start, thread/resume or turn/start has been sent by this helper.
+    cleanup?.();
+    await confirmedStop(child, closed);
+    signal.throwIfAborted();
+    if (error instanceof InitializationTimeout) throw new RetryableProviderStartupTimeout();
+    throw error;
+  } finally {
+    cleanup?.();
+    child.stderr.off("data", discard);
+  }
+}
+
+export function initializeCodexProvider({ signal, onRetry, ...options }) {
+  return retryUnadmittedStartup({ signal, onRetry,
+    attempt: (attemptSignal) => initializeAttempt({ ...options, signal: attemptSignal }),
+  });
+}

--- a/packages/gateway/src/coding-agents/provider-startup-retry.d.mts
+++ b/packages/gateway/src/coding-agents/provider-startup-retry.d.mts
@@ -1,0 +1,8 @@
+export class RetryableProviderStartupTimeout extends Error {
+  constructor();
+}
+export function retryUnadmittedStartup<T>(options: {
+  signal: AbortSignal;
+  attempt: (signal: AbortSignal) => Promise<T>;
+  onRetry: (event: { retry: number; maxRetries: 5; label: string }) => Promise<void>;
+}): Promise<T>;

--- a/packages/gateway/src/coding-agents/provider-startup-retry.mjs
+++ b/packages/gateway/src/coding-agents/provider-startup-retry.mjs
@@ -1,0 +1,36 @@
+// Private failure proof, never derived from a public error string. Construct
+// only after a startup timeout before prompt admission AND confirmed process exit.
+export class RetryableProviderStartupTimeout extends Error {
+  constructor() {
+    super("Provider startup timed out before admission; process stopped");
+    this.name = "RetryableProviderStartupTimeout";
+  }
+}
+
+function backoff(ms, signal) {
+  signal.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const abort = () => { clearTimeout(timer); reject(signal.reason); };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", abort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+// attempt owns cancellation/cleanup of resources it creates, including a late
+// success. This is the single retry budget: one initial attempt plus five retries.
+export async function retryUnadmittedStartup({ signal, attempt, onRetry }) {
+  for (let retry = 0; ; retry += 1) {
+    signal.throwIfAborted();
+    try {
+      return await attempt(signal);
+    } catch (error) {
+      signal.throwIfAborted();
+      if (!(error instanceof RetryableProviderStartupTimeout) || retry >= 5) throw error;
+      await onRetry({ retry: retry + 1, maxRetries: 5, label: `Reconnecting… ${retry + 1}/5` });
+      await backoff(Math.min(250 * 2 ** retry, 4_000), signal);
+    }
+  }
+}

--- a/specs/113-provider-neutral-chat-architecture/chat-startup-and-model-discovery.md
+++ b/specs/113-provider-neutral-chat-architecture/chat-startup-and-model-discovery.md
@@ -1,5 +1,7 @@
 # Canonical Chat startup, usage errors, and model discovery
 
+Related delivery: OM-234. This supplements the [canonical Chat architecture](./spec.md).
+
 ## 1. Scope / Trigger
 
 Use this contract when changing provider startup recovery, native error projection,

--- a/specs/113-provider-neutral-chat-architecture/spec.md
+++ b/specs/113-provider-neutral-chat-architecture/spec.md
@@ -8,6 +8,8 @@
 **Scope:** Canonical contracts, persistence, provider execution, shared Desktop surfaces, workspace resources, migration, and implementation sequencing
 **Related delivery:** MAT-299, MAT-318, MAT-321, MAT-344, MAT-364, and MAT-468
 
+**Startup/recovery contract:** [OM-234: startup, usage errors, and model discovery](./chat-startup-and-model-discovery.md).
+
 ## Purpose
 
 Matrix OS needs one durable user-facing Chat abstraction. A Chat is the task the

--- a/tests/desktop/chat-claude-quota-transcript.test.tsx
+++ b/tests/desktop/chat-claude-quota-transcript.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment gateway-renderer
+import React from "react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { CanonicalChatWorkspace } from "@desktop/renderer/src/features/chat/CanonicalChatWorkspace";
+import { useBoard } from "@desktop/renderer/src/stores/board";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { createCanonicalChatEventSource } from "../../packages/ui/src/canonical-chat-event-source";
+import { createCanonicalChatWorkspaceClient } from "./canonical-chat-workspace-test-utils";
+import { createClaudeSteerStreamHarness } from "../helpers/claude-steer-stream-harness";
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
+  useBoard.setState(useBoard.getInitialState(), true);
+  useConnection.setState(useConnection.getInitialState(), true);
+  window.operator = { invoke: vi.fn(async () => ({ ok: true })), on: vi.fn(() => () => undefined) };
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+it.each(["assistant", "result"])("renders the %s quota reset safely from live SSE without retry or reload", async (envelope) => {
+  const h = await createClaudeSteerStreamHarness();
+  const source = createCanonicalChatEventSource({ openStream: h.openStream });
+  const client = createCanonicalChatWorkspaceClient();
+  const initial = await h.getDetail();
+  vi.mocked(client.list).mockResolvedValue({ items: [initial.record] });
+  vi.mocked(client.getDetail).mockResolvedValue(initial);
+  client.acknowledgeCompletion = async (chatId, runId) => h.repository.acknowledgeCompletion(h.owner, chatId, runId);
+  try {
+    render(<CanonicalChatWorkspace client={client} eventSource={source} catalog={h.catalog}
+      projectId={null} initialChatId={h.chatId} initialView="conversation" active />);
+    await act(async () => { await source.start(); });
+    await waitFor(() => expect(h.frames.at(-1)?.type).toBe("chat.replay.end"));
+    await screen.findByRole("log");
+    await act(async () => { await h.admit(); });
+    await waitFor(() => expect(h.children).toHaveLength(1));
+    // Only the clock and external native process are controlled.
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-10T08:00:00Z"));
+    await act(async () => {
+      const text = "You've hit your weekly limit · resets Sep 14, 1pm (UTC)";
+      h.children[0]!.line(envelope === "assistant"
+        ? { type: "assistant", error: "rate_limit", isApiErrorMessage: true,
+            message: { role: "assistant", content: [{ type: "text", text }] } }
+        : { type: "result", is_error: true, result: text });
+      clock.mockRestore();
+      h.children[0]!.exit(1);
+      await h.orchestrator.drain();
+    });
+    const log = within(screen.getByRole("log"));
+    const message = "Your usage limit has been reached. Try again after 2026-09-14 13:00 UTC.";
+    await waitFor(() => expect(log.getAllByText(message)).toHaveLength(1));
+    expect(log.queryByRole("button", { name: /retry/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+    expect(screen.getByRole("log").textContent).not.toMatch(/Check its connection|Reconnecting|You've hit/);
+    expect(client.getDetail).toHaveBeenCalledTimes(1);
+    expect(h.openStream).toHaveBeenCalledTimes(1);
+    expect(h.spawn).toHaveBeenCalledTimes(1);
+  } finally {
+    cleanup(); source.dispose(); await h.close();
+  }
+}, 20_000);

--- a/tests/desktop/chat-claude-steer-transcript.test.tsx
+++ b/tests/desktop/chat-claude-steer-transcript.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment gateway-renderer
+import React from "react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { CanonicalChatWorkspace } from "@desktop/renderer/src/features/chat/CanonicalChatWorkspace";
+import { useBoard } from "@desktop/renderer/src/stores/board";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { createCanonicalChatEventSource } from "../../packages/ui/src/canonical-chat-event-source";
+import { createCanonicalChatWorkspaceClient } from "./canonical-chat-workspace-test-utils";
+import { AFTER_STEER, BEFORE_STEER, FINAL_TEXT, STEER_REQUEST,
+  createClaudeSteerStreamHarness } from "../helpers/claude-steer-stream-harness";
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
+  useBoard.setState(useBoard.getInitialState(), true);
+  useConnection.setState(useConnection.getInitialState(), true);
+  window.operator = { invoke: vi.fn(async () => ({ ok: true })), on: vi.fn(() => () => undefined) };
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
+
+it("renders real Claude post-Steer HTTP events in the Electron transcript before completion without reloading", async () => {
+  const h = await createClaudeSteerStreamHarness();
+  const source = createCanonicalChatEventSource({ openStream: h.openStream });
+  const client = createCanonicalChatWorkspaceClient();
+  const initial = await h.getDetail();
+  // A frozen initial snapshot makes HTTP content delivery necessary for progress.
+  vi.mocked(client.list).mockResolvedValue({ items: [initial.record] });
+  vi.mocked(client.getDetail).mockResolvedValue(initial);
+  // Completion acknowledgement is not part of this streaming seam. Avoid its
+  // separate user-state invalidation triggering an unrelated detail refresh.
+  client.acknowledgeCompletion = async () => (await h.getDetail()).record;
+  try {
+    render(<CanonicalChatWorkspace client={client} eventSource={source} catalog={h.catalog}
+      projectId={null} initialChatId={h.chatId} initialView="conversation" active />);
+    await act(async () => { await source.start(); });
+    await waitFor(() => expect(h.frames.at(-1)?.type).toBe("chat.replay.end"));
+    await screen.findByRole("log");
+    let admitted!: Awaited<ReturnType<typeof h.admit>>;
+    await act(async () => { admitted = await h.admit(); });
+    await waitFor(() => expect(h.children).toHaveLength(1));
+    await act(async () => h.children[0]!.text(BEFORE_STEER));
+    await waitFor(() => expect(within(screen.getByRole("log")).getByText(BEFORE_STEER)).toBeTruthy());
+    expect(h.children[0]!.exited).toBe(false);
+
+    // This is an ingestion test: exercise public Steer, not a fabricated UI button.
+    await act(async () => {
+      expect(await h.steer(admitted.run.id, admitted.turn.id)).toMatchObject({ steering: "accepted" });
+    });
+    await waitFor(() => expect(h.children).toHaveLength(2));
+    const resumed = h.children[1]!;
+    await act(async () => { resumed.text(AFTER_STEER, true); resumed.tool(); });
+    await waitFor(() => {
+      const log = within(screen.getByRole("log"));
+      expect(log.getByText(AFTER_STEER)).toBeTruthy();
+      expect(log.getByText("src/streaming.ts")).toBeTruthy();
+    });
+    const log = within(screen.getByRole("log"));
+    expect(log.getByText(STEER_REQUEST)).toBeTruthy();
+    expect(log.queryByText(FINAL_TEXT)).toBeNull();
+    expect(screen.getByRole("button", { name: "Stop" })).toBeTruthy();
+    expect(resumed.resultReleased).toBe(false);
+    expect(resumed.exited).toBe(false);
+    expect(client.getDetail).toHaveBeenCalledTimes(1);
+    expect(h.openStream).toHaveBeenCalledTimes(1);
+    expect(log.getAllByText(AFTER_STEER)).toHaveLength(1);
+    const transcript = screen.getByRole("log").textContent!;
+    expect(transcript.indexOf(BEFORE_STEER)).toBeLessThan(transcript.indexOf(STEER_REQUEST));
+    expect(transcript.indexOf(STEER_REQUEST)).toBeLessThan(transcript.indexOf(AFTER_STEER));
+
+    await act(async () => { resumed.finish(); await h.orchestrator.drain(); });
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Stop" })).toBeNull());
+    // Completed intermediate work is intentionally collapsed into its receipt.
+    await waitFor(() => expect(screen.getByRole("log").textContent).toContain(FINAL_TEXT));
+    expect(screen.getByRole("log").textContent!.split(FINAL_TEXT)).toHaveLength(2);
+    expect(client.getDetail).toHaveBeenCalledTimes(1);
+  } finally {
+    cleanup(); source.dispose(); await h.close();
+  }
+}, 20_000);

--- a/tests/desktop/chat-hermes-startup-transcript.test.tsx
+++ b/tests/desktop/chat-hermes-startup-transcript.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment gateway-renderer
+import React from "react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { CanonicalChatWorkspace } from "@desktop/renderer/src/features/chat/CanonicalChatWorkspace";
+import { useBoard } from "@desktop/renderer/src/stores/board";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { createCanonicalChatWorkspaceClient } from "./canonical-chat-workspace-test-utils";
+import { hermesStartupStreamHarness } from "../helpers/hermes-startup-stream-harness";
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
+  useBoard.setState(useBoard.getInitialState(), true);
+  useConnection.setState(useConnection.getInitialState(), true);
+  window.operator = { invoke: vi.fn(async () => ({ ok: true })), on: vi.fn(() => () => undefined) };
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
+
+it("renders Hermes Reconnecting from HTTP before success without a failed-run flash or snapshot refresh", async () => {
+  const h = await hermesStartupStreamHarness({ timeouts: 1 });
+  const client = createCanonicalChatWorkspaceClient();
+  const initial = await h.getDetail();
+  vi.mocked(client.list).mockResolvedValue({ items: [initial.record] });
+  vi.mocked(client.getDetail).mockResolvedValue(initial);
+  client.acknowledgeCompletion = async () => (await h.getDetail()).record;
+  try {
+    render(<CanonicalChatWorkspace client={client} eventSource={h.source} catalog={h.catalog}
+      projectId={null} initialChatId={h.chatId} initialView="conversation" active />);
+    await act(async () => { await h.source.start(); });
+    await screen.findByRole("log");
+    await act(async () => { await h.admit(); });
+    await waitFor(() => expect(within(screen.getByRole("log")).getByText("Reconnecting… 1/5")).toBeTruthy());
+    expect(screen.queryByText(/Agent work failed|connection failed/)).toBeNull();
+    expect(screen.getByRole("button", { name: "Stop" })).toBeTruthy();
+    expect(client.getDetail).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(h.process.requests().filter((request) => request.method === "prompt.submit")).toHaveLength(1));
+    await act(async () => {
+      h.process.children[1]!.event("message.complete", { text: "Startup recovered once.", status: "complete" });
+      await h.orchestrator.drain();
+    });
+    await waitFor(() => expect(within(screen.getByRole("log")).getByText("Startup recovered once.")).toBeTruthy());
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+    expect(client.getDetail).toHaveBeenCalledTimes(1);
+  } finally { cleanup(); await h.close(); }
+});

--- a/tests/desktop/codex-startup-transcript.test.tsx
+++ b/tests/desktop/codex-startup-transcript.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment gateway-renderer
+import React from "react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { CanonicalChatWorkspace } from "@desktop/renderer/src/features/chat/CanonicalChatWorkspace";
+import { useBoard } from "@desktop/renderer/src/stores/board";
+import { useConnection } from "@desktop/renderer/src/stores/connection";
+import { createCanonicalChatEventSource } from "../../packages/ui/src/canonical-chat-event-source";
+import { createCanonicalChatWorkspaceClient } from "./canonical-chat-workspace-test-utils";
+import { createCodexStartupStreamHarness } from "../helpers/codex-startup-stream-harness";
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
+  useBoard.setState(useBoard.getInitialState(), true);
+  useConnection.setState(useConnection.getInitialState(), true);
+  window.operator = { invoke: vi.fn(async () => ({ ok: true })), on: vi.fn(() => () => undefined) };
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
+
+it("renders live Codex Reconnecting before prompt admission and recovers without reload", async () => {
+  const h = await createCodexStartupStreamHarness();
+  const source = createCanonicalChatEventSource({ openStream: h.openStream });
+  const client = createCanonicalChatWorkspaceClient();
+  const initial = await h.getDetail();
+  vi.mocked(client.list).mockResolvedValue({ items: [initial.record] });
+  vi.mocked(client.getDetail).mockResolvedValue(initial);
+  client.acknowledgeCompletion = async () => (await h.getDetail()).record;
+  try {
+    render(<CanonicalChatWorkspace client={client} eventSource={source} catalog={h.catalog}
+      projectId={null} initialChatId={h.chatId} initialView="conversation" active />);
+    await act(async () => { await source.start(); });
+    await waitFor(() => expect(h.frames.at(-1)?.type).toBe("chat.replay.end"));
+    await screen.findByRole("log");
+    await act(async () => { await h.admit(); });
+    const log = within(screen.getByRole("log"));
+    await waitFor(() => expect(log.getByText("Reconnecting… 1/5")).toBeTruthy(), { timeout: 4_000 });
+    expect(screen.getByRole("button", { name: "Stop" })).toBeTruthy();
+    expect(log.queryByRole("button", { name: /retry/i })).toBeNull();
+    expect((await h.getRunner()!.requests()).some((request) => request.method === "turn/start")).toBe(false);
+    await act(async () => { await h.release(); });
+    await waitFor(() => expect(log.getByText("Started exactly once.")).toBeTruthy(), { timeout: 4_000 });
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Stop" })).toBeNull());
+    expect(log.getAllByText("Started exactly once.")).toHaveLength(1);
+    expect(client.getDetail).toHaveBeenCalledTimes(1);
+    expect(h.openStream).toHaveBeenCalledTimes(1);
+  } finally { cleanup(); source.dispose(); await h.close(); }
+}, 15_000);

--- a/tests/fixtures/codex-startup-process-stub.mjs
+++ b/tests/fixtures/codex-startup-process-stub.mjs
@@ -1,0 +1,45 @@
+import { EventEmitter } from "node:events";
+import { appendFile } from "node:fs/promises";
+import { createRequire, syncBuiltinESMExports } from "node:module";
+import { PassThrough } from "node:stream";
+
+// Controlled external process boundary for otherwise unobservable close races.
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process");
+let spawned = 0;
+childProcess.spawn = () => {
+  const attempt = ++spawned;
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(), stdout: new PassThrough(), stderr: new PassThrough(),
+    pid: 100_000 + attempt, exitCode: null, signalCode: null,
+  });
+  let closeScheduled = false;
+  let writes = Promise.resolve();
+  child.stdin.on("data", (chunk) => {
+    const message = JSON.parse(chunk.toString());
+    writes = writes.then(() => appendFile(process.env.TEST_CODEX_STARTUP_REQUESTS,
+      `${JSON.stringify({ attempt, method: message.method })}\n`));
+    if (process.env.TEST_CODEX_STARTUP_MODE === "stdin_error") {
+      queueMicrotask(() => child.stdin.emit("error", new Error("EPIPE private transport")));
+    }
+    if (process.env.TEST_CODEX_STARTUP_MODE === "ready_abort") {
+      child.stdout.write(`${JSON.stringify({ id: message.id, result: { userAgent: "test" } })}\n`);
+      queueMicrotask(() => process.emit("SIGTERM"));
+    }
+  });
+  child.kill = () => {
+    if (!closeScheduled) {
+      closeScheduled = true;
+      setTimeout(async () => {
+        await writes;
+        child.exitCode = 0;
+        child.stdout.end(); child.stderr.end(); child.stdin.end();
+        child.emit("close", 0, null);
+      }, ["stdin_error", "ready_abort"].includes(process.env.TEST_CODEX_STARTUP_MODE) ? 20 : 6_500);
+    }
+    if (process.env.TEST_CODEX_STARTUP_MODE === "kill_error") throw new Error("EPERM private process detail");
+    return true;
+  };
+  return child;
+};
+syncBuiltinESMExports();

--- a/tests/fixtures/codex-startup-process.mjs
+++ b/tests/fixtures/codex-startup-process.mjs
@@ -1,0 +1,57 @@
+import { appendFile, readFile, writeFile } from "node:fs/promises";
+import { createInterface } from "node:readline";
+
+const statePath = process.env.TEST_CODEX_STARTUP_STATE;
+const requestsPath = process.env.TEST_CODEX_STARTUP_REQUESTS;
+let previous = 0;
+try { previous = Number(await readFile(statePath, "utf8")); }
+catch (error) { if (error.code !== "ENOENT") throw error; }
+const attempt = previous + 1;
+await writeFile(statePath, String(attempt));
+const failures = Number(process.env.TEST_CODEX_STARTUP_FAILURES ?? 1);
+const mode = process.env.TEST_CODEX_STARTUP_MODE;
+let initializeId;
+const input = createInterface({ input: process.stdin, crlfDelay: Infinity });
+process.on("SIGTERM", () => {
+  if (mode === "late_ready") {
+    console.log(JSON.stringify({ id: initializeId, result: { userAgent: "late" } }));
+    console.log(JSON.stringify({ method: "item/agentMessage/delta", params: {
+      turnId: "late_turn", itemId: "late_item", delta: "Discard late startup output" } }));
+  }
+  setTimeout(() => {
+    void appendFile(requestsPath, `${JSON.stringify({ attempt, event: "stopped" })}\n`).then(() => process.exit(0));
+  }, mode === "late_ready" ? 100 : 0);
+});
+for await (const line of input) {
+  const message = JSON.parse(line);
+  await appendFile(requestsPath, `${JSON.stringify({ attempt, method: message.method })}\n`);
+  if (message.method === "initialize") {
+    initializeId = message.id;
+    if (mode === "rejected") {
+      console.log(JSON.stringify({ id: message.id, error: { message: "private authentication rejected", code: -1 } }));
+      continue;
+    }
+    if (mode === "malformed") { console.log("malformed initialization"); continue; }
+    if (mode === "no_result") { console.log(JSON.stringify({ id: message.id })); continue; }
+    if (mode === "wrong_id" && attempt <= failures) {
+      console.log(JSON.stringify({ id: "unrelated_response", result: {} })); continue;
+    }
+    if (attempt <= failures) continue;
+    if (process.env.TEST_CODEX_STARTUP_READY_GATE) {
+      for (;;) {
+        try { await readFile(process.env.TEST_CODEX_STARTUP_READY_GATE); break; }
+        catch (error) { if (error.code !== "ENOENT") throw error; }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+    }
+    console.log(JSON.stringify({ id: message.id, result: { userAgent: "test" } }));
+  } else if (message.method === "thread/start") {
+    console.log(JSON.stringify({ id: message.id, result: { thread: { id: "startup_thread" } } }));
+  } else if (message.method === "turn/start") {
+    console.log(JSON.stringify({ id: message.id, result: { turn: { id: "startup_turn" } } }));
+    console.log(JSON.stringify({ method: "item/agentMessage/delta", params: {
+      turnId: "startup_turn", itemId: "startup_message", delta: "Started exactly once." } }));
+    console.log(JSON.stringify({ method: "turn/completed", params: { turn: { status: "completed" } } }));
+    process.exit(0);
+  }
+}

--- a/tests/gateway/chat-claude-quota-stream.test.ts
+++ b/tests/gateway/chat-claude-quota-stream.test.ts
@@ -1,0 +1,39 @@
+import { expect, it, vi } from "vitest";
+import { contentFrames, createClaudeSteerStreamHarness } from "../helpers/claude-steer-stream-harness";
+
+it.each(["assistant", "result"])("publishes one safe %s quota failure over live HTTP SSE", async (envelope) => {
+  const h = await createClaudeSteerStreamHarness();
+  const controller = new AbortController();
+  const response = await h.openStream({ signal: controller.signal });
+  const reader = response.body!.getReader();
+  const reading = (async () => { while (!(await reader.read()).done) { /* Consume the real wire. */ } })();
+  try {
+    await vi.waitFor(() => expect(h.frames.at(-1)?.type).toBe("chat.replay.end"));
+    await h.admit();
+    await vi.waitFor(() => expect(h.children).toHaveLength(1));
+    const text = "You've hit your weekly limit · resets Sep 14, 1pm (unverified timezone) /opt/private token=private";
+    h.children[0]!.line(envelope === "assistant"
+      ? { type: "assistant", error: "rate_limit", isApiErrorMessage: true,
+          message: { role: "assistant", content: [{ type: "text", text }] } }
+      : { type: "result", is_error: true, result: text });
+    h.children[0]!.exit(1);
+    await h.orchestrator.drain();
+    await vi.waitFor(() => expect(contentFrames(h.frames).some((frame) => frame.event.eventType === "run.failed")).toBe(true));
+    const terminal = contentFrames(h.frames).filter((frame) => frame.event.eventType === "run.failed");
+    expect(terminal).toHaveLength(1);
+    const errors = terminal.flatMap((frame) => frame.content.activities ?? [])
+      .filter((activity) => activity.type === "run.error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ error: {
+      code: "run_failed", safeMessage: "Your usage limit has been reached. Try again after your allowance resets.",
+      retryable: false,
+    } });
+    expect(JSON.stringify(h.frames)).not.toMatch(/Check its connection|Reconnecting|\/opt\/private|token=private|unverified timezone/);
+    expect(h.spawn).toHaveBeenCalledTimes(1);
+  } finally {
+    controller.abort();
+    await reader.cancel();
+    await reading;
+    await h.close();
+  }
+}, 20_000);

--- a/tests/gateway/chat-claude-quota.test.ts
+++ b/tests/gateway/chat-claude-quota.test.ts
@@ -1,0 +1,162 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createClaudeChatProviderAdapter } from "../../packages/gateway/src/chat/claude-provider-adapter.js";
+import type { CanonicalProviderRunEvent } from "../../packages/gateway/src/chat/provider-adapter.js";
+
+const input = {
+  owner: { type: "personal" as const, ownerId: "owner_quota" },
+  chatId: "chat_quota", turnId: "turn_quota", runId: "run_quota",
+  prompt: "hello", parts: [{ type: "text" as const, text: "hello" }],
+  selection: { instanceId: "claude_code_default", model: "opus" },
+  interactionMode: "default", permissionMode: "supervised",
+  signal: new AbortController().signal,
+};
+
+function assistantError(text: string) {
+  return { type: "assistant", error: "rate_limit", isApiErrorMessage: true,
+    message: { role: "assistant", content: [{ type: "text", text }] } };
+}
+
+async function replay(lines: unknown[], exitCode = 1, cancel = false) {
+  const controller = new AbortController();
+  const spawnFn = vi.fn(() => {
+    const child = Object.assign(new EventEmitter(), {
+      stdout: new EventEmitter(), stderr: new EventEmitter(), kill: vi.fn(),
+    });
+    queueMicrotask(() => {
+      for (const line of lines) child.stdout.emit("data", Buffer.from(`${JSON.stringify(line)}\n`));
+      if (cancel) controller.abort();
+      child.emit("exit", exitCode, null);
+    });
+    return child;
+  });
+  const adapter = createClaudeChatProviderAdapter({ homePath: "/safe/home", spawnFn,
+    resolveCredentialEnv: async () => ({}) });
+  const events: CanonicalProviderRunEvent[] = [];
+  for await (const event of adapter.start({ ...input, signal: controller.signal })) events.push(event);
+  return { events, spawnFn };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("Claude usage-limit failure through the adapter", () => {
+  it.each([
+    { type: "result", is_error: true, result: "Request failed", errors: ["You've hit your weekly limit"] },
+    { type: "result", is_error: true, errors: ["Request failed", "You've hit your weekly limit"] },
+    { ...assistantError("ignored"), message: { role: "assistant", content: [
+      { type: "text", text: "Request failed" }, { type: "text", text: "You've hit your weekly limit" },
+    ] } },
+    { ...assistantError("ignored"), message: { role: "assistant", content: [
+      { type: "text", text: "Too many requests" }, { type: "text", text: "You've hit your weekly limit" },
+    ] } },
+  ])("recognizes quota evidence independently in a mixed error envelope %#", async (line) => {
+    const { events } = await replay([line]);
+    expect(events).toEqual([{ type: "run.completed", outcome: "failed", error: {
+      code: "run_failed", safeMessage: "Your usage limit has been reached. Try again after your allowance resets.",
+      retryable: false,
+    } }]);
+  });
+
+  it.each([
+    "", " · resets Sep 14, 1pm", " · resets Sep 14, 1pm (PST)",
+    " · resets Sep 31, 1pm (UTC)", " · resets Sep 14, 13pm (UTC)",
+    " · resets Sep 14, 0am (UTC)", " · resets Sep 14, 1:99pm (UTC)",
+    " · resets Sep 9, 1pm (UTC)", " · resets Oct 14, 1pm (UTC)",
+    " · resets tomorrow", " · resets Sep 14, 1pm (UTC) token=private /opt/private",
+  ])("keeps reset metadata absent or ambiguous (%s) generic and private", async (suffix) => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-09-10T08:00:00Z"));
+    const { events } = await replay([assistantError(`You've hit your weekly limit${suffix}`)]);
+    expect(events).toEqual([{ type: "run.completed", outcome: "failed", error: {
+      code: "run_failed", safeMessage: "Your usage limit has been reached. Try again after your allowance resets.",
+      retryable: false,
+    } }]);
+  });
+
+  it("validates December to January rollover without guessing an expired year", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-12-30T08:00:00Z"));
+    const { events } = await replay([assistantError("You've hit your weekly limit · resets Jan 2, 12:15am (UTC)")]);
+    expect(events.at(-1)).toMatchObject({ error: {
+      safeMessage: "Your usage limit has been reached. Try again after 2027-01-02 00:15 UTC.", retryable: false,
+    } });
+  });
+
+  it.each([
+    { ...assistantError("You've hit your weekly limit"), isApiErrorMessage: false },
+    { ...assistantError("You've hit your weekly limit"), error: "unknown" },
+    { ...assistantError("You've hit your weekly limit"), message: { content: "invalid" } },
+    assistantError(`You've hit your weekly limit${"x".repeat(4_001)}`),
+  ])("does not trust malformed or non-API assistant error evidence %#", async (line) => {
+    const { events } = await replay([line]);
+    expect(events.at(-1)).toMatchObject({ outcome: "failed", error: { retryable: true } });
+    expect(JSON.stringify(events)).not.toContain("You've hit your weekly limit");
+  });
+
+  it("does not classify successful model-authored quota prose as an account failure", async () => {
+    const { events } = await replay([{ type: "result", subtype: "success", is_error: false,
+      result: "You've hit your weekly limit" }], 0);
+    expect(events.at(-1)).toEqual({ type: "run.completed", outcome: "completed" });
+  });
+
+  it("settles cancellation once without offering quota retry", async () => {
+    const { events, spawnFn } = await replay([assistantError("You've hit your weekly limit")], 1, true);
+    expect(events).toEqual([{ type: "run.completed", outcome: "aborted" }]);
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles assistant plus result quota evidence once", async () => {
+    const { events } = await replay([assistantError("You've hit your weekly limit"),
+      { type: "result", is_error: true, result: "You've hit your weekly limit" }]);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ outcome: "failed", error: { retryable: false } });
+  });
+  it("does not downgrade quota exhaustion when a later error contains temporary throttling", async () => {
+    const { events } = await replay([
+      assistantError("You've hit your weekly limit"),
+      assistantError("Too many requests. Please try again shortly."),
+    ]);
+    expect(events.at(-1)).toMatchObject({ outcome: "failed", error: { retryable: false,
+      safeMessage: "Your usage limit has been reached. Try again after your allowance resets." } });
+  });
+  it("retains bounded errors-array evidence from an error result", async () => {
+    const { events } = await replay([{ type: "result", is_error: true, subtype: "error_during_execution",
+      errors: ["You've hit your weekly limit"] }]);
+    expect(events).toEqual([{ type: "run.completed", outcome: "failed", error: {
+      code: "run_failed", safeMessage: "Your usage limit has been reached. Try again after your allowance resets.",
+      retryable: false,
+    } }]);
+  });
+  it("keeps temporary native throttling distinct from exhausted allowance", async () => {
+    const { events } = await replay([assistantError("Too many requests. Please try again shortly.")]);
+    expect(events).toEqual([{ type: "run.completed", outcome: "failed", error: {
+      code: "service_unavailable", safeMessage: "Requests are temporarily rate limited. Wait a moment and try again.",
+      retryable: true, recoveryActions: ["retry"],
+    } }]);
+  });
+  it("normalizes the native reset date using the current execution date and explicit UTC timezone", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-09-10T08:00:00Z"));
+    const { events } = await replay([assistantError("You've hit your weekly limit · resets Sep 14, 1pm (UTC)")]);
+    expect(events).toEqual([{ type: "run.completed", outcome: "failed", error: {
+      code: "run_failed", safeMessage: "Your usage limit has been reached. Try again after 2026-09-14 13:00 UTC.",
+      retryable: false,
+    } }]);
+  });
+  it("retains explicit result-error quota evidence without an assistant envelope", async () => {
+    const { events } = await replay([{ type: "result", is_error: true, subtype: "error_during_execution",
+      result: "You've hit your weekly limit" }], 0);
+    expect(events).toEqual([{ type: "run.completed", outcome: "failed", error: {
+      code: "run_failed", safeMessage: "Your usage limit has been reached. Try again after your allowance resets.",
+      retryable: false,
+    } }]);
+  });
+  it("reports native assistant-only weekly exhaustion without connection advice or immediate retry", async () => {
+    const { events, spawnFn } = await replay([assistantError("You've hit your weekly limit")]);
+    expect(events).toEqual([{ type: "run.completed", outcome: "failed", error: {
+      code: "run_failed", safeMessage: "Your usage limit has been reached. Try again after your allowance resets.",
+      retryable: false,
+    } }]);
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/gateway/chat-claude-steer-live-stream.test.ts
+++ b/tests/gateway/chat-claude-steer-live-stream.test.ts
@@ -1,0 +1,54 @@
+import { expect, it, vi } from "vitest";
+import { AFTER_STEER, BEFORE_STEER, FINAL_TEXT, STEER_REQUEST, contentFrames,
+  createClaudeSteerStreamHarness, messageFrame } from "../helpers/claude-steer-stream-harness";
+
+it("publishes accepted Claude Steer text and tool progress over HTTP before result or exit", async () => {
+  const h = await createClaudeSteerStreamHarness();
+  const controller = new AbortController();
+  const response = await h.openStream({ signal: controller.signal });
+  const reader = response.body!.getReader();
+  const reading = (async () => { while (!(await reader.read()).done) { /* Observe wire frames in the harness. */ } })();
+  try {
+    await vi.waitFor(() => expect(h.frames.at(-1)?.type).toBe("chat.replay.end"));
+    const admitted = await h.admit();
+    await vi.waitFor(() => expect(h.children).toHaveLength(1));
+    h.children[0]!.text(BEFORE_STEER);
+    await vi.waitFor(() => expect(messageFrame(h.frames, BEFORE_STEER)).toBeDefined());
+    expect(h.children[0]!.exited).toBe(false);
+
+    expect(await h.steer(admitted.run.id, admitted.turn.id)).toMatchObject({ steering: "accepted" });
+    await vi.waitFor(() => expect(h.children).toHaveLength(2));
+    expect(h.children[0]!.exited).toBe(true);
+    expect(h.spawn.mock.calls[1]?.[1]).toEqual(expect.arrayContaining([
+      "--resume", "claude_stream_session", "--include-partial-messages", "--", STEER_REQUEST,
+    ]));
+    const resumed = h.children[1]!;
+    resumed.text(AFTER_STEER, true);
+    resumed.tool();
+    await vi.waitFor(() => {
+      expect(messageFrame(h.frames, AFTER_STEER)).toBeDefined();
+      expect(contentFrames(h.frames).flatMap((frame) => frame.content.activities ?? []))
+        .toContainEqual(expect.objectContaining({ preview: "src/streaming.ts" }));
+    });
+    const before = messageFrame(h.frames, BEFORE_STEER)!.content.messageDelta!.message;
+    const afterFrame = messageFrame(h.frames, AFTER_STEER)!;
+    const after = afterFrame.content.messageDelta!.message;
+    expect(after.id).not.toBe(before.id);
+    expect(after.seq).toBeGreaterThan(before.seq);
+    expect(afterFrame.content.record.activeRun).toMatchObject({ runId: admitted.run.id, status: "running" });
+    expect(resumed.resultReleased).toBe(false);
+    expect(resumed.exited).toBe(false);
+    expect(messageFrame(h.frames, FINAL_TEXT)).toBeUndefined();
+
+    resumed.finish();
+    await h.orchestrator.drain();
+    await vi.waitFor(() => expect(contentFrames(h.frames).at(-1)?.content.record.activeRun).toBeUndefined());
+    expect(contentFrames(h.frames).filter((frame) => frame.event.eventType === "run.completed")).toHaveLength(1);
+    expect(messageFrame(h.frames, FINAL_TEXT)).toBeDefined();
+  } finally {
+    controller.abort();
+    await reader.cancel();
+    await reading;
+    await h.close();
+  }
+}, 20_000);

--- a/tests/gateway/chat-dispatch-ownership.test.ts
+++ b/tests/gateway/chat-dispatch-ownership.test.ts
@@ -1,0 +1,48 @@
+import { expect, it } from "vitest";
+import { dispatchAdmissionKey, hasStoppingChatExecution } from "../../packages/gateway/src/chat/dispatch-ownership";
+
+const owner = { type: "personal" as const, ownerId: "owner_execution" };
+
+it("rechecks retained execution ownership after cancellation changes during admission", () => {
+  const controller = new AbortController();
+  const executions = [{ owner, chatId: "chat_execution", controller,
+    admissionKey: dispatchAdmissionKey("turn", "req_original") }];
+  expect(hasStoppingChatExecution(executions, owner, "chat_execution")).toBe(false);
+  controller.abort();
+  expect(hasStoppingChatExecution(executions, owner, "chat_execution")).toBe(true);
+  expect(hasStoppingChatExecution([], owner, "chat_execution")).toBe(false);
+});
+
+it("allows an exact admitted request replay but never a new turn or retry through cleanup", () => {
+  const controller = new AbortController();
+  controller.abort();
+  const original = dispatchAdmissionKey("turn", "req_original");
+  const executions = [{ owner, chatId: "chat_execution", controller, admissionKey: original }];
+  expect(hasStoppingChatExecution(executions, owner, "chat_execution", original)).toBe(false);
+  for (const key of [dispatchAdmissionKey("turn", "req_new"), dispatchAdmissionKey("retry", "req_original", "turn_original")]) {
+    expect(hasStoppingChatExecution(executions, owner, "chat_execution", key)).toBe(true);
+  }
+  // The last pre-dispatch check permits no new execution, including callers
+  // that reused a request key but were not reported already-accepted by storage.
+  expect(hasStoppingChatExecution(executions, owner, "chat_execution")).toBe(true);
+});
+
+it("scopes retry replay keys to their turn and retains unknown queued admission ownership", () => {
+  const controller = new AbortController();
+  controller.abort();
+  const original = dispatchAdmissionKey("retry", "req_retry", "turn_original");
+  expect(hasStoppingChatExecution([{ owner, chatId: "chat_execution", controller, admissionKey: original }],
+    owner, "chat_execution", original)).toBe(false);
+  expect(hasStoppingChatExecution([{ owner, chatId: "chat_execution", controller, admissionKey: original }],
+    owner, "chat_execution", dispatchAdmissionKey("retry", "req_retry", "turn_other"))).toBe(true);
+  expect(hasStoppingChatExecution([{ owner, chatId: "chat_execution", controller }],
+    owner, "chat_execution", original)).toBe(true);
+});
+
+it("does not block an unrelated owner's or Chat's execution", () => {
+  const controller = new AbortController();
+  controller.abort();
+  const executions = [{ owner, chatId: "chat_execution", controller }];
+  expect(hasStoppingChatExecution(executions, owner, "chat_other")).toBe(false);
+  expect(hasStoppingChatExecution(executions, { ...owner, ownerId: "owner_other" }, "chat_execution")).toBe(false);
+});

--- a/tests/gateway/chat-hermes-provider.test.ts
+++ b/tests/gateway/chat-hermes-provider.test.ts
@@ -1705,21 +1705,6 @@ describe("Hermes canonical Chat Provider adapter", () => {
     expect(gateway.process.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
-  it("bounds gateway startup instead of waiting forever for a ready frame", async () => {
-    const gateway = fakeGateway({ emitReady: false });
-    const adapter = createHermesChatProviderAdapter({
-      homePath: "/home/matrix/home",
-      spawnFn: gateway.spawnFn,
-      readyTimeoutMs: 5,
-    });
-
-    expect(await collect(adapter.start(baseInput))).toEqual([
-      expect.objectContaining({ type: "run.completed", outcome: "failed" }),
-    ]);
-    expect(gateway.process.kill).toHaveBeenCalledWith("SIGTERM");
-    expect(gateway.requests).toEqual([]);
-  });
-
   it("bounds JSON-RPC requests instead of waiting forever for a response", async () => {
     const gateway = fakeGateway({ ignoreMethods: ["session.create"] });
     const adapter = createHermesChatProviderAdapter({

--- a/tests/gateway/chat-hermes-startup-retry.test.ts
+++ b/tests/gateway/chat-hermes-startup-retry.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { createHermesChatProviderAdapter } from "../../packages/gateway/src/chat/hermes-provider-adapter";
+import type { CanonicalProviderRunEvent } from "../../packages/gateway/src/chat/provider-adapter";
+import { hermesStartupInput, hermesStartupProcesses } from "../helpers/hermes-startup-process";
+
+afterEach(() => vi.useRealTimers());
+
+function start(options: Parameters<typeof hermesStartupProcesses>[0] = {}, runOptions: {
+  timeoutMs?: number; aborted?: boolean;
+} = {}) {
+  const fixture = hermesStartupProcesses(options);
+  const controller = new AbortController();
+  if (runOptions.aborted) controller.abort();
+  const adapter = createHermesChatProviderAdapter({ homePath: "/safe/home", spawnFn: fixture.spawnFn,
+    readyTimeoutMs: 10, requestTimeoutMs: 10, timeoutMs: runOptions.timeoutMs });
+  const events: CanonicalProviderRunEvent[] = [];
+  let settled = false;
+  const done = (async () => {
+    for await (const event of adapter.start({ ...hermesStartupInput, signal: controller.signal })) events.push(event);
+  })().then(() => undefined, (error: unknown) => error).finally(() => { settled = true; });
+  return { fixture, controller, events, done, get settled() { return settled; } };
+}
+
+function reconnects(events: CanonicalProviderRunEvent[]) {
+  return events.filter((event) => event.type === "agent.activity"
+    && event.label.startsWith("Reconnecting") && event.status === "running");
+}
+
+it("reconnects after confirmed pre-prompt timeout and submits one Hermes prompt", async () => {
+  vi.useFakeTimers();
+  const fixture = hermesStartupProcesses({ timeouts: 1 });
+  const controller = new AbortController();
+  const adapter = createHermesChatProviderAdapter({ homePath: "/safe/home",
+    spawnFn: fixture.spawnFn, readyTimeoutMs: 10 });
+  const events: CanonicalProviderRunEvent[] = [];
+  const running = (async () => {
+    for await (const event of adapter.start({ ...hermesStartupInput, signal: controller.signal })) events.push(event);
+  })();
+  try {
+    await vi.advanceTimersByTimeAsync(11);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "agent.activity", kind: "phase", label: "Reconnecting… 1/5", status: "running",
+    }));
+    expect(events.some((event) => event.type === "run.completed")).toBe(false);
+    expect(fixture.children[0]!.exited).toBe(true);
+    expect(fixture.requests()).toEqual([]);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(fixture.children).toHaveLength(2);
+    expect(fixture.requests().filter((request) => request.method === "session.create")).toHaveLength(1);
+    expect(fixture.requests().filter((request) => request.method === "prompt.submit")).toHaveLength(1);
+    fixture.children[1]!.event("message.complete", { text: "Inspection complete.", status: "complete" });
+    await running;
+    expect(events.filter((event) => event.type === "run.completed"))
+      .toEqual([{ type: "run.completed", outcome: "completed" }]);
+  } finally {
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await running;
+  }
+});
+
+it("succeeds on the fifth Hermes retry without duplicate prompt admission", async () => {
+  vi.useFakeTimers();
+  const run = start({ timeouts: 5 });
+  await vi.advanceTimersByTimeAsync(8_000);
+  expect(reconnects(run.events).map((event) => "label" in event && event.label)).toEqual([
+    "Reconnecting… 1/5", "Reconnecting… 2/5", "Reconnecting… 3/5", "Reconnecting… 4/5", "Reconnecting… 5/5",
+  ]);
+  expect(run.fixture.children).toHaveLength(6);
+  expect(run.fixture.children.slice(0, 5).every((child) => child.exited)).toBe(true);
+  expect(run.fixture.requests().filter((request) => request.method === "prompt.submit")).toHaveLength(1);
+  expect(run.events.some((event) => event.type === "run.completed")).toBe(false);
+  run.fixture.children[5]!.event("message.complete", { text: "Recovered once.", status: "complete" });
+  await run.done;
+  expect(run.events.filter((event) => event.type === "run.completed"))
+    .toEqual([{ type: "run.completed", outcome: "completed" }]);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("exhausts exactly five Hermes retries and publishes one safe terminal error", async () => {
+  vi.useFakeTimers();
+  const run = start({ timeouts: 6 });
+  await vi.advanceTimersByTimeAsync(8_000);
+  await run.done;
+  expect(run.fixture.children).toHaveLength(6);
+  expect(run.fixture.children.every((child) => child.exited)).toBe(true);
+  expect(run.fixture.requests()).toEqual([]);
+  expect(reconnects(run.events)).toHaveLength(5);
+  expect(run.events.filter((event) => event.type === "run.completed"))
+    .toEqual([expect.objectContaining({ outcome: "failed", error: expect.objectContaining({
+      safeMessage: "The Hermes connection failed. Try again.",
+    }) })]);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it.each(["backoff", "ready", "already_aborted"] as const)("cancels Hermes startup during %s without another child", async (phase) => {
+  vi.useFakeTimers();
+  const run = start({ timeouts: 6 }, { aborted: phase === "already_aborted" });
+  await vi.advanceTimersByTimeAsync(phase === "backoff" ? 11 : 0);
+  run.controller.abort();
+  await vi.advanceTimersByTimeAsync(8_000);
+  await run.done;
+  expect(run.fixture.children).toHaveLength(phase === "already_aborted" ? 0 : 1);
+  expect(run.fixture.requests()).toEqual([]);
+  expect(run.events.filter((event) => event.type === "run.completed"))
+    .toEqual([{ type: "run.completed", outcome: "aborted" }]);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("keeps unconfirmed startup cleanup pending and ignores late ready/output until actual exit", async () => {
+  vi.useFakeTimers();
+  const run = start({ timeouts: 6, confirmExit: false });
+  await vi.advanceTimersByTimeAsync(2_000);
+  expect(run.fixture.children).toHaveLength(1);
+  expect(run.fixture.children[0]!.process.kill).toHaveBeenCalledWith("SIGKILL");
+  expect(run.settled).toBe(false);
+  expect(reconnects(run.events)).toHaveLength(0);
+  expect(run.events).toContainEqual(expect.objectContaining({ type: "agent.activity",
+    label: "Stopping", summary: "The Run could not be stopped. Its status is being checked.", status: "running" }));
+  run.fixture.children[0]!.event("gateway.ready");
+  run.fixture.children[0]!.event("message.delta", { text: "Late unowned output" });
+  run.controller.abort();
+  await vi.advanceTimersByTimeAsync(8_000);
+  expect(run.settled).toBe(false);
+  expect(run.fixture.requests()).toEqual([]);
+  expect(run.fixture.children).toHaveLength(1);
+  expect(run.events.some((event) => event.type === "assistant.delta" || event.type === "run.completed")).toBe(false);
+  run.fixture.children[0]!.exit();
+  expect(await run.done).toBeUndefined();
+  expect(run.events.filter((event) => event.type === "run.completed"))
+    .toEqual([{ type: "run.completed", outcome: "aborted" }]);
+  expect(run.settled).toBe(true);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it.each(["error", "protocol", "exit"] as const)("does not retry permanent Hermes startup %s", async (startupFailure) => {
+  vi.useFakeTimers();
+  const run = start({ startupFailure });
+  await vi.advanceTimersByTimeAsync(8_000);
+  await run.done;
+  expect(run.fixture.children).toHaveLength(1);
+  expect(run.fixture.requests()).toEqual([]);
+  expect(reconnects(run.events)).toHaveLength(0);
+  expect(run.events.filter((event) => event.type === "run.completed"))
+    .toEqual([expect.objectContaining({ outcome: "failed" })]);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it.each(["session.create", "prompt.submit"])("never replays a Hermes %s request timeout", async (ignoreMethod) => {
+  vi.useFakeTimers();
+  const run = start({ ignoreMethod });
+  await vi.advanceTimersByTimeAsync(8_000);
+  await run.done;
+  expect(run.fixture.children).toHaveLength(1);
+  expect(run.fixture.requests().filter((request) => request.method === ignoreMethod)).toHaveLength(1);
+  expect(reconnects(run.events)).toHaveLength(0);
+  expect(run.events.filter((event) => event.type === "run.completed"))
+    .toEqual([expect.objectContaining({ outcome: "failed" })]);
+});
+
+it("keeps the overall run deadline across Hermes startup retries", async () => {
+  vi.useFakeTimers();
+  const run = start({ timeouts: 6 }, { timeoutMs: 100 });
+  await vi.advanceTimersByTimeAsync(8_000);
+  await run.done;
+  expect(run.fixture.children).toHaveLength(1);
+  expect(run.fixture.requests()).toEqual([]);
+  expect(run.events.filter((event) => event.type === "run.completed"))
+    .toEqual([expect.objectContaining({ outcome: "failed", error: expect.objectContaining({
+      safeMessage: "The Hermes Run timed out.",
+    }) })]);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it.each(["session.create", "prompt.submit"])("retains post-ready %s failure ownership until actual exit", async (ignoreMethod) => {
+  vi.useFakeTimers();
+  const run = start({ ignoreMethod, confirmExit: false });
+  try {
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(run.fixture.children[0]!.process.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(run.fixture.children[0]!.exited).toBe(false);
+    expect(run.settled).toBe(false);
+    expect(run.events.some((event) => event.type === "run.completed")).toBe(false);
+    run.fixture.children[0]!.event("message.delta", { text: "Late retired output" });
+    run.fixture.children[0]!.exit();
+    await run.done;
+    expect(run.events.filter((event) => event.type === "run.completed"))
+      .toEqual([expect.objectContaining({ outcome: "failed" })]);
+    expect(run.events.some((event) => event.type === "assistant.delta")).toBe(false);
+    expect(run.fixture.children).toHaveLength(1);
+  } finally {
+    run.fixture.children[0]?.exit();
+    run.controller.abort();
+    await run.done;
+  }
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/tests/gateway/chat-hermes-startup-stream.test.ts
+++ b/tests/gateway/chat-hermes-startup-stream.test.ts
@@ -1,0 +1,172 @@
+import { expect, it, vi } from "vitest";
+import { hermesStartupStreamHarness } from "../helpers/hermes-startup-stream-harness";
+
+it.each(["eventual_exit", "user_stop", "shutdown"] as const)(
+  "retains post-ready protocol-failure ownership through HTTP until %s", async (mode) => {
+    const h = await hermesStartupStreamHarness({ confirmExit: false });
+    try {
+      await h.source.start();
+      const admitted = await h.admit();
+      await vi.waitFor(() => expect(h.process.requests().filter((request) => request.method === "prompt.submit")).toHaveLength(1));
+      const drained = h.orchestrator.drain();
+      h.process.children[0]!.process.stdout.emit("data", Buffer.from("invalid\n"));
+      await vi.waitFor(() => expect(h.frames.flatMap((frame) => frame.content.activities ?? []))
+        .toContainEqual(expect.objectContaining({ label: "Stopping", status: "running" })), { timeout: 3_000 });
+      expect(h.orchestrator.activeCount).toBe(1);
+      expect(h.frames.some((frame) => ["run.completed", "run.failed", "run.aborted"].includes(frame.event.eventType))).toBe(false);
+      await expect(h.admit("req_post_ready_duplicate", h.frames.at(-1)!.event.revision))
+        .rejects.toMatchObject({ safeError: { code: "chat_busy" } });
+      if (mode === "user_stop") await h.orchestrator.cancelRun(h.owner, h.chatId, admitted.run.id);
+      else if (mode === "shutdown") await h.orchestrator.close();
+      h.process.children[0]!.event("message.delta", { text: "Late retired output" });
+      h.process.children[0]!.exit();
+      await drained;
+      await vi.waitFor(() => expect(h.frames.at(-1)?.content.record.activeRun).toBeUndefined());
+      expect(h.frames.filter((frame) => ["run.completed", "run.failed", "run.aborted"].includes(frame.event.eventType))).toHaveLength(1);
+      const terminal = h.frames.flatMap((frame) => frame.content.runs ?? []).filter((run) => run.id === admitted.run.id).at(-1);
+      expect(terminal?.status).toBe(mode === "eventual_exit" ? "failed" : "aborted");
+      expect(h.frames.some((frame) => frame.content.messageDelta)).toBe(false);
+      expect(h.process.children).toHaveLength(1);
+      expect(h.orchestrator.activeCount).toBe(0);
+    } finally { await h.close(); }
+  }, 15_000,
+);
+
+it("rechecks direct dispatch when Stop commits during awaited admission preparation", async () => {
+  const h = await hermesStartupStreamHarness({ timeouts: 6, confirmExit: false });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  try {
+    await h.source.start();
+    const admitted = await h.admit();
+    await vi.waitFor(() => expect(h.frames.flatMap((frame) => frame.content.activities ?? []))
+      .toContainEqual(expect.objectContaining({ label: "Stopping", status: "running" })), { timeout: 3_000 });
+    const before = await h.repository.get(h.owner, h.chatId);
+    const originalGet = h.repository.get.bind(h.repository);
+    let entered = false;
+    vi.spyOn(h.repository, "get").mockImplementationOnce(async (...args) => {
+      entered = true;
+      await gate;
+      return originalGet(...args);
+    });
+    // A competing client can submit the next revision while Stop is committing.
+    const next = h.admit("req_cancel_admission_race", before!.chat.revision + 1);
+    const rejected = expect(next).rejects.toMatchObject({ safeError: { code: "chat_busy" } });
+    await vi.waitFor(() => expect(entered).toBe(true));
+    await h.orchestrator.cancelRun(h.owner, h.chatId, admitted.run.id);
+    expect((await originalGet(h.owner, h.chatId))!.chat.revision).toBe(before!.chat.revision + 1);
+    release();
+    await rejected;
+    expect(h.orchestrator.activeCount).toBe(1);
+    expect(h.process.children).toHaveLength(1);
+    expect(h.process.requests()).toEqual([]);
+  } finally { release(); await h.close(); }
+}, 10_000);
+
+it.each(["user_stop", "shutdown"] as const)(
+  "retains early %s cleanup ownership until the startup child actually exits", async (mode) => {
+    const h = await hermesStartupStreamHarness({ timeouts: 6, confirmExit: false });
+    try {
+      await h.source.start();
+      await vi.waitFor(() => expect(h.source.connectionState()).toBe("open"));
+      const admitted = await h.admit();
+      await vi.waitFor(() => expect(h.process.children).toHaveLength(1));
+      let settled = false;
+      const drained = h.orchestrator.drain().then(() => { settled = true; });
+      if (mode === "user_stop") await h.orchestrator.cancelRun(h.owner, h.chatId, admitted.run.id);
+      else await h.orchestrator.close();
+      // Observe the public cleanup diagnostic or controlled process stop, then
+      // cross the bounded close window without releasing the actual child exit.
+      await vi.waitFor(() => expect(h.process.children[0]!.process.kill).toHaveBeenCalledWith("SIGKILL"), { timeout: 3_000 });
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      expect(settled).toBe(false);
+      // Stop already persists its established user-visible aborted outcome;
+      // execution ownership must still prevent more work until cleanup finishes.
+      expect(h.frames.filter((frame) => frame.event.eventType === "run.aborted")).toHaveLength(1);
+      if (mode === "user_stop") {
+        expect(h.orchestrator.activeCount).toBe(1);
+        expect(await h.admit()).toMatchObject({ admission: "already_accepted" });
+        await expect(h.admit("req_early_stop_duplicate", h.frames.at(-1)!.event.revision))
+          .rejects.toMatchObject({ safeError: { code: "chat_busy" } });
+        await expect(h.orchestrator.retryTurn({ userId: h.owner.ownerId, source: "jwt" }, h.owner,
+          h.chatId, admitted.turn.id, { clientRequestId: "req_early_retry", baseRevision: h.frames.at(-1)!.event.revision }))
+          .rejects.toMatchObject({ safeError: { code: "chat_busy" } });
+      }
+      h.process.children[0]!.event("gateway.ready");
+      h.process.children[0]!.event("message.complete", { text: "Late unowned result", status: "complete" });
+      expect(h.process.requests()).toEqual([]);
+      h.process.children[0]!.exit();
+      await drained;
+      await vi.waitFor(() => expect(h.frames.at(-1)?.content.record.activeRun).toBeUndefined());
+      expect(h.frames.filter((frame) => frame.event.eventType === "run.aborted")).toHaveLength(1);
+      expect(h.frames.some((frame) => frame.content.messageDelta)).toBe(false);
+      expect(h.process.children).toHaveLength(1);
+    } finally { await h.close(); }
+  }, 15_000,
+);
+
+it.each(["eventual_exit", "user_stop", "shutdown"] as const)(
+  "keeps Hermes startup cleanup owned through HTTP until %s and settles once", async (mode) => {
+    const h = await hermesStartupStreamHarness({ timeouts: 6, confirmExit: false });
+    try {
+      await h.source.start();
+      await vi.waitFor(() => expect(h.source.connectionState()).toBe("open"));
+      const admitted = await h.admit();
+      await vi.waitFor(() => expect(h.frames.flatMap((frame) => frame.content.activities ?? []))
+        .toContainEqual(expect.objectContaining({ label: "Stopping", status: "running" })), { timeout: 3_000 });
+      expect(h.frames.at(-1)?.content.record.activeRun).toMatchObject({ runId: admitted.run.id });
+      expect(h.frames.some((frame) => ["run.completed", "run.failed", "run.aborted"].includes(frame.event.eventType))).toBe(false);
+      expect(h.process.children).toHaveLength(1);
+      expect(h.process.requests()).toEqual([]);
+      expect(h.orchestrator.activeCount).toBe(1);
+      // Capture the active completion before bounded shutdown clears its registry.
+      // Keep the test DB alive for late-exit callbacks that shutdown cannot await.
+      const drained = h.orchestrator.drain();
+      await expect(h.admit("req_duplicate_start", h.frames.at(-1)!.event.revision))
+        .rejects.toMatchObject({ safeError: { code: "chat_busy" } });
+      h.process.children[0]!.event("gateway.ready");
+      h.process.children[0]!.event("message.complete", { text: "Late unowned result", status: "complete" });
+      if (mode === "user_stop") {
+        expect(await h.orchestrator.cancelRun(h.owner, h.chatId, admitted.run.id))
+          .toMatchObject({ cancellation: "aborted" });
+        expect(h.orchestrator.activeCount).toBe(1);
+      } else if (mode === "shutdown") {
+        // Returns despite no exit; shutdown's bounded drain is not exit proof.
+        await h.orchestrator.close();
+        expect(h.process.children[0]!.exited).toBe(false);
+      }
+      expect(h.process.requests()).toEqual([]);
+      expect(h.process.children).toHaveLength(1);
+      h.process.children[0]!.exit();
+      await drained;
+      await vi.waitFor(() => expect(h.frames.at(-1)?.content.record.activeRun).toBeUndefined());
+      expect(h.frames.filter((frame) => ["run.completed", "run.failed", "run.aborted"].includes(frame.event.eventType))).toHaveLength(1);
+      const terminal = h.frames.flatMap((frame) => frame.content.runs ?? [])
+        .filter((run) => run.id === admitted.run.id).at(-1);
+      expect(terminal?.status).toBe(mode === "eventual_exit" ? "failed" : "aborted");
+      expect(h.frames.some((frame) => frame.content.messageDelta)).toBe(false);
+      expect(h.process.children).toHaveLength(1);
+      expect(h.orchestrator.activeCount).toBe(0);
+    } finally { await h.close(); }
+  }, 15_000,
+);
+
+it("publishes Hermes Reconnecting through HTTP with one admitted run and no failure flash", async () => {
+  const h = await hermesStartupStreamHarness({ timeouts: 1 });
+  try {
+    await h.source.start();
+    await vi.waitFor(() => expect(h.source.connectionState()).toBe("open"));
+    const admitted = await h.admit();
+    await vi.waitFor(() => expect(h.frames.flatMap((frame) => frame.content.activities ?? []))
+      .toContainEqual(expect.objectContaining({ label: "Reconnecting… 1/5", status: "running" })));
+    expect(h.frames.some((frame) => frame.event.eventType === "run.completed")).toBe(false);
+    expect(h.frames.at(-1)?.content.record.activeRun?.runId).toBe(admitted.run.id);
+    await vi.waitFor(() => expect(h.process.requests().filter((request) => request.method === "prompt.submit")).toHaveLength(1));
+    h.process.children[1]!.event("message.complete", { text: "Recovered startup.", status: "complete" });
+    await h.orchestrator.drain();
+    await vi.waitFor(() => expect(h.frames.at(-1)?.content.record.activeRun).toBeUndefined());
+    expect(h.frames.filter((frame) => frame.event.eventType === "run.completed")).toHaveLength(1);
+    expect(new Set(h.frames.flatMap((frame) => frame.content.runs ?? []).map((run) => run.id)))
+      .toEqual(new Set([admitted.run.id]));
+  } finally { await h.close(); }
+});

--- a/tests/gateway/codex-launch-failure.test.ts
+++ b/tests/gateway/codex-launch-failure.test.ts
@@ -32,6 +32,9 @@ describe("provider launch failure reaches canonical Chat", () => {
           codexProviderEventPath(homePath, sessionId), process.version.slice(1), process.execPath,
           join(process.cwd(), "tests/fixtures/codex-launch-failure.mjs"), config], {
           cwd: homePath, stdio: ["ignore", "ignore", "pipe"], env: { ...process.env, MATRIX_TEST_LAUNCH_FAILURE: mode,
+            // Exercise all six startup attempts without spending the production
+            // 30-second handshake budget on each deliberately silent fixture.
+            ...(mode === "handshake-timeout" ? { MATRIX_CODEX_STARTUP_TIMEOUT_MS: "500" } : {}),
             ...(mode === "spawn-eagain" ? { NODE_OPTIONS: `--import=${join(process.cwd(), "tests/fixtures/codex-spawn-eagain.mjs")}` } : {}) },
         });
         ended = once(child, "close");
@@ -56,6 +59,11 @@ describe("provider launch failure reaches canonical Chat", () => {
       await ended;
       if (mode === "spawn-eagain") expect(stderr).toContain("Injected spawn EAGAIN");
       if (mode === "resume-identity-mismatch") expect(await readFile(transcriptPath, "utf8")).not.toContain("native_failure_test");
+      if (mode === "handshake-timeout") {
+        const transcript = (await readFile(transcriptPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+        expect(transcript.filter((event) => event.type === "matrix.codex.tool.started").map((event) => event.displayName))
+          .toEqual(["Reconnecting… 1/5", "Reconnecting… 2/5", "Reconnecting… 3/5", "Reconnecting… 4/5", "Reconnecting… 5/5"]);
+      }
       now = 61_000;
       await bridge.drain();
       await collecting;

--- a/tests/gateway/codex-startup-retry.test.ts
+++ b/tests/gateway/codex-startup-retry.test.ts
@@ -1,0 +1,164 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, it, vi } from "vitest";
+import { startCodexStartupRunner, waitForStartupText } from "../helpers/codex-startup-runner";
+
+async function stop(child: ChildProcess) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const closed = new Promise<void>((resolve) => child.once("close", () => resolve()));
+  child.kill("SIGTERM");
+  const timer = setTimeout(() => child.kill("SIGKILL"), 1_000);
+  await closed;
+  clearTimeout(timer);
+}
+
+async function waitForText(path: string, text: string) {
+  const deadline = Date.now() + 4_000;
+  while (Date.now() < deadline) {
+    try { if ((await readFile(path, "utf8")).includes(text)) return; }
+    catch (error) { if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error; }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Expected public startup event: ${text}`);
+}
+
+it("retries a timed-out preprompt Codex initialization after confirmed stop and submits the prompt once", async () => {
+  const dir = await mkdtemp("/tmp/matrix-startup-");
+  const eventPath = join(dir, "events.jsonl");
+  const requestsPath = join(dir, "requests.jsonl");
+  const config = Buffer.from(JSON.stringify({ prompt: "Reply once", approvalPolicy: "never",
+    sandbox: "workspace-write", writableRoots: [dir] })).toString("base64");
+  const runnerPath = join(process.cwd(), "packages/gateway/src/coding-agents/codex-app-server-runner.mjs");
+  const fixturePath = join(process.cwd(), "tests/fixtures/codex-startup-process.mjs");
+  const child = spawn(process.execPath, [runnerPath, eventPath, process.version.slice(1), process.execPath, fixturePath, config], {
+    cwd: dir, stdio: ["ignore", "pipe", "pipe"], env: { ...process.env,
+      MATRIX_CODEX_STARTUP_TIMEOUT_MS: "1000", TEST_CODEX_STARTUP_STATE: join(dir, "state"),
+      TEST_CODEX_STARTUP_REQUESTS: requestsPath },
+  });
+  child.stdout?.resume(); child.stderr?.resume();
+  try {
+    await waitForText(eventPath, "Reconnecting… 1/5");
+    await waitForText(eventPath, "Started exactly once.");
+    const records = (await readFile(requestsPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    expect(records.filter((record) => record.method === "turn/start")).toEqual([{ attempt: 2, method: "turn/start" }]);
+    expect(records.findIndex((record) => record.event === "stopped"))
+      .toBeLessThan(records.findIndex((record) => record.attempt === 2));
+    const events = (await readFile(eventPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    expect(events.filter((event) => event.type === "turn.failed")).toHaveLength(0);
+  } finally {
+    await stop(child);
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 10_000);
+
+it("requires a matching initialize response before handing off the process", async () => {
+  const h = await startCodexStartupRunner({ mode: "wrong_id" });
+  try {
+    await waitForStartupText(h.eventPath, "turn.completed");
+    await h.closed;
+    expect((await h.requests()).filter((record) => record.method === "turn/start"))
+      .toEqual([{ attempt: 2, method: "turn/start" }]);
+  } finally { await h.close(); }
+}, 10_000);
+
+it("cancels a ready/abort handoff race before any thread or prompt admission", async () => {
+  const h = await startCodexStartupRunner({ stubProcess: true, mode: "ready_abort" });
+  try {
+    await waitForStartupText(h.eventPath, "turn.aborted");
+    await h.closed;
+    expect(await h.events()).toEqual([{ type: "turn.aborted" }]);
+    expect(await h.requests()).toEqual([{ attempt: 1, method: "initialize" }]);
+  } finally { await h.close(); }
+}, 10_000);
+
+it.each([5, 6])("allows exactly five retries with %i timed-out initialization attempts", async (failures) => {
+  const h = await startCodexStartupRunner({ failures });
+  try {
+    await waitForStartupText(h.eventPath, failures === 5 ? "turn.completed" : "turn.failed", 20_000);
+    await h.closed;
+    const records = await h.requests();
+    expect(records.filter((record) => record.method === "initialize")).toHaveLength(6);
+    expect(records.filter((record) => record.method === "turn/start")).toHaveLength(failures === 5 ? 1 : 0);
+    const events = await h.events();
+    expect(events.filter((event) => event.type === "matrix.codex.tool.started").map((event) => event.displayName))
+      .toEqual(["Reconnecting… 1/5", "Reconnecting… 2/5", "Reconnecting… 3/5", "Reconnecting… 4/5", "Reconnecting… 5/5"]);
+    expect(events.filter((event) => String(event.type).startsWith("turn.")))
+      .toEqual([{ type: failures === 5 ? "turn.completed" : "turn.failed" }]);
+  } finally { await h.close(); }
+}, 25_000);
+
+it.each(["rejected", "malformed", "no_result"])("does not retry %s initialization", async (mode) => {
+  const h = await startCodexStartupRunner({ mode });
+  try {
+    await waitForStartupText(h.eventPath, "turn.failed");
+    await h.closed;
+    const events = await h.events();
+    expect(events).toEqual([{ type: "turn.failed" }]);
+    expect(await h.requests()).toEqual([{ attempt: 1, method: "initialize" }, { attempt: 1, event: "stopped" }]);
+  } finally { await h.close(); }
+}, 10_000);
+
+it("fences late startup success and output while waiting for the timed-out child to close", async () => {
+  const h = await startCodexStartupRunner({ mode: "late_ready" });
+  try {
+    await waitForStartupText(h.eventPath, "turn.completed");
+    await h.closed;
+    expect(JSON.stringify(await h.events())).not.toContain("Discard late startup output");
+    expect((await h.requests()).filter((record) => record.method === "turn/start"))
+      .toEqual([{ attempt: 2, method: "turn/start" }]);
+  } finally { await h.close(); }
+}, 10_000);
+
+it("contains startup stdin errors as one safe non-retried failure", async () => {
+  const h = await startCodexStartupRunner({ stubProcess: true, mode: "stdin_error" });
+  try {
+    await waitForStartupText(h.eventPath, "turn.failed");
+    await h.closed;
+    const events = await h.events();
+    expect(events.filter((event) => String(event.type).startsWith("turn."))).toEqual([{ type: "turn.failed" }]);
+    expect(JSON.stringify(events)).not.toMatch(/Reconnecting|EPIPE|private transport/);
+    expect(await h.requests()).toEqual([{ attempt: 1, method: "initialize" }]);
+  } finally { await h.close(); }
+}, 10_000);
+
+it("retains an unconfirmed startup child until actual close, then settles Stop once", async () => {
+  const h = await startCodexStartupRunner({ stubProcess: true });
+  try {
+    await waitForStartupText(h.eventPath, "Waiting for startup cleanup", 8_000);
+    expect(h.child.exitCode).toBeNull();
+    expect((await h.events()).some((event) => String(event.type).startsWith("turn."))).toBe(false);
+    expect(await h.requests()).toEqual([{ attempt: 1, method: "initialize" }]);
+    h.child.kill("SIGTERM");
+    await h.closed;
+    expect((await h.events()).filter((event) => String(event.type).startsWith("turn.")))
+      .toEqual([{ type: "turn.aborted" }]);
+    expect(await h.requests()).toEqual([{ attempt: 1, method: "initialize" }]);
+  } finally { await h.close(); }
+}, 10_000);
+
+it("retains Codex startup ownership when termination calls throw instead of confirming exit", async () => {
+  const h = await startCodexStartupRunner({ stubProcess: true, mode: "kill_error" });
+  try {
+    await vi.waitFor(async () => expect((await h.events()).length).toBeGreaterThan(0), { timeout: 8_000 });
+    expect((await h.events()).some((event) => String(event.type).startsWith("turn."))).toBe(false);
+    expect(await h.events()).toContainEqual(expect.objectContaining({ displayName: "Waiting for startup cleanup" }));
+    expect(await h.requests()).toEqual([{ attempt: 1, method: "initialize" }]);
+    await h.closed;
+    expect((await h.events()).filter((event) => String(event.type).startsWith("turn.")))
+      .toEqual([{ type: "turn.failed" }]);
+    expect(JSON.stringify(await h.events())).not.toMatch(/EPERM|private process/);
+  } finally { await h.close(); }
+}, 12_000);
+
+it("cancels startup backoff without a second process or a failed-run flash", async () => {
+  const h = await startCodexStartupRunner({ failures: 6 });
+  try {
+    await waitForStartupText(h.eventPath, "Reconnecting… 1/5");
+    h.child.kill("SIGTERM");
+    await h.closed;
+    expect((await h.requests()).some((record) => record.attempt > 1 || record.method === "turn/start")).toBe(false);
+    const terminal = (await h.events()).filter((event) => ["turn.failed", "turn.aborted", "turn.completed"].includes(String(event.type)));
+    expect(terminal).toEqual([{ type: "turn.aborted" }]);
+  } finally { await h.close(); }
+}, 10_000);

--- a/tests/gateway/codex-startup-stream.test.ts
+++ b/tests/gateway/codex-startup-stream.test.ts
@@ -1,0 +1,24 @@
+import { expect, it, vi } from "vitest";
+import { createCodexStartupStreamHarness } from "../helpers/codex-startup-stream-harness";
+
+it("streams Reconnecting before the Codex prompt is sent, without an intermediate failed Run", async () => {
+  const h = await createCodexStartupStreamHarness();
+  const controller = new AbortController();
+  const reader = (await h.openStream({ signal: controller.signal })).body!.getReader();
+  const reading = (async () => { while (!(await reader.read()).done) { /* Consume real HTTP. */ } })();
+  try {
+    await vi.waitFor(() => expect(h.frames.at(-1)?.type).toBe("chat.replay.end"));
+    await h.admit();
+    await vi.waitFor(() => expect(h.frames.some((frame) => frame.type === "chat.content"
+      && frame.content.activities?.some((activity) => activity.type === "agent.activity"
+        && activity.kind === "phase" && activity.label === "Reconnecting… 1/5"))).toBe(true), { timeout: 4_000 });
+    expect(h.frames.some((frame) => frame.type === "chat.content" && frame.event.eventType === "run.failed")).toBe(false);
+    expect((await h.getRunner()!.requests()).some((request) => request.method === "turn/start")).toBe(false);
+    await h.release();
+    await vi.waitFor(() => expect(h.frames.some((frame) => frame.type === "chat.content"
+      && frame.event.eventType === "run.completed")).toBe(true), { timeout: 4_000 });
+    expect((await h.getRunner()!.requests()).filter((request) => request.method === "turn/start")).toHaveLength(1);
+  } finally {
+    controller.abort(); await reader.cancel(); await reading; await h.close();
+  }
+}, 15_000);

--- a/tests/gateway/hermes-stdio-cleanup.test.ts
+++ b/tests/gateway/hermes-stdio-cleanup.test.ts
@@ -1,0 +1,53 @@
+import { EventEmitter } from "node:events";
+import { afterEach, expect, it, vi } from "vitest";
+import { createHermesStdioClient, type HermesGatewayProcess } from "../../packages/gateway/src/chat/hermes-stdio-client";
+
+afterEach(() => vi.useRealTimers());
+
+it("shares a bounded close result without mistaking failed termination calls for exit", async () => {
+  vi.useFakeTimers();
+  const child = Object.assign(new EventEmitter(), {
+    stdin: { write: () => true, end: () => { throw new Error("EPIPE"); } },
+    stdout: new EventEmitter(), stderr: new EventEmitter(),
+    kill: vi.fn(() => { throw new Error("EPERM"); }),
+  }) satisfies HermesGatewayProcess;
+  const client = createHermesStdioClient({ command: "hermes", args: [], cwd: "/safe", env: {},
+    spawnFn: () => child, onEvent: () => undefined, onFailure: () => undefined });
+  const ready = client.ready().catch(() => undefined);
+  const first = client.close();
+  expect(client.close()).toBe(first);
+  const result = first.catch((error: unknown) => error);
+  await vi.advanceTimersByTimeAsync(2_000);
+  expect(await result).toBe(false);
+  expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  let confirmed = false;
+  void client.whenExited().then(() => { confirmed = true; });
+  await vi.advanceTimersByTimeAsync(0);
+  expect(confirmed).toBe(false);
+  child.emit("exit", 0, null);
+  await client.whenExited();
+  expect(confirmed).toBe(true);
+  await ready;
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("settles a definitive no-child spawn error without waiting for an impossible exit", async () => {
+  vi.useFakeTimers();
+  const child = Object.assign(new EventEmitter(), {
+    pid: undefined,
+    stdin: { write: () => true, end: vi.fn() },
+    stdout: new EventEmitter(), stderr: new EventEmitter(), kill: vi.fn(),
+  });
+  const client = createHermesStdioClient({ command: "missing-hermes", args: [], cwd: "/safe", env: {},
+    spawnFn: () => child, onEvent: () => undefined, onFailure: () => undefined });
+  const ready = client.ready().catch((error: unknown) => error);
+  child.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+  expect(await ready).toBeInstanceOf(Error);
+  const closing = client.close();
+  await vi.advanceTimersByTimeAsync(2_000);
+  expect(await closing).toBe(true);
+  await client.whenExited();
+  expect(child.kill).not.toHaveBeenCalled();
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/tests/helpers/claude-steer-stream-harness.ts
+++ b/tests/helpers/claude-steer-stream-harness.ts
@@ -1,0 +1,175 @@
+import { EventEmitter } from "node:events";
+import { Hono } from "hono";
+import { KyselyPGlite } from "kysely-pglite";
+import { vi } from "vitest";
+import {
+  CanonicalChatTransportFrameSchema,
+  CanonicalProviderCatalogSchema,
+  type CanonicalChatTransportFrame,
+} from "@matrix-os/contracts";
+import { createCanonicalProviderCatalogFixture } from "../contracts/fixtures/canonical-chat";
+import { createClaudeChatProviderAdapter } from "../../packages/gateway/src/chat/claude-provider-adapter";
+import type { CanonicalCliSpawn } from "../../packages/gateway/src/chat/cli-process";
+import { CanonicalChatOrchestrator } from "../../packages/gateway/src/chat/orchestrator";
+import { CanonicalChatProviderRegistry } from "../../packages/gateway/src/chat/provider-adapter";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository";
+import { createCanonicalChatEventStream } from "../../packages/gateway/src/chat/event-stream";
+import { registerCanonicalChatEventHttpRoute } from "../../packages/gateway/src/chat/event-http-route";
+
+export const BEFORE_STEER = "I am reviewing the original module.";
+export const STEER_REQUEST = "Focus on the streaming module instead.";
+export const AFTER_STEER = "I have switched to the streaming module.";
+export const FINAL_TEXT = "The focused streaming review is complete.";
+
+// Only the external CLI process is controlled. No canonical events are injected.
+class ControlledClaudeChild extends EventEmitter {
+  readonly stdout = new EventEmitter();
+  readonly stderr = new EventEmitter();
+  exited = false;
+  resultReleased = false;
+
+  kill(signal: NodeJS.Signals) {
+    queueMicrotask(() => this.exit(null, signal));
+  }
+
+  exit(code: number | null, signal: NodeJS.Signals | null = null) {
+    if (this.exited) return;
+    this.exited = true;
+    this.emit("exit", code, signal);
+  }
+
+  line(value: unknown, fragmented = false) {
+    if (this.exited) throw new Error("Cannot emit output from an exited fixture child");
+    const bytes = Buffer.from(`${JSON.stringify(value)}\n`);
+    if (fragmented) {
+      const split = Math.floor(bytes.length / 2);
+      this.stdout.emit("data", bytes.subarray(0, split));
+      this.stdout.emit("data", bytes.subarray(split));
+    } else this.stdout.emit("data", bytes);
+  }
+
+  initialize() {
+    this.line({ type: "system", subtype: "init", session_id: "claude_stream_session", model: "sonnet" });
+  }
+
+  text(text: string, fragmented = false) {
+    this.line({ type: "stream_event", event: {
+      type: "content_block_start", index: 0, content_block: { type: "text", text: "" },
+    } }, fragmented);
+    this.line({ type: "stream_event", event: {
+      type: "content_block_delta", index: 0, delta: { type: "text_delta", text },
+    } }, fragmented);
+    this.line({ type: "stream_event", event: { type: "content_block_stop", index: 0 } }, fragmented);
+  }
+
+  tool() {
+    this.line({ type: "stream_event", event: { type: "content_block_start", index: 1,
+      content_block: { type: "tool_use", id: "tool_stream_review", name: "Read",
+        input: { file_path: "/safe/project/src/streaming.ts" } },
+    } });
+  }
+
+  finish() {
+    if (this.exited) return;
+    this.resultReleased = true;
+    this.text(FINAL_TEXT);
+    this.line({ type: "result", subtype: "success", is_error: false,
+      result: FINAL_TEXT, session_id: "claude_stream_session" });
+    this.exit(0);
+  }
+}
+
+export async function createClaudeSteerStreamHarness() {
+  const owner = { type: "personal" as const, ownerId: "owner_claude_stream" };
+  const principal = { userId: owner.ownerId, source: "jwt" as const };
+  const chatId = "chat_claude_stream";
+  const selection = { instanceId: "claude_stream", model: "sonnet", options: [{ id: "effort", value: "high" }] };
+  const fixture = createCanonicalProviderCatalogFixture();
+  const catalog = CanonicalProviderCatalogSchema.parse({ ...fixture,
+    drivers: [{ ...fixture.drivers[0], kind: "claude_code", displayName: "Claude Code" }],
+    instances: [{ ...fixture.instances[0], id: selection.instanceId, driverKind: "claude_code",
+      displayName: "Claude Code", models: [{ ...fixture.instances[0]!.models[0], id: "sonnet", displayName: "Sonnet" }],
+      defaultSelection: selection,
+      options: [{ id: "effort", label: "Reasoning", kind: "enum", placement: "composer",
+        values: [{ value: "high", label: "High" }] }],
+      supports: { ...fixture.instances[0]!.supports, steering: "same_run" },
+    }],
+  });
+  const db = await KyselyPGlite.create();
+  const repository = new ChatRepository(db.dialect);
+  await repository.bootstrap();
+  await repository.create(owner, { id: chatId, clientRequestId: "req_create_stream", title: "Claude streaming" });
+  const children: ControlledClaudeChild[] = [];
+  const spawn = vi.fn<CanonicalCliSpawn>(() => {
+    if (children.length >= 4) throw new Error("Unexpected extra Claude child");
+    const child = new ControlledClaudeChild();
+    children.push(child);
+    queueMicrotask(() => child.initialize());
+    return child;
+  });
+  const adapter = createClaudeChatProviderAdapter({
+    homePath: "/safe/home", spawnFn: spawn, resolveCredentialEnv: async () => ({}),
+  });
+  const root = { ref: { kind: "project" as const, projectId: "project_stream" },
+    fingerprint: "a".repeat(64), primaryWorkspaceRoot: "/safe/project", projectSlug: "stream" };
+  const orchestrator = new CanonicalChatOrchestrator({ repository,
+    catalog: { getCatalog: async () => catalog }, adapters: new CanonicalChatProviderRegistry([adapter]),
+    executionRoots: { resolve: async () => root, revalidate: async () => root },
+  });
+  const stream = createCanonicalChatEventStream({ repository });
+  const app = new Hono();
+  registerCanonicalChatEventHttpRoute({ app, stream, getPrincipal: () => principal });
+  const frames: CanonicalChatTransportFrame[] = [];
+  const openStream = vi.fn(async ({ signal, cursor }: { signal: AbortSignal; cursor?: number }) => {
+    const response = await app.request(`/api/chats/events?messageVersion=2${cursor === undefined ? "" : `&cursor=${cursor}`}`, {
+      signal, headers: { accept: "text/event-stream", "x-matrix-chat-protocol": "2" },
+    });
+    const decoder = new TextDecoder();
+    let buffered = "";
+    return new Response(response.body!.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        buffered += decoder.decode(chunk, { stream: true });
+        if (buffered.length > 512_000) throw new Error("Fixture SSE buffer limit exceeded");
+        let end: number;
+        while ((end = buffered.indexOf("\n\n")) >= 0) {
+          const block = buffered.slice(0, end);
+          buffered = buffered.slice(end + 2);
+          const data = block.split("\n").filter((line) => line.startsWith("data: "))
+            .map((line) => line.slice(6)).join("\n");
+          if (data) {
+            if (frames.length >= 256) throw new Error("Fixture SSE frame limit exceeded");
+            frames.push(CanonicalChatTransportFrameSchema.parse(JSON.parse(data)));
+          }
+        }
+        controller.enqueue(chunk);
+      },
+    })), { status: response.status, headers: response.headers });
+  });
+  const getDetail = async () => (await repository.getDetailPage(owner, chatId, { limit: 200 }))!;
+  return {
+    owner, principal, chatId, catalog, children, spawn, frames, openStream, getDetail, repository, orchestrator,
+    async admit() {
+      return orchestrator.admitTurn(principal, owner, chatId, { clientRequestId: "req_stream_turn", baseRevision: 0,
+        parts: [{ type: "text", text: "Review the original module." }], selection,
+        interactionMode: "default", permissionMode: "supervised", executionRoot: root.ref });
+    },
+    async steer(runId: string, turnId: string) {
+      return orchestrator.steerRun(owner, chatId, runId, { clientRequestId: "req_stream_steer",
+        expectedTurnId: turnId, parts: [{ type: "text", text: STEER_REQUEST }] });
+    },
+    async close() {
+      await orchestrator.close();
+      stream.shutdown();
+      await repository.kysely.destroy();
+    },
+  };
+}
+
+export function contentFrames(frames: CanonicalChatTransportFrame[]) {
+  return frames.filter((frame) => frame.type === "chat.content");
+}
+
+export function messageFrame(frames: CanonicalChatTransportFrame[], text: string) {
+  return contentFrames(frames).find((frame) => frame.content.messageDelta?.message.parts
+    .some((part) => part.type === "text" && part.text === text));
+}

--- a/tests/helpers/codex-startup-runner.ts
+++ b/tests/helpers/codex-startup-runner.ts
@@ -1,0 +1,57 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+export async function waitForStartupText(path: string, text: string, timeoutMs = 4_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try { if ((await readFile(path, "utf8")).includes(text)) return; }
+    catch (error) { if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error; }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Expected public startup event: ${text}`);
+}
+
+export async function startCodexStartupRunner(options: {
+  homePath?: string; eventPath?: string; failures?: number; timeoutMs?: number;
+  mode?: string; readyGate?: string; stubProcess?: boolean;
+} = {}) {
+  const dir = options.homePath ?? await mkdtemp("/tmp/matrix-startup-");
+  const eventPath = options.eventPath ?? join(dir, "events.jsonl");
+  const requestsPath = join(dir, "requests.jsonl");
+  const config = Buffer.from(JSON.stringify({ prompt: "Reply once", approvalPolicy: "never",
+    sandbox: "workspace-write", writableRoots: [dir] })).toString("base64");
+  const runnerPath = join(process.cwd(), "packages/gateway/src/coding-agents/codex-app-server-runner.mjs");
+  const fixturePath = join(process.cwd(), "tests/fixtures/codex-startup-process.mjs");
+  const child = spawn(process.execPath, [
+    ...(options.stubProcess ? ["--import", join(process.cwd(), "tests/fixtures/codex-startup-process-stub.mjs")] : []),
+    runnerPath, eventPath, process.version.slice(1), process.execPath, fixturePath, config,
+  ], {
+    cwd: dir, stdio: ["ignore", "pipe", "pipe"], env: { ...process.env,
+      MATRIX_CODEX_STARTUP_TIMEOUT_MS: String(options.timeoutMs ?? 1_000),
+      TEST_CODEX_STARTUP_STATE: join(dir, "state"), TEST_CODEX_STARTUP_REQUESTS: requestsPath,
+      TEST_CODEX_STARTUP_FAILURES: String(options.failures ?? 1),
+      TEST_CODEX_STARTUP_MODE: options.mode ?? "timeout",
+      ...(options.readyGate ? { TEST_CODEX_STARTUP_READY_GATE: options.readyGate } : {}),
+    },
+  });
+  const closed = new Promise<number | null>((resolve) => child.once("close", resolve));
+  child.stdout?.resume(); child.stderr?.resume();
+  return { child, closed, eventPath, requestsPath, dir,
+    async events(): Promise<Array<Record<string, unknown>>> {
+      return (await readFile(eventPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    },
+    async requests(): Promise<Array<{ attempt: number; method?: string; event?: string }>> {
+      return (await readFile(requestsPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    },
+    async close() {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGTERM");
+        const timer = setTimeout(() => child.kill("SIGKILL"), 1_000);
+        await closed;
+        clearTimeout(timer);
+      }
+      if (!options.homePath) await rm(dir, { recursive: true, force: true });
+    },
+  };
+}

--- a/tests/helpers/codex-startup-stream-harness.ts
+++ b/tests/helpers/codex-startup-stream-harness.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { KyselyPGlite } from "kysely-pglite";
+import { vi } from "vitest";
+import { CanonicalChatTransportFrameSchema, CanonicalProviderCatalogSchema,
+  type CanonicalChatTransportFrame } from "@matrix-os/contracts";
+import { createCanonicalProviderCatalogFixture } from "../contracts/fixtures/canonical-chat";
+import { createCodingAgentThreadStore } from "../../packages/gateway/src/coding-agents/thread-store";
+import { createWorkspaceCodingAgentProvider } from "../../packages/gateway/src/coding-agents/workspace-provider";
+import { createCodexEventBridge, codexProviderEventPath } from "../../packages/gateway/src/coding-agents/codex-event-bridge";
+import { createCanonicalCodingChatProviderAdapter } from "../../packages/gateway/src/chat/coding-provider-adapter";
+import { CanonicalChatOrchestrator } from "../../packages/gateway/src/chat/orchestrator";
+import { CanonicalChatProviderRegistry } from "../../packages/gateway/src/chat/provider-adapter";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository";
+import { createCanonicalChatEventStream } from "../../packages/gateway/src/chat/event-stream";
+import { registerCanonicalChatEventHttpRoute } from "../../packages/gateway/src/chat/event-http-route";
+import { startCodexStartupRunner } from "./codex-startup-runner";
+
+export async function createCodexStartupStreamHarness() {
+  // Darwin Unix sockets have a short path ceiling; keep the native control path valid.
+  const homePath = await mkdtemp("/tmp/ms-");
+  const gatePath = join(homePath, "ready");
+  const owner = { type: "personal" as const, ownerId: "owner_startup" };
+  const principal = { userId: owner.ownerId, source: "jwt" as const };
+  const chatId = "chat_startup";
+  const selection = { instanceId: "codex_startup", model: "default", options: [] };
+  const fixture = createCanonicalProviderCatalogFixture();
+  const catalog = CanonicalProviderCatalogSchema.parse({ ...fixture,
+    drivers: [{ ...fixture.drivers[0], kind: "codex", displayName: "Codex" }],
+    instances: [{ ...fixture.instances[0], id: selection.instanceId, driverKind: "codex",
+      displayName: "Codex", models: [{ ...fixture.instances[0]!.models[0], id: "default", displayName: "Default" }],
+      defaultSelection: selection }],
+  });
+  let runner: Awaited<ReturnType<typeof startCodexStartupRunner>> | undefined;
+  const bridge = createCodexEventBridge({ homePath, pollIntervalMs: 50,
+    runVersionCommand: async () => ({ stdout: "codex-cli 0.153.4", stderr: "" }),
+    isRuntimeAlive: async () => !runner || (runner.child.exitCode === null && runner.child.signalCode === null),
+  });
+  const session = (id: string) => ({
+    id, kind: "agent" as const, agent: "codex" as const, ownerId: owner.ownerId,
+    runtime: { type: "zellij" as const, status: "running" as const, zellijSession: id,
+      createdAt: new Date().toISOString() },
+    terminalSessionId: id, transcriptPath: codexProviderEventPath(homePath, id),
+    attachedClients: 0, writeMode: "owner" as const,
+    startedAt: new Date().toISOString(), lastActivityAt: new Date().toISOString(),
+  });
+  // External terminal creation is controlled; its launched runner, event bridge,
+  // legacy thread store and canonical adapter are all real production code.
+  const provider = createWorkspaceCodingAgentProvider({ providerId: "codex", agent: "codex", codexEvents: bridge,
+    runtime: {
+      async startSession({ request }) {
+        const id = request.sessionId!;
+        runner = await startCodexStartupRunner({ homePath, eventPath: codexProviderEventPath(homePath, id),
+          timeoutMs: 1_000, readyGate: gatePath });
+        return { ok: true as const, status: 201, session: session(id) };
+      },
+      async stopSession(id) { await runner?.close(); return { ok: true as const, session: session(id) }; },
+    },
+  });
+  const threads = createCodingAgentThreadStore({ homePath, providers: [provider],
+    relationValidator: { validateCreate: async () => undefined, validateThread: async () => undefined } });
+  bridge.attachThreadStore(threads);
+  const adapter = createCanonicalCodingChatProviderAdapter({ providerId: "codex", threads });
+  const db = await KyselyPGlite.create();
+  const repository = new ChatRepository(db.dialect);
+  await repository.bootstrap();
+  await repository.create(owner, { id: chatId, clientRequestId: "req_startup_create", title: "Startup recovery" });
+  const root = { ref: { kind: "project" as const, projectId: "project_startup" },
+    fingerprint: "a".repeat(64), primaryWorkspaceRoot: homePath, projectSlug: "startup" };
+  const orchestrator = new CanonicalChatOrchestrator({ repository,
+    catalog: { getCatalog: async () => catalog }, adapters: new CanonicalChatProviderRegistry([adapter]),
+    executionRoots: { resolve: async () => root, revalidate: async () => root } });
+  const stream = createCanonicalChatEventStream({ repository });
+  const app = new Hono();
+  registerCanonicalChatEventHttpRoute({ app, stream, getPrincipal: () => principal });
+  const frames: CanonicalChatTransportFrame[] = [];
+  const openStream = vi.fn(async ({ signal, cursor }: { signal: AbortSignal; cursor?: number }) => {
+    const response = await app.request(`/api/chats/events?messageVersion=2${cursor === undefined ? "" : `&cursor=${cursor}`}`, {
+      signal, headers: { accept: "text/event-stream", "x-matrix-chat-protocol": "2" },
+    });
+    const decoder = new TextDecoder();
+    let buffered = "";
+    return new Response(response.body!.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        buffered += decoder.decode(chunk, { stream: true });
+        if (buffered.length > 512_000) throw new Error("Fixture SSE buffer limit exceeded");
+        let end: number;
+        while ((end = buffered.indexOf("\n\n")) >= 0) {
+          const block = buffered.slice(0, end); buffered = buffered.slice(end + 2);
+          const data = block.split("\n").filter((line) => line.startsWith("data: ")).map((line) => line.slice(6)).join("\n");
+          if (data) {
+            if (frames.length >= 256) throw new Error("Fixture SSE frame limit exceeded");
+            frames.push(CanonicalChatTransportFrameSchema.parse(JSON.parse(data)));
+          }
+        }
+        controller.enqueue(chunk);
+      },
+    })), { status: response.status, headers: response.headers });
+  });
+  return { homePath, owner, chatId, catalog, repository, orchestrator, frames, openStream,
+    getRunner: () => runner,
+    getDetail: async () => (await repository.getDetailPage(owner, chatId, { limit: 200 }))!,
+    admit: () => orchestrator.admitTurn(principal, owner, chatId, { clientRequestId: "req_startup_turn", baseRevision: 0,
+      parts: [{ type: "text", text: "Reply once" }], selection,
+      interactionMode: "default", permissionMode: "supervised", executionRoot: root.ref }),
+    release: () => writeFile(gatePath, "ready", { flag: "wx" }),
+    async close() {
+      await runner?.close();
+      await bridge.drain(); await bridge.shutdown();
+      await orchestrator.close(); await threads.shutdownTurns();
+      stream.shutdown(); await repository.kysely.destroy();
+      await rm(homePath, { recursive: true, force: true });
+    },
+  };
+}

--- a/tests/helpers/gateway-renderer-environment.ts
+++ b/tests/helpers/gateway-renderer-environment.ts
@@ -1,0 +1,15 @@
+import { createRequire } from "node:module";
+import type { Environment } from "vitest/environments";
+
+// Resolve the package export using Node: this repository's `vitest` alias is
+// intentionally anchored to its installation root for test import identity.
+const { builtinEnvironments } = createRequire(import.meta.url)("vitest/environments") as typeof import("vitest/environments");
+
+// Full-stack renderer tests need a DOM, but the real Gateway launcher resolves
+// native runner files through import.meta.url. Preserve Node module transforms
+// instead of rewriting those URLs as browser asset URLs. No product modules mocked.
+export default {
+  ...builtinEnvironments.jsdom,
+  name: "gateway-renderer",
+  viteEnvironment: "ssr",
+} satisfies Environment;

--- a/tests/helpers/hermes-startup-process.ts
+++ b/tests/helpers/hermes-startup-process.ts
@@ -1,0 +1,66 @@
+import { EventEmitter } from "node:events";
+import { vi } from "vitest";
+import type { HermesGatewayProcess, HermesGatewaySpawn } from "../../packages/gateway/src/chat/hermes-stdio-client";
+
+interface Request { id: number; method: string; params: Record<string, unknown> }
+
+export function hermesStartupProcesses(options: {
+  timeouts?: number;
+  confirmExit?: boolean;
+  ignoreMethod?: string;
+  startupFailure?: "error" | "protocol" | "exit";
+} = {}) {
+  const children: ReturnType<typeof makeChild>[] = [];
+  function makeChild() {
+    const emitter = new EventEmitter();
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const requests: Request[] = [];
+    let exited = false;
+    const send = (value: unknown) => stdout.emit("data", Buffer.from(`${JSON.stringify(value)}\n`));
+    const exit = () => { if (!exited) { exited = true; emitter.emit("exit", 0, null); } };
+    const event = (type: string, payload: unknown = {}, sessionId = "hermes_live") => send({
+      jsonrpc: "2.0", method: "event", params: { type, session_id: sessionId, payload },
+    });
+    const close = () => { if (options.confirmExit !== false) queueMicrotask(exit); };
+    const process = Object.assign(emitter, { stdout, stderr,
+      kill: vi.fn(close),
+      stdin: { end: vi.fn(close), write: vi.fn((line: string) => {
+        const request = JSON.parse(line) as Request;
+        requests.push(request);
+        if (request.method === options.ignoreMethod) return true;
+        queueMicrotask(() => {
+          const result = request.method === "session.create" || request.method === "session.resume"
+            ? { session_id: "hermes_live", stored_session_id: "hermes_durable" }
+            : request.method === "session.cwd.set" ? { cwd: request.params.cwd }
+            : request.method === "config.set" ? { key: "yolo", value: "1", scope: "session" }
+            : { status: "streaming" };
+          send({ jsonrpc: "2.0", id: request.id, result });
+        });
+        return true;
+      }) },
+    }) satisfies HermesGatewayProcess;
+    return { process, requests, event, exit, get exited() { return exited; } };
+  }
+  const spawnFn = vi.fn<HermesGatewaySpawn>(() => {
+    if (children.length >= 6) throw new Error("Unexpected extra Hermes startup attempt");
+    const child = makeChild();
+    children.push(child);
+    queueMicrotask(() => {
+      if (options.startupFailure === "error") child.process.emit("error", new Error("ENOENT"));
+      else if (options.startupFailure === "protocol") child.process.stdout.emit("data", Buffer.from("invalid\n"));
+      else if (options.startupFailure === "exit") child.exit();
+      else if (children.length > (options.timeouts ?? 0)) child.event("gateway.ready");
+    });
+    return child.process;
+  });
+  return { children, spawnFn, requests: () => children.flatMap((child) => child.requests) };
+}
+
+export const hermesStartupInput = {
+  owner: { type: "personal" as const, ownerId: "owner_hermes_start" },
+  chatId: "chat_hermes_start", turnId: "cturn_hermes_start", runId: "run_hermes_start",
+  prompt: "Inspect one module.", parts: [{ type: "text" as const, text: "Inspect one module." }],
+  selection: { instanceId: "hermes_default", model: "openai-codex:gpt-5.6-luna" },
+  interactionMode: "default", permissionMode: "full_access", executionRoot: "/safe/project",
+};

--- a/tests/helpers/hermes-startup-stream-harness.ts
+++ b/tests/helpers/hermes-startup-stream-harness.ts
@@ -1,0 +1,67 @@
+import { Hono } from "hono";
+import { KyselyPGlite } from "kysely-pglite";
+import { CanonicalProviderCatalogSchema, type CanonicalChatContentFrame } from "@matrix-os/contracts";
+import { createCanonicalProviderCatalogFixture } from "../contracts/fixtures/canonical-chat";
+import { hermesStartupInput, hermesStartupProcesses } from "./hermes-startup-process";
+import { createHermesChatProviderAdapter } from "../../packages/gateway/src/chat/hermes-provider-adapter";
+import { CanonicalChatProviderRegistry } from "../../packages/gateway/src/chat/provider-adapter";
+import { CanonicalChatOrchestrator } from "../../packages/gateway/src/chat/orchestrator";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository";
+import { createCanonicalChatEventStream } from "../../packages/gateway/src/chat/event-stream";
+import { registerCanonicalChatEventHttpRoute } from "../../packages/gateway/src/chat/event-http-route";
+import { createCanonicalChatEventSource } from "../../packages/ui/src/canonical-chat-event-source";
+
+export async function hermesStartupStreamHarness(options: Parameters<typeof hermesStartupProcesses>[0]) {
+  const process = hermesStartupProcesses(options);
+  const { owner, chatId, selection } = hermesStartupInput;
+  const principal = { userId: owner.ownerId, source: "jwt" as const };
+  const fixture = createCanonicalProviderCatalogFixture();
+  const catalog = CanonicalProviderCatalogSchema.parse({ ...fixture,
+    drivers: [{ ...fixture.drivers[0], kind: "hermes", displayName: "Hermes", capabilityClass: "system_agent" }],
+    instances: [{ ...fixture.instances[0], id: selection.instanceId, driverKind: "hermes", displayName: "Hermes",
+      models: [{ ...fixture.instances[0]!.models[0], id: selection.model, displayName: "Hermes model" }],
+      defaultSelection: selection }],
+  });
+  const db = await KyselyPGlite.create();
+  const repository = new ChatRepository(db.dialect);
+  await repository.bootstrap();
+  await repository.create(owner, { id: chatId, clientRequestId: "req_hermes_stream", title: "Hermes startup" });
+  const adapter = createHermesChatProviderAdapter({ homePath: "/safe/home", spawnFn: process.spawnFn, readyTimeoutMs: 10 });
+  const root = { ref: { kind: "project" as const, projectId: "project_startup" },
+    fingerprint: "a".repeat(64), primaryWorkspaceRoot: "/safe/project", projectSlug: "startup" };
+  const orchestrator = new CanonicalChatOrchestrator({ repository, shutdownDrainMs: 25,
+    catalog: { getCatalog: async () => catalog }, adapters: new CanonicalChatProviderRegistry([adapter]),
+    executionRoots: { resolve: async () => root, revalidate: async () => root },
+  });
+  const stream = createCanonicalChatEventStream({ repository });
+  const app = new Hono();
+  registerCanonicalChatEventHttpRoute({ app, stream, getPrincipal: () => principal });
+  const source = createCanonicalChatEventSource({ openStream: async ({ signal, cursor }) => app.request(
+    `/api/chats/events?messageVersion=2${cursor === undefined ? "" : `&cursor=${cursor}`}`,
+    { signal, headers: { accept: "text/event-stream", "x-matrix-chat-protocol": "2" } },
+  ) });
+  const frames: CanonicalChatContentFrame[] = [];
+  source.subscribe((event) => {
+    if (event.type === "chat.changed" && event.content) {
+      if (frames.length >= 256) throw new Error("Startup fixture exceeded frame limit");
+      frames.push(event.content);
+    }
+  });
+  let admittedWork = Promise.resolve();
+  return { owner, chatId, catalog, repository, source, frames, process, orchestrator,
+    getDetail: async () => (await repository.getDetailPage(owner, chatId, { limit: 200 }))!,
+    async admit(clientRequestId = "req_hermes_start_turn", baseRevision = 0) {
+      const admitted = await orchestrator.admitTurn(principal, owner, chatId, { clientRequestId, baseRevision,
+        parts: hermesStartupInput.parts, selection, permissionMode: "full_access", interactionMode: "default", executionRoot: root.ref });
+      admittedWork = orchestrator.drain();
+      return admitted;
+    },
+    async close() {
+      // Even a failed assertion releases the test-owned fake child before DB disposal.
+      process.children.forEach((child) => child.exit());
+      await orchestrator.close();
+      await admittedWork;
+      source.dispose(); stream.shutdown(); await repository.kysely.destroy();
+    },
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
     conditions: ["node"],
     alias: {
       "@matrix-os/brand/boot-screen": path.resolve(__dirname, "packages/brand/src/boot-screen.ts"),
+      "vitest-environment-gateway-renderer": path.resolve(__dirname, "tests/helpers/gateway-renderer-environment.ts"),
       "@": path.resolve(__dirname, "shell/src"),
       "@desktop": path.resolve(__dirname, "desktop/src"),
       "@renderer": path.resolve(__dirname, "desktop/src/renderer/src"),


### PR DESCRIPTION
## Summary

- Stack 2/2. Parent #1616 merged into `main` as `92e8e44bd` after exact-head Greptile 5/5, full CI and Docker smoke passed. This remaining layer has been restacked onto that current main; it requires its own fresh Greptile 5/5, CI and Preview acceptance before Graphite landing.
- Retry verified pre-prompt Codex initialization and Hermes readiness timeouts with one initial attempt plus five bounded retries and live Reconnecting activity.
- Retain actual child cleanup ownership through early Stop/shutdown, termination exceptions, and admission races. Stop may display aborted immediately without allowing overlapping same-Chat execution.
- Classify native Claude weekly quota errors safely, including mixed result/errors fields and multi-block native assistant error envelopes. Model discovery is isolated in #1616.
- Add real adapter/orchestrator/HTTP SSE/transcript controls that observe intermediate content before completion. The original Claude Steer wait was native thinking silence; this PR does not claim a speculative transport fix.

OM-234. Split by review responsibility using Graphite without changing the tested final code tree. The owner has paused the companion documentation PR: https://github.com/FinnaAI/matrix-os-site/pull/98.

## Tests

- Final post-parent restack head `63774aca470b2a984b09d3cc0613c41669876319`: 144 tests across 17 runtime, HTTP, transcript and upstream boot-screen files pass (69.20s). Workspace typecheck, full-source pattern scan and Electron Desktop production build pass. The sole conflict in `vitest.config.ts` preserves both independent aliases: main's boot-screen source and this layer's Gateway renderer test environment. Exact-head Greptile is 5/5 with all threads resolved. Full CI `34504917645`, Docker `34504917622`, Codex contracts and Preview `34503970972` are successful.
- Final Preview bundle `v2026.09.10-pr1609-34503970972-1-63774ac`: installed `release.json` and `BUNDLE_VERSION` match the reviewed head; deployment verified 15 minutes of gateway stability. Two fresh read-only Codex turns each displayed intermediate output before final completion without reload. The second retained the previous turn's context marker, and both persisted after an intentional reload. No live Claude generation or native Web UI Stop action is claimed.
- Current stack head `f9f285e37d1840194a8e17ec87b35f28c18a9f88`: all 172 tests in the 20 changed test files pass (58.34s), including catalog-composition and typed failure guards. The parent-only broader catalog/picker group also passes 87 tests across 6 files. Workspace typecheck and full-source pattern scan pass after the parent fix. The runtime slice is unchanged from Greptile-approved `0273bfd`; the parent fix and both current heads require fresh review/CI.
- Review fixes: 155 focused tests across 17 files pass, including six red-before-green mixed-envelope/post-ready cleanup regressions and three real HTTP ownership tests covering eventual exit, Stop and shutdown. Workspace typecheck and full-source pattern scan pass. The legacy Codex launch-failure fixture now exercises all five retries within a shortened fixture-only handshake budget; production timeouts are unchanged.
- Broad macOS run on `9326c0f`: 14,541 tests passed, 24 failed, 34 skipped. One failure was the now-fixed Codex fixture budget; remaining failures are in unrelated Linux host-script/checkout fixtures, onboarding tool-pack timing, billing/runtime setup, date-sensitive Todo tests and interactive terminal fixtures. This run is not described as green; Linux CI on each current stack head remains required.
- Before commit: 408 unique targeted tests across 31 files passed, full typecheck passed, Gateway build/built-module imports and Electron Desktop production build passed.
- Exact committed source: 207 non-Claude targeted tests across 17 files passed (70.20s), full typecheck passed; live Preview validation will exclude Claude at the owner's request.
- Full-source pattern scan: zero violations, five warning categories. Whitespace checks pass.
- Local root lint is environment-blocked before source evaluation: linked Next ESLint config cannot resolve its bundled parser. No dependency or lockfile changes.
- Before the review fixes, `9326c0f338ecc51784b18a641f59f1328d5b2625`: 200 non-Claude focused tests across 17 files, full typecheck, full-source pattern scan and Electron Desktop build passed.
- Initial Preview Codex 0.153.4 authentication, two live turns, intermediate/final replies without reload, and persisted transcript recovery passed; repeated final-head acceptance is recorded above. Web Canvas/Web Desktop Chat lacks a Stop control, so native UI Stop is not claimed; controlled real-runner/HTTP/transcript regressions cover cancellation and retained ownership. No live Claude generation or quota recovery is claimed.

## Large-file boundaries and extraction plan

- `chat/orchestrator.ts` remains a 1,491-line admission/lifecycle composition module. This change extracts the retained same-Chat execution predicate into the focused 20-line `dispatch-ownership.ts` helper; existing transactional admission and settlement stay in place. Future additions to admission/lifecycle should extract those domain boundaries with the real HTTP ownership regressions first, rather than growing this coordinator.
- `coding-agents/codex-app-server-runner.mjs` remains a 1,412-line process/RPC runner. Startup readiness, exit proof and retry orchestration now live in the focused 126-line `codex-provider-startup.mjs` and shared `provider-startup-retry.mjs`. The runner only wires those helpers into its existing process lifecycle. Further session/RPC decomposition is outside this recovery fix and must preserve its process-backed contract tests.
- The 891-line Hermes adapter retains one provider-execution responsibility; startup policy is separated into `hermes-startup.ts`, process cleanup into `hermes-stdio-client.ts`, and cross-provider retry budgeting into the shared helper. Claude quota classification is separated into `claude-usage-failure.ts` rather than growing the stream parser. No new behavior is added to an entrypoint above 2,000 lines in this layer.

## Invariants

### Surface matrix and visual scope

| Surface | Implementation scope | Validation boundary |
| --- | --- | --- |
| Web Canvas | Existing Chat presentation; no renderer, layout or copy change. | Shared runtime/HTTP regressions; no new visual implementation claimed. |
| Web Desktop | Existing Chat presentation and protocol; no renderer change. | Live Preview Codex intermediate/final delivery and persistence; repeat on the final bundle before merge. |
| Electron Desktop | Existing transcript and composer; no production renderer change. | Real HTTP/transcript regressions and production build pass. |
| Web Mobile | Existing mobile Chat presentation; no renderer change. | Shared backend contract tests; no new mobile device-runtime claim. |
| Native Mobile | Existing client protocol and presentation; no native implementation change. | Shared backend contract tests; no device-runtime change claimed. |

The production changes are backend execution/streaming safety only; `.tsx` changes are tests of existing UI, not styling, layout or copy. Live Claude acceptance remains explicitly excluded. Web Canvas/Web Desktop do not currently expose a Stop control in this Chat presentation; controlled adapter/HTTP/transcript tests cover cancellation instead of claiming a nonexistent live UI action.

### Source of truth

- Owner Postgres remains canonical for Chat/Turn/Run/event state. The existing process-local active execution registry remains authoritative for still-owned execution after Stop clears durable activeRun.
- Native process close/exit, not a kill signal or timeout, proves cleanup. Post-ready Hermes failures retain ownership and defer terminal delivery until actual exit, just as startup failures do.

### Lock/transaction scope

- Existing repository admission/finish transactions are unchanged. Owner/Chat-scoped stopping checks run before admission and are rechecked immediately before dispatch; exact originating request replay is preserved.
- If a racing new run is admitted after Stop, the final guard finishes that never-executed run as failed and returns the existing busy error, without starting a second process.
- Native handshakes run outside database transactions. Retries occur only before any session/prompt RPC and after the previous child is confirmed stopped.

### Acceptable orphan states

- Unconfirmed cleanup retains the exact child and execution capacity; no retry or overlapping same-Chat work. Without explicit Stop it remains nonterminal; user Stop may be visibly aborted while cleanup continues.
- Shutdown stays bounded; no guarantee that an unkillable process stopped and no new durable cross-restart process registry. Late readiness/output is fenced and terminal publication remains once-only.

### Auth source of truth

- Existing verified principals, owner scope and provider launch credential resolution remain authoritative. No new endpoints, permission bypass, credential-store reads or account switching.
- Public failures remain normalized; raw provider diagnostics and private credential digests are not exposed.

### Deferred scope

- Generic workspace readiness or already-admitted CLI/RPC work is not automatically replayed; a broader admission barrier needs separate design.
- External Claude allowance restoration and Fable 5.1 entitlement are not implemented or implied. The observed runtime metadata reports Fable 5, not Fable 5.1.
- Live Claude testing is excluded from this Preview acceptance run by request. The owner authorized agent-led testing followed by merge only after current-head Greptile 5/5 and green CI. Current-head Preview and current-main verification remain separate gates.
