### PR TITLE
docs(speech): specify consolidated platform speech and interviews

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,1 @@
-{
-  "feature_directory": "specs/121-collaboration-session-sharing"
-}
+{"feature_directory":"specs/120-platform-speech"}

--- a/specs/120-platform-speech/checklists/requirements.md
+++ b/specs/120-platform-speech/checklists/requirements.md
@@ -1,0 +1,23 @@
+# Specification Quality Checklist: Platform Speech
+
+Created: 2026-09-10  
+Feature: [spec.md](../spec.md)
+
+- [x] User-approved priorities and all original stories are retained.
+- [x] Record/stop/transcribe is the first release; live dictation and interview phases are distinct.
+- [x] User value, edge cases, measurable outcomes and acceptance scenarios are specified.
+- [x] Platform-held OpenAI credential and interchangeable provider selection are explicit.
+- [x] Source inventory covers chat, kernel transcription, channel notes, legacy services and Gemini Vocal.
+- [x] Consolidation includes removal/migration criteria, not another parallel implementation.
+- [x] Technical implementation detail is separated into research and plan documents.
+- [x] Endpoint authentication, ownership, limits, timeout, retention and metering plans are included.
+- [x] Web Canvas, Web Desktop, Electron Desktop, Web Mobile and Native Mobile scopes are explicit.
+- [x] Native Mobile reply-streaming repair remains a separate delivery workstream.
+- [x] Public documentation PR is an explicit implementation deliverable.
+- [x] No provider credential, private customer identifier or raw customer transcript is included.
+- [x] Live-provider feasibility is distinguished from a completed runtime spike.
+- [x] No blocking product clarification is outstanding; operator allowance amounts and device/model spikes are recorded as pre-rollout validation.
+
+## Review result
+
+Specification is ready for implementation planning. The design is not an implemented consolidation. Prior uncommitted experimental code remains separate and must be revised to the platform boundary before use. Provider feasibility was checked against official documentation; no live audio or paid provider request was made.

--- a/specs/120-platform-speech/checklists/requirements.md
+++ b/specs/120-platform-speech/checklists/requirements.md
@@ -16,8 +16,19 @@ Feature: [spec.md](../spec.md)
 - [x] Public documentation PR is an explicit implementation deliverable.
 - [x] No provider credential, private customer identifier or raw customer transcript is included.
 - [x] Live-provider feasibility is distinguished from a completed runtime spike.
-- [x] No blocking product clarification is outstanding; operator allowance amounts and device/model spikes are recorded as pre-rollout validation.
+- [x] No blocking product clarification is outstanding; operator allowance/unknown-usage policy and media/device/model spikes are recorded as explicit implementation gates.
 
 ## Review result
 
 Specification is ready for implementation planning. The design is not an implemented consolidation. Prior uncommitted experimental code remains separate and must be revised to the platform boundary before use. Provider feasibility was checked against official documentation; no live audio or paid provider request was made.
+
+## Self-review follow-up
+
+- [x] Runtime-bound auth, operation-specific funding, dispatch claims and cancellation races are specified.
+- [x] Client draft generations and source-audio retention have concrete migration semantics.
+- [x] Mobile repair and future live providers do not block the batch vertical slice.
+- [ ] Bounded media validation and actual account usage contract have passed a spike.
+- [ ] Allowance sources, reconciliation policy and deployment-wide resource caps are configured and tested.
+- [ ] Packaged capture and Native Mobile transport have device evidence.
+
+The unchecked items are implementation gates, not completed validation or missing product approval. See [implementation.md](../implementation.md).

--- a/specs/120-platform-speech/implementation.md
+++ b/specs/120-platform-speech/implementation.md
@@ -1,0 +1,131 @@
+# Implementation blueprint after self-review
+
+Date: 2026-09-10. Review baseline: PR #1611 at `ed7a5d78f`, against source at `d80d821b2`. These are proposed contracts, not implemented APIs. This document makes [plan.md](plan.md) concrete; [spec.md](spec.md) remains the product scope.
+
+## Findings that change implementation
+
+| Priority | Evidence and gap | Required design correction |
+|---|---|---|
+| P1 | `platform-token.ts` has both handle-only and machine/runtime-bound credentials. The plan said “existing verified identity” without choosing which. | Use runtime-bound identity, reject the legacy handle-only credential, and explicitly authorize the speech operation. |
+| P1 | `funded-ai.ts` fixes scope to `ai:invoke`; the metering repository debits machine balances. Reusing it is not a drop-in audio integration. | Add typed speech policy and server-verified usage while retaining the existing ledger, machine funding scope, and text-inference behavior. |
+| P1 | `startReservation()` returns its cached start response for an in-flight reservation. That response is not an exclusive right to call the provider. | Add a durable dispatch claim; repeated start/status requests never dispatch again. Separate execution, delivery and settlement states. |
+| P1 | Draft identity was described without specifying when it changes or how results merge. | Atomic final insertion against the current draft and generation; cancellation invalidates callbacks synchronously, including late permission resolution. |
+| P1 | `channel-voice.ts` stores source audio before transcription and downloads into memory before checking actual size. | Preserve owner source attachments; bound streaming downloads and validate redirects/SSRF. Temporary dictation and imported source retention are distinct. |
+| P2 | The mobile subscription effect depends only on `computerKey`, and content handling invalidates query snapshots. | Key transport lifetime to user/runtime/generation, merge content locally and fence stale snapshots. Subscribe before connecting. |
+| P2 | “One service” could become a prerequisite to rebuilding all Vocal/onboarding behavior before basic recording ships. | Deliver one batch vertical slice first. Later live adapters share contracts without forcing a speculative universal audio framework. |
+
+## Concrete module ownership
+
+| Location | Responsibility | Excluded responsibility |
+|---|---|---|
+| `packages/contracts/src/speech/` | Versioned Zod schemas, safe error codes, capability/status/result types | Provider SDK types, browser globals, secrets |
+| `packages/platform/src/speech/service.ts` | Admission, dispatch claim, cancellation coordination, outcome normalization | HTTP parsing or microphone handling |
+| `packages/platform/src/speech/operations.ts` | Kysely operation metadata and conditional transitions | A second wallet, transcript persistence |
+| `packages/platform/src/speech/adapters/openai.ts` | File transcription, bounded upstream I/O, usage normalization | Owner resolution, public error strings |
+| `packages/platform/src/speech/media.ts` | Format/duration validation with resource caps | Trusting client MIME/duration |
+| `packages/gateway/src/speech/` | Authenticated routes and injected platform client | Direct speech provider credentials/calls |
+| `packages/ui/src/speech/` | Pure lifecycle reducer, controller, shared controls and capture adapter | Chat creation or provider selection |
+| Extracted kernel transcription tool | Safe owner file opening and injected `transcribe` port | Importing gateway internals or constructing a provider |
+
+Names may adapt to repository conventions. The kernel depends on a narrow contract supplied by gateway composition, not on the gateway package. Web Canvas, Web Desktop and Electron Desktop mount the same controls. Use surface adapters only for transport and microphone permissions. Ship only the file adapter initially; test provider replacement with a deterministic fake. Grok and Gemini dependencies are unnecessary for that first slice.
+
+## First release wire contract
+
+- `GET /api/speech/capabilities`: `contractVersion`, `fileTranscription` readiness, stable unavailable reason, supported encodings, effective byte/duration/text limits. No provider name/key, model catalog or inference-account dependency. Readiness is advisory; admission rechecks it.
+- `POST /api/speech/transcriptions`: one multipart audio file plus bounded request ID, source kind and optional language hints. Source kind is `dictation` or `owner_audio`; the gateway derives/authorizes it for each caller. No caller-selected provider, model, owner, funding source, file URL, system prompt or tools. Draft identity remains client-side; the platform does not need chat history or draft text.
+- Successful response: `contractVersion`, `requestId`, final `text`, validated `audioDurationMs`, completion status. No speech is a safe explicit outcome that leaves the draft unchanged. All responses use `Cache-Control: no-store` and exclude content from tracing.
+- `GET /api/speech/transcriptions/:requestId`: metadata-only status for uncertain outcomes; never replay a transcript. Include execution state and whether a new attempt is safe or may consume allowance again.
+- `DELETE /api/speech/transcriptions/:requestId`: idempotent cancellation request, with `bodyLimit` even for an empty body. Return whether execution had already started; do not promise a refund or immediate provider cancellation.
+- Mirror the three transcription operations under `/internal/speech/transcriptions`; use the same owner/machine/runtime checks for POST, GET and DELETE. Unknown or foreign operation IDs reveal no ownership details. Validate path IDs and all metadata with bounded Zod schemas.
+
+A POST stays synchronous; this release does not need an audio job queue or persisted response cache. GET and DELETE exist to resolve cancellation and lost-response state. Only the original successful POST carries text. Client retries of transport errors are disabled by default.
+
+### Authentication and allowance
+
+Reuse the machine/runtime lookup and constant-time verification pattern in `ai-funded-policy-routes.ts`. Authenticate bounded credentials before reading audio, verify a currently running machine/runtime and its owner in platform DB, then require explicit `speech:transcribe` policy. The existing runtime-bound credential authenticates the machine; it does not confer speech eligibility by itself. Do not accept the Gemini handle-only token. Revocation must be a checked policy/machine state, not an assumption that HMAC values expire. Future scoped session grants are a separate change.
+
+Introduce a typed operation discriminator in shared admission policy rather than weakening `ai:invoke` to arbitrary strings. Keep speech configuration independent of text-model allowlists. Reservations retain the existing machine account and owner identity; do not silently convert funding into an owner-wide wallet. Owner-wide abuse limits additionally prevent bypass by switching runtime slots. Platform selection pins adapter, model and pricing revision for each accepted operation.
+
+Use the existing ledger transaction primitives through a focused extension. Reservation, operation linkage and settlement mutations are atomic; a failed operation insert cannot leave an untracked hold. Namespace request IDs by operation and verified identity, independent of credential rotation. Preserve promotional/add-on source restrictions and test that speech cannot spend a text-only grant. Allowance configuration must explicitly identify eligible sources; missing speech policy means unavailable. No new customer pricing or automatic add-on purchase is implied.
+
+## Execution, delivery and money are separate states
+
+Persist non-content metadata: verified identity, operation/request ID, source kind, keyed content fingerprint, policy/pricing revision, reservation ID, execution state, cancellation flag, dispatch claim, timestamps/deadline, safe outcome code and normalized usage. Do not store transcript, raw audio, chat context or provider error body. A fingerprint is scoped metadata, not cross-owner deduplication; restrict access and expire it with the operation.
+
+| Transition | Required behavior |
+|---|---|
+| Receive → validated | Acquire bounded upload capacity; validate actual media. No provider work yet. |
+| Validated → reserved | Atomically reserve allowance and link operation. Same ID plus different audio/options returns conflict. |
+| Reserved → dispatching | Conditional DB claim granted to exactly one handler, committed before upstream call. Recheck cancellation and policy. |
+| Dispatching → succeeded/failed/uncertain | Persist outcome/usage metadata. A timeout or crash after dispatch intent is uncertain, not proof of zero usage. |
+| Reserved → cancelled | Win a conditional race against dispatch, release hold once; never call provider. |
+| Dispatching + cancel requested | Abort transport best-effort, suppress UI insertion immediately; reconcile billable usage independently. |
+| Terminal → settled/released | Idempotent ledger finalization in a transaction; late completion and cleanup cannot debit twice. |
+
+There is no exactly-once provider guarantee across a network/process failure. Guarantee at most one application dispatch attempt per operation, disable hidden SDK retries, and guarantee idempotent ledger effects. A replayed reservation-start receipt is not a new dispatch claim. Do not lease/reassign a dispatched operation to another worker. Recovery reconciles it without redispatching audio.
+
+Cancellation arriving before POST registration creates a bounded authenticated tombstone for that ID; a later POST cannot resurrect it. Rate-limit these writes. Multi-instance cancellation uses the durable flag plus a bounded check/notification path, not only an in-memory AbortController. Every control read/write revalidates owner and runtime.
+
+Set a finite reconciliation deadline in policy. Before rollout, specify how unknown usage closes under the existing conservative settlement mechanism and how later authoritative usage corrects it; do not silently release a possibly billable hold or leave it forever. Customer allowance effects must match documented policy, including cancellation after dispatch. Metadata retention must outlast supported retry/reconciliation windows; once metadata expires, expired request IDs cannot be reused as new operations. Use timestamped bounded request IDs and enforce their admission age.
+
+A lost final response displays: “The transcription result could not be recovered. Trying again may use your speech allowance again.” A deliberate retry uses a new ID and existing local audio only while that attempt remains active. Clear retained audio on success, cancellation, identity change or a five-minute retry timeout. A successful metadata status does not mean text can be downloaded again.
+
+## Shared draft behavior
+
+```text
+idle → requesting_permission → recording → uploading → transcribing → idle
+                                   └ stop                   └ final inserted
+any active state → cancel/identity change → idle (generation invalidated)
+any active state → failure → recoverable error (typed draft remains)
+```
+
+- Bind to user, machine/runtime, composer instance, draft ID and draft generation. New draft, clear, send, sign-out or runtime change increments generation. Ordinary typing does not. No chat needs to be created to dictate into a new draft.
+- The completion action reads the current draft in one store update and appends the final transcript once with appropriate whitespace. It preserves intervening edits and attachments. Do not read a captured textarea value. Track applied request ID within bounded draft state; repeated finals do nothing.
+- Keep provisional transcript in a separate preview; never overwrite editable text with partials. On overflow, preserve the complete bounded result in a review area with copy/discard actions; never truncate into the draft.
+- All submit paths (button, Enter, shortcut and queued send) share the same active-dictation guard. The guard ends on cancellation or completion. Transcription readiness and selected harness send-readiness are separate.
+- Cancel invalidates the attempt synchronously before asynchronous cleanup. Late microphone permission immediately stops every returned track. Navigation tears down the capture session; it never moves an attempt to a newly mounted composer.
+- One microphone lease per renderer, with cross-window coordination where available; server admission still prevents simultaneous paid attempts exceeding policy. Switching presentation ends active capture without losing typed draft text. Browser/tab limitations must be tested, not presented as an OS-wide exclusive microphone guarantee.
+- Electron grants microphone permission only to the trusted renderer and relevant origin. Preserve embedded untrusted web-content denial. Verify packaged usage description, entitlements and gateway-scoped CSP without broad media/network allowances.
+
+## Media admission and retention
+
+Two limits are independent: compressed upload bytes and decoded audio duration. Initial dictation remains 120 seconds/10 MiB; multipart overhead has its own small cap. Duration metadata alone is insufficient for hostile files. The media spike must prove bounded decode/sample counting or an equally sound duration validation path, including malformed and misleading containers. Cap CPU time, decoded samples, subprocess count, memory and temp bytes. No unbounded transcoding. Explicitly package and maintain a decoder if required; do not assume ffmpeg is installed on the host.
+
+Acquire upload/probe capacity before buffering or decoding, then monetary reservation before provider work. Include gateway buffers, platform buffers, multipart copies and decoder output in the measured memory budget. Initial canary defaults: one active operation per owner, ten admissions per owner per minute and four concurrent media/provider operations per platform process, with a separately configured deployment-wide cap. Shared DB leases/counters enforce aggregate limits across replicas. Reject excess work instead of queueing audio. Validate these defaults under load before expanding them.
+
+Control calls have a 10-second timeout. File POST has a proposed 65-second total deadline starting at upload, with bounded stage budgets; abort signals combine user cancellation and remaining timeout. A slow upload cannot leave the provider a fresh unbounded minute. Return explicit safe timeout states rather than retrying upstream.
+
+The 120-second dictation limit must not silently become the import limit. Inventory existing supported owner files/channel recordings before migration and define a separately bounded `owner_audio` policy with compatibility fixtures. If a previously accepted format/length cannot be supported safely, document the limitation and migration before replacing that caller. No automatic audio slicing or summarization in this release.
+
+Channel source attachments already live in the owner's home. Preserve them according to existing owner retention, even when transcription is unavailable; delete only generated temporary copies. Validate download destinations, reject redirects or revalidate every hop, enforce SSRF protection and streaming byte limits before allocation. Owner-file tools resolve within authorized roots and reject symlink escape. Platform sees bounded bytes, never a caller URL or local path.
+
+## Delivery units and exit gates
+
+| Unit | Reviewable deliverable | Gate |
+|---|---|---|
+| A: admission/media spike | Actual format, duration, usage and timeout evidence; funding schema migration design | No assumed decoder, price unit or provider access. Synthetic/consented audio only. |
+| B: batch vertical slice | Contracts, platform file adapter and ledger extension, gateway facade, shared composer controls behind disabled capability | End-to-end fake provider test, concurrency/crash/cancel tests, no automatic Send and no leaked key |
+| C: caller consolidation | Kernel/channel injection, old STT code removal, source-audio preservation | Caller inventory closed, supported import fixtures and retained TTS/telephony tests pass |
+| D: surface release | Shared Web Canvas/Web Desktop/Electron Desktop/Web Mobile behavior | Packaged microphone tests, real latency/language evidence, source docs PR; enable only after B/C |
+| M: independent mobile fix | Transport selected from device spike; shared pure merge/recovery code | Device deltas, account switch, foreground, replay gap and stale snapshot tests |
+| E: progressive/live dictation | File-preview enhancement first, then normalized realtime segments | One final insertion, no duplicate paid fallback, bounded session lifetime and metering |
+| F: interviews | Shared session UI, explicit save/start-work, provider adapters and Gemini migration | Canonical tool approvals/deduplication and onboarding parity before old live stack removal |
+
+B may be developed before C completes but cannot be declared consolidated until C passes. M is independently shippable and does not block a validated speech release. Do not require Grok/Gemini realtime rewrites for A–D. Rollback disables speech capability; it never restores a direct runtime-key STT fallback. Deploy additive platform contracts before gateway/client rollout and keep compatibility until supported clients migrate.
+
+For M, extract the existing pure `canonical-chat-content.ts` merger into a runtime-neutral shared export without pulling React DOM into Expo. Subscribe before connection startup; fence every callback and REST response by user/runtime/connection generation. Apply deltas to detail state without list refetch per token; invalidate list membership on creation/deletion and coalesce status changes. Negotiate content protocol explicitly, handle cursor gaps with authoritative snapshots, and reconnect with fresh auth. Compare Expo HTTP streaming against the existing WS route on a real device before selecting one.
+
+Later interview context is explicit and bounded; never send the whole chat/home by default. Dictation has no tools; interview tools exclude computer actions, with save/start-work driven by explicit UI intent. Assistant mode invokes the canonical gateway/kernel tool executor with normal approvals and idempotent identities. Store saved briefs/transcripts only in owner-controlled storage through existing APIs. Changing providers takes effect on a new session, not midway through an active conversation.
+
+## Required failure tests
+
+1. Two POSTs with the same ID; same ID with different bytes/options; key rotation during retry.
+2. Crash before reservation commit, after dispatch claim, after provider completion and before settlement.
+3. Cancel before registration, during upload, racing dispatch, and after provider success; cancel served by another replica.
+4. Missing/foreign/revoked runtime identity and text-only promotional credit presented for speech.
+5. Oversized multipart metadata, no Content-Length, malformed media, forged duration and parallel memory pressure.
+6. Permission resolves after cancel; typing during transcription; clear/new chat/runtime switch; duplicate final; keyboard send during capture.
+7. Channel audio remains available when STT fails; owner file traversal/symlink and redirected download rejected.
+8. Mobile account change on the same computer, old snapshot after new delta, duplicate/reordered content, reconnect with an expired cursor, final status received while backgrounded.
+
+These are implementation acceptance tests, not tests executed by this documentation review. Operator allowance/unknown-usage policy and the media/device spikes remain explicit implementation gates.

--- a/specs/120-platform-speech/plan.md
+++ b/specs/120-platform-speech/plan.md
@@ -1,0 +1,123 @@
+# Platform Speech implementation plan
+
+Status: proposed implementation design, following accepted product direction. This plan does not enable credentials or deploy a service.
+
+## Service boundaries
+
+```mermaid
+flowchart LR
+  C[Shared chat dictation or interview UI] --> G[Authenticated runtime speech facade]
+  K[Kernel transcription tool and channel voice notes] --> G
+  G --> P[Platform Speech service]
+  P --> A[Capability policy and usage reservations]
+  P --> O[OpenAI adapter]
+  P --> X[Grok adapter - later]
+  P --> M[Gemini compatibility adapter]
+  P --> G
+  G --> C
+  G --> T[Canonical chat and kernel tool authorization]
+```
+
+- `packages/contracts/src/speech/`: versioned capability, request, result, lifecycle event, and safe error schemas. No long-lived key or provider-native event crosses this boundary.
+- `packages/platform/src/speech/`: one service owning provider selection, secrets, policy admission, normalization, cancellation, and settlement. Keep adapters for different capabilities focused; do not force a transcription model to implement conversation tools.
+- `packages/gateway/src/speech/`: thin owner/runtime-authenticated facade and managed platform client. It handles owner file access and canonical chat/tool integration, not provider calls or provider selection.
+- `packages/ui/src/speech/`: shared recording state/controller and Web/Electron components. Surfaces supply authenticated transport, permission adapters, and draft identity. Native Mobile later supplies its own microphone adapter using the same contracts.
+- Existing platform AI funding repositories remain the budget source of truth. Extend operation/model policy and verified speech usage; do not build a second wallet or use arbitrary text-token estimates for audio.
+- Provider credentials reside only in platform infrastructure. The runtime facade uses its existing verified machine identity, with a speech-specific capability authorization. It receives neither the OpenAI key nor a broad-purpose provider token.
+
+One implementation means one service and client lifecycle with explicit adapters. Purpose-specific interview/onboarding prompts can differ; transport, policy, storage, and execution must not fork.
+
+## Proposed endpoint authentication matrix
+
+All routes are proposed names. Verify platform routing order and reserve these namespaces before implementation.
+
+| Route | Caller/authentication | Owner/runtime authority | Public? | Phase |
+|---|---|---|---|---|
+| `GET /api/speech/capabilities` | Existing authenticated Web/Electron gateway session | Gateway principal and selected runtime | No | 1 |
+| `POST /api/speech/transcriptions` | Same gateway auth; body limit before buffering | Same; caller supplies request/draft ID, never authoritative owner | No | 1 |
+| `GET /internal/speech/capabilities` | Verified runtime-to-platform credential | Platform resolves machine, runtime and owner from authenticated registration | No | 1 |
+| `POST /internal/speech/transcriptions` | Same, plus explicit speech capability policy | Same; reservation keyed to verified identity and operation | No | 1 |
+| `POST /api/speech/sessions` | Authenticated gateway principal | Binds chat/draft, mode and runtime server-side | No | Later |
+| `DELETE /api/speech/sessions/:id` | Same; body limit even with empty body | Session owner and runtime match | No | Later |
+| Session media channel, path selected by spike | Authenticated short-lived session grant or authenticated relay | Session bound to owner/runtime; grants scoped to one capability/session | No | Later |
+| Existing `/ws/vocal` or STT aliases during migration | Existing route auth, then canonical authorization | Same service; no local provider fallback | No | Transition only |
+
+Platform service authentication is not just accepting an owner ID passed by a VPS. Resolve and compare machine/runtime ownership using the platform database, reject inactive/revoked credentials, and verify speech policy for each admission. Local/self-hosted gateways without a managed platform relationship report speech unavailable; do not silently fall back to a runtime key.
+
+## Recording request lifecycle
+
+1. Read coarse capability readiness and limits. Missing configuration is an unavailable service, not “file not found.”
+2. Bind a request ID to owner, runtime, chat/draft and draft generation. Capture begins only on user action.
+3. Record with a supported codec; prefer negotiated WebM/Opus or MP4 for browser compatibility. Stop/cancel always releases tracks.
+4. On Stop, upload bounded audio to the gateway facade. The facade validates media headers, actual supported format and size; authenticated identity is never taken from audio metadata.
+5. Platform checks capability eligibility, rate and concurrency limits, and creates an atomic usage reservation before provider work. The provider/model are selected from server policy.
+6. Platform adapter transcribes and validates the response. For optional streamed file output, normalize provisional updates and one final result; never equate a chunk with an independently submitted chat message.
+7. Reconcile the final result into the same draft once. Preserve intervening typing and attachments. Display overflow instead of silently truncating.
+8. Release buffers; settle usage exactly once. The ordinary Send path later creates the chat turn.
+
+### Retry and uncertain outcomes
+
+Use a request ID scoped to verified owner/runtime plus a bounded content fingerprint to reject ID reuse with different audio. Do not persist raw transcripts at the platform for replay. Keep non-content operation/usage metadata in Postgres with explicit retention and reconciliation.
+
+A lost response after provider execution is an uncertain outcome: no silent automatic re-run. The client retains its local recording only within its bounded active attempt, shows a deliberate retry action and sends a new request ID for a new billable attempt. Pre-execution retries use the existing ID and admission state. Reserve/start/finalize transitions must prevent concurrent duplicate upstream execution and double settlement.
+
+## Limits, cancellation and privacy
+
+- Proposed first release bounds: 120 seconds, 10 MiB audio, 32,000 transcript characters; 10-second control requests and 65-second end-to-end file transcription deadline. Validate deadlines against measured model behavior.
+- Enforce upload limits at every receiving boundary using streaming body limits. Do not trust client-reported duration or infer seconds from compressed byte size.
+- To enforce duration/cost, spike a bounded media probe in platform infrastructure or reserve a safe encoding-specific worst case validated against actual format. The implementation must not claim a hard duration limit without server-side verification.
+- Per-owner/runtime and global concurrency/rate caps, bounded registries, TTL/stale eviction and shutdown drains. Initial policy values must be explicit and tested; these are operational limits, not new commercial prices.
+- Provider URLs are platform configuration allowlists, never user URLs; reject redirects. Cancellation propagates through gateway and platform to the provider connection, subject to upstream cancellation semantics.
+- No raw audio or transcript in platform logs, analytics, exception payloads or usage rows. Provider retention requirements must be separately verified; use available controls without asserting guarantees not supported by the account.
+- No automatic microphone resume after navigation, disconnect or session restart. Dictation UI keeps typed draft state on errors.
+- Avoid temp files where possible. If a media probe needs one, use exclusive creation, bounded storage, symlink-safe recurring cleanup, and finally cleanup.
+
+## Live dictation and interviews
+
+### Enhancement A: progressive transcript after Stop
+
+Retain the recording/upload lifecycle. If the OpenAI file adapter supports it, stream partial text into a separate preview and commit the authoritative final text once. This improves perceived wait without maintaining an open microphone session.
+
+### Enhancement B: true live dictation
+
+Use a transcription-only session. Normalize `segmentId`, revision/sequence, provisional text, finalized text and end reason. Share the recorder/audio pipeline where practical, but use the negotiated PCM/WebRTC encoding rather than sending MediaRecorder chunks as if each were a complete file. Never fake live streaming with repeated overlapping uploads.
+
+A live failure does not trigger automatic full-recording retranscription. Preserve finalized text, mark incompleteness, and offer a deliberate retry/re-record action. Any fallback to batch must use valid retained audio, explicit user action, and its own admission decision.
+
+### Later: interview and action sessions
+
+- One session controller handles connecting, listening, thinking, speaking, interrupted, reconnecting, ended and failed states. Shared transcript and controls ship on Web Canvas, Web Desktop and Electron Desktop.
+- Session creation carries a Matrix mode (`dictation`, `interview`, `assistant`) and bounded topic/context. It does not accept arbitrary provider tools or an unrestricted system prompt from the browser.
+- Platform adapters normalize audio input/output, transcript deltas/finals, interruptions, usage and tool requests. Provider/model selection is pinned for the session.
+- The gateway validates and executes tool requests through the existing canonical chat/kernel path. Stable tool IDs, owner scope, approvals and bounded results are mandatory. Provider tool requests never directly run shell commands or bypass the selected harness's permissions.
+- Interview mode asks questions and produces a reviewable brief. “Start work from this brief” is explicit. Retain no separate provider conversation store as Matrix's user data source of truth.
+- Reuse/upgrade the current Gemini Vocal flow through a compatibility adapter, then retire `/internal/containers/:handle/gemini-live` and provider-specific client events after rollout. Onboarding stays a workflow using the same session engine.
+- Prefer an initial platform-relayed media path when it is needed to enforce session lifetime, tool authority and metering. Spike direct WebRTC with ephemeral credentials and a server control channel for latency. A short-lived connection token is not enough to prove active-session cost limits or trusted settlement.
+- OpenAI and Grok adapters must each prove interruption, cancellation, usage accounting and tool-call deduplication. Shared JSON similarity is not proof of API interchangeability.
+
+## Native Mobile chat streaming companion work
+
+Reproduce the failure on the current Expo development client and latest gateway. Compare authenticated HTTP content streaming via Expo-compatible streaming fetch with extending the existing native WebSocket route to opt into content. Prefer the transport with demonstrated device behavior and least duplicate infrastructure; choose based on the spike, not the paused prototype.
+
+Whichever transport wins, use shared canonical content reducers and message-version negotiation, replay-gap snapshot recovery, bounded cursor deduplication, heartbeat/inactivity handling, fresh credentials and AppState foreground recovery. Prevent an older REST response from rolling back a newer streamed revision. Polling remains a bounded recovery path instead of the normal token delivery path. Test list creation/deletion updates as well as active-chat content.
+
+## Consolidation and delivery sequence
+
+1. **Contracts and platform foundation**: failing tests for auth, key isolation, capability policy, admission, usage, safe errors and adapter normalization; implement OpenAI file transcription. Scope the funded-policy schema extension before coding. Extract focused modules instead of adding substantial behavior to `server.ts` or `ipc-server.ts`.
+2. **Caller migration and UI**: migrate chat capture, kernel `transcribe`, and channel STT to the same managed client. Wire every consumer at registration. Remove duplicate direct provider STT code and the unused Web Speech API path. Preserve TTS/telephony separately and test their STT dependencies. Never remove or rotate owner-supplied keys as part of this cleanup.
+3. **Cross-surface validation**: Web Canvas first, Web Desktop next, Electron Desktop next; Web Mobile capture compatibility. Check Electron microphone permission description/entitlement, CSP, origin checks and trusted renderer permission handling. Test stop/cancel, draft identity, limits, accessibility, language and privacy.
+4. **Native Mobile streaming repair**: independently ship the chosen transport/reducer/recovery changes after real-device reproduction and acceptance tests. Keep the original repair objective visible; do not bury it inside voice work.
+5. **Progressive file transcription / live dictation spike**: benchmark latency, audio format, interruption/recovery, permission behavior and verified usage. Enable each capability only when all applicable surfaces pass; keep batch dictation available otherwise.
+6. **Interview/session migration**: adapt Gemini compatibility, add OpenAI and Grok session adapters, connect canonical tools, and ship one shared interview UI. Remove the old Vocal provider-specific stack once workflow parity is verified.
+7. **Documentation and delivery**: implementation PR(s) plus a separate `FinnaAI/matrix-os-site` documentation PR under `content/docs/`, covering microphone setup, retention, limits, language support and modes. Greptile 5/5 before merge. Roll out platform service before enabling client capabilities. Validate an exact host bundle on a disposable feature VPS; native packaging is a separate release gate.
+
+## Verification and completion evidence
+
+- Contract fixtures run unchanged against OpenAI, alternate test adapter, and later Grok/Gemini adapters.
+- Route auth matrix tests cover unauthenticated, wrong-owner/runtime, revoked credential, malformed input, body limits and disabled policy.
+- End-to-end mocked wiring test: shared client → gateway → platform admission/provider stub → final transcript; assert no chat turn before Send, no key at runtime, and exactly one usage settlement.
+- Kernel/channel tests prove delegation to the same client, safe file resolution, registration-time dependencies and consistent error behavior.
+- UI/component and packaged-device tests cover all US-01–03 and US-06–08 states. Real audio latency/language results are recorded without committing private recordings.
+- Mobile tests cover live deltas, final outcomes, gap recovery, stale REST responses, network partitions, expired tokens, account/runtime switches and foreground recovery.
+- Static inventory confirms no active direct STT provider calls remain outside platform adapters; compatibility aliases have callers, tests, removal criteria and no independent provider state.
+- Scoped tests/typechecks precede broader required checks. No success claim based solely on the earlier runtime-local prototype's green tests.

--- a/specs/120-platform-speech/plan.md
+++ b/specs/120-platform-speech/plan.md
@@ -1,6 +1,6 @@
 # Platform Speech implementation plan
 
-Status: proposed implementation design, following accepted product direction. This plan does not enable credentials or deploy a service.
+Status: proposed implementation design, following accepted product direction. This plan does not enable credentials or deploy a service. See [implementation.md](implementation.md) for the reviewed module boundaries, wire contract, dispatch state machine, draft lifecycle and delivery gates.
 
 ## Service boundaries
 
@@ -12,7 +12,7 @@ flowchart LR
   P --> A[Capability policy and usage reservations]
   P --> O[OpenAI adapter]
   P --> X[Grok adapter - later]
-  P --> M[Gemini compatibility adapter]
+  P --> M[Gemini compatibility adapter - later]
   P --> G
   G --> C
   G --> T[Canonical chat and kernel tool authorization]
@@ -34,8 +34,10 @@ All routes are proposed names. Verify platform routing order and reserve these n
 | Route | Caller/authentication | Owner/runtime authority | Public? | Phase |
 |---|---|---|---|---|
 | `GET /api/speech/capabilities` | Existing authenticated Web/Electron gateway session | Gateway principal and selected runtime | No | 1 |
-| `POST /api/speech/transcriptions` | Same gateway auth; body limit before buffering | Same; caller supplies request/draft ID, never authoritative owner | No | 1 |
+| `POST /api/speech/transcriptions` | Same gateway auth; body limit before buffering | Same; caller supplies request ID; draft binding stays client-side, never authoritative owner | No | 1 |
 | `GET /internal/speech/capabilities` | Verified runtime-to-platform credential | Platform resolves machine, runtime and owner from authenticated registration | No | 1 |
+| `GET /api/speech/transcriptions/:requestId` and internal equivalent | Authenticated principal/runtime credential | Same owner, machine and runtime as operation; metadata only | No | 1 |
+| `DELETE /api/speech/transcriptions/:requestId` and internal equivalent | Same, with body limit and cancellation rate limit | Same operation scope; idempotent cancel | No | 1 |
 | `POST /internal/speech/transcriptions` | Same, plus explicit speech capability policy | Same; reservation keyed to verified identity and operation | No | 1 |
 | `POST /api/speech/sessions` | Authenticated gateway principal | Binds chat/draft, mode and runtime server-side | No | Later |
 | `DELETE /api/speech/sessions/:id` | Same; body limit even with empty body | Session owner and runtime match | No | Later |
@@ -59,13 +61,13 @@ Platform service authentication is not just accepting an owner ID passed by a VP
 
 Use a request ID scoped to verified owner/runtime plus a bounded content fingerprint to reject ID reuse with different audio. Do not persist raw transcripts at the platform for replay. Keep non-content operation/usage metadata in Postgres with explicit retention and reconciliation.
 
-A lost response after provider execution is an uncertain outcome: no silent automatic re-run. The client retains its local recording only within its bounded active attempt, shows a deliberate retry action and sends a new request ID for a new billable attempt. Pre-execution retries use the existing ID and admission state. Reserve/start/finalize transitions must prevent concurrent duplicate upstream execution and double settlement.
+A lost response after provider execution is an uncertain outcome: no silent automatic re-run. The client retains its local recording only within its bounded active attempt, shows a deliberate retry action and sends a new request ID for a new billable attempt. Pre-execution retries use the existing ID and admission state. A separate durable dispatch claim prevents duplicate application dispatch; replaying the existing funding start receipt is not permission to call upstream. Ledger finalization is idempotent. Process/network failures can still leave provider execution uncertain; see the state table and cancellation tombstones in [implementation.md](implementation.md).
 
 ## Limits, cancellation and privacy
 
 - Proposed first release bounds: 120 seconds, 10 MiB audio, 32,000 transcript characters; 10-second control requests and 65-second end-to-end file transcription deadline. Validate deadlines against measured model behavior.
 - Enforce upload limits at every receiving boundary using streaming body limits. Do not trust client-reported duration or infer seconds from compressed byte size.
-- To enforce duration/cost, spike a bounded media probe in platform infrastructure or reserve a safe encoding-specific worst case validated against actual format. The implementation must not claim a hard duration limit without server-side verification.
+- To enforce duration/cost, spike bounded decode/sample counting or equally sound validation in platform infrastructure; container metadata alone is insufficient. The implementation must not claim a hard duration limit without server-side verification.
 - Per-owner/runtime and global concurrency/rate caps, bounded registries, TTL/stale eviction and shutdown drains. Initial policy values must be explicit and tested; these are operational limits, not new commercial prices.
 - Provider URLs are platform configuration allowlists, never user URLs; reject redirects. Cancellation propagates through gateway and platform to the provider connection, subject to upstream cancellation semantics.
 - No raw audio or transcript in platform logs, analytics, exception payloads or usage rows. Provider retention requirements must be separately verified; use available controls without asserting guarantees not supported by the account.

--- a/specs/120-platform-speech/research.md
+++ b/specs/120-platform-speech/research.md
@@ -1,0 +1,60 @@
+# Speech consolidation research
+
+Date: 2026-09-10. Baseline: fetched `origin/main` at `d80d821b2`. Findings concern repository wiring, not live production credentials or observed device behavior.
+
+## Existing paths and migration disposition
+
+| Existing path | Finding | Disposition |
+|---|---|---|
+| `packages/gateway/src/voice.ts` | Separate ElevenLabs STT/TTS service with its own config and cost estimates | Remove its direct STT implementation; migrate retained TTS behavior behind a single capability adapter when needed |
+| `packages/gateway/src/voice/index.ts`, `voice/stt/whisper.ts` | Another voice service, selecting Whisper from runtime config/environment | Replace runtime provider construction with the managed speech client; migrate useful provider tests into the platform adapter |
+| `packages/gateway/src/voice/routes.ts`, `voice/voice-ws.ts` | REST STT route factory and a voice flow that transcribes, dispatches to the kernel, and synthesizes a response; not registered in the current server bootstrap | Retire dead wiring. If an older supported client needs an alias, forward to canonical operations; never auto-dispatch dictation |
+| `packages/kernel/src/ipc-server.ts`, tool `transcribe` | A third direct transcription call to ElevenLabs, reading runtime credentials and owner audio files | Extract the tool into a focused module, inject managed transcription at registration, validate owner-relative paths, preserve normal tool permissions |
+| `packages/gateway/src/voice/channel-voice.ts`, `channels/telegram.ts` | Channel voice-note helper accepts an injected STT provider; adapter has `setVoiceContext`, but no call was found in current server bootstrap | Reuse channel preprocessing and inject canonical speech client. Add a registration-to-transcription test; do not claim currently enabled Telegram transcription |
+| `shell/src/hooks/useVoice.ts`, `components/ChatApp.tsx` | Chat microphone uses the unregistered `/ws/voice` flow; final text replaces draft content | Replace with shared dictation controller and ordinary manual Send |
+| `shell/src/components/ai-elements/speech-input.tsx` | Browser speech-recognition component exists, no external caller found | Remove unused direct browser transcription or make it a facade over the shared service; no independent browser-provider fallback |
+| `packages/platform/src/voice-env.ts` | Helper can emit OpenAI/ElevenLabs keys into managed runtime env; current provisioning use was not established | Remove platform transcription-key propagation and test generated configuration; preserve unrelated owner-supplied credentials and telephony behavior |
+| `packages/platform/src/gemini-live-proxy.ts` | Platform-held Gemini key and internal runtime proxy already exist | Migrate into the common speech-session service as a compatibility provider adapter; retire provider-specific route after consumers migrate |
+| `packages/gateway/src/onboarding/gemini-live.ts`, `onboarding/ws-handler.ts`, `vocal/ws-handler.ts` | Shared Gemini transport but provider-coupled orchestration/protocol; `/ws/vocal` is registered | Keep onboarding/interview purpose-specific workflows, use the same capability/session engine and normalized events |
+| `shell/src/hooks/useVocalSession.ts`, `components/VocalPanel.tsx` | Existing Web voice capture/playback and overlay, including a PCM worklet and delegation to chat | Extract reusable capture/playback and presentation. Validate Web Canvas parent-overlay wiring; add shared Electron Desktop presentation rather than duplicate the hook |
+| `packages/proxy/src/funded-relay*.ts`, platform funded policy/metering | Existing managed AI admission, reservations and settlement; relay payload/model code is Anthropic text-specific | Reuse funding invariants and repositories, explicitly add speech capabilities/usage units; do not proxy audio through the Anthropic Messages implementation |
+| Native Mobile canonical chat event source/detail query | Legacy metadata WebSocket and frequent snapshot polling; misses replay-gap handling; current HTTP stream supports content frames | Share content merge/recovery. Spike native HTTP streaming versus versioned WebSocket support before choosing transport |
+
+The paused experimental implementation adds another runtime-local Whisper route. It is not the desired consolidation and is not part of this specification's release deliverable.
+
+## Provider feasibility
+
+### OpenAI
+
+The current [file transcription guide](https://developers.openai.com/api/docs/guides/speech-to-text) recommends `gpt-transcribe` for new general-purpose file transcription. It supports returning partial transcript events after an already-recorded file is submitted. The existing `whisper-1` implementation does not support that streaming mode. Proposed evaluation candidate: `gpt-transcribe`, with model selection retained in platform policy and verified using the actual account.
+
+The [realtime transcription guide](https://developers.openai.com/api/docs/guides/realtime-transcription) documents transcription-only sessions, incremental and finalized transcript events, and `gpt-live-transcribe`. It distinguishes microphone transcription from spoken assistant responses. Therefore live dictation is technically feasible but has a different audio/session lifecycle from uploaded recordings.
+
+These are documentation findings, not completed integration spikes. Do not reuse Whisper-specific response-format or audio assumptions without checking the chosen model contract.
+
+### Grok
+
+The [speech-to-speech guide](https://docs.x.ai/developers/model-capabilities/audio/speech-to-speech) documents realtime audio and tool use. It describes compatibility with OpenAI's event style but also event-name differences. An explicit adapter is required; changing only the URL/model is insufficient.
+
+[Ephemeral tokens](https://docs.x.ai/developers/model-capabilities/audio/ephemeral-tokens) permit short-lived client connections without distributing the long-lived provider key. A short token lifetime alone does not establish enforceable limits for an already-open session; session control and usage verification still need a spike.
+
+### Recommendation
+
+One logical service, three capabilities: file transcription, live transcription, and voice conversation. Implement the OpenAI file adapter first. Evaluate streamed text after Stop as a small enhancement. Validate open-microphone transcription separately. Add OpenAI/Grok realtime conversation adapters for interviews without changing the client-facing lifecycle or tool authorization contract.
+
+## Questions resolved by the user
+
+- Credential ownership: platform, not per-user runtime.
+- First release: record → stop → transcribe, editable before Send.
+- Live dictation: desirable if feasible, not a blocker.
+- Future direction: live interview and computer actions, with OpenAI or Grok selected at platform level.
+- Consolidation: all old transcription paths must converge on one service.
+- Previously proposed user stories: accepted.
+
+## Validation still needed before implementation rollout
+
+- Real platform account model access, pricing version, latency and usage response; no credential was read or tested for this research.
+- Native Mobile's exact reported streaming symptom on a device, including fresh auth and foreground recovery.
+- Supported recording formats on packaged Electron/macOS, Chromium, Safari, and Web Mobile.
+- Provider live-session shutdown, interruption and verified usage; test direct WebRTC plus server control against platform-relayed WebSocket.
+- Explicit bounded speech allowance defaults from operator policy; do not invent commercial prices.

--- a/specs/120-platform-speech/research.md
+++ b/specs/120-platform-speech/research.md
@@ -58,3 +58,7 @@ One logical service, three capabilities: file transcription, live transcription,
 - Supported recording formats on packaged Electron/macOS, Chromium, Safari, and Web Mobile.
 - Provider live-session shutdown, interruption and verified usage; test direct WebRTC plus server control against platform-relayed WebSocket.
 - Explicit bounded speech allowance defaults from operator policy; do not invent commercial prices.
+
+## Deep self-review
+
+[implementation.md](implementation.md) records source-backed gaps and their design corrections. In particular, the existing funded start receipt is replayable, the wallet is machine-scoped, the legacy channel helper persists owner audio before STT, and the mobile transport lifetime omits user identity from its effect dependencies. These details require explicit changes rather than direct reuse. The OpenAI file and realtime transcription guides were rechecked during review; no live provider call was made.

--- a/specs/120-platform-speech/spec.md
+++ b/specs/120-platform-speech/spec.md
@@ -1,0 +1,231 @@
+# Feature Specification: Platform Speech and Voice Interviews
+
+**Feature Branch**: `codex/platform-speech-design`  
+**Created**: 2026-09-10  
+**Status**: Design proposal; user stories and product direction accepted, implementation paused  
+**Input**: Consolidate speech into one platform-managed service. Use a platform-hosted OpenAI credential for record → stop → transcribe first. Support interchangeable platform-selected providers, explore live dictation, and plan live interviews and computer actions with OpenAI or Grok. Retain all previously accepted stories and Native Mobile chat streaming repair.
+
+## User Scenarios & Testing
+
+### US-01 — Speak an editable message (P0, first release)
+
+As a chat user, I can record a message, stop, and review the transcript before sending it.
+
+**Why**: This is the explicitly selected first experience. Speech is another way to compose a normal chat message.
+
+**Independent test**: Dictate a short prompt, correct one word, then send it to the selected chat/harness.
+
+**Acceptance**:
+1. Given a ready computer, pressing the microphone requests permission when needed and shows a recording indicator and elapsed time.
+2. Stop releases the microphone and starts transcription. Cancel releases the microphone and discards this recording.
+3. The resulting text is editable. No chat turn or tool action starts until Send is pressed.
+4. The same flow is available in a new chat and an existing chat on Web Canvas, Web Desktop, and Electron Desktop. Web Mobile uses the same behavior where chat is available.
+5. The microphone is visually and semantically distinct from the later “Talk to computer” action.
+
+### US-02 — Keep my draft and attachments (P0, first release)
+
+As a user, I can mix typing and speech without losing work.
+
+**Independent test**: Start with text and a file, dictate more text, and inspect the draft and attachment.
+
+**Acceptance**:
+1. Dictation appends to the existing draft, preserving text, structured references, and attachments. It does not silently replace a selected region.
+2. Typed edits made while transcription is pending survive. The result is added once to the current revision of the same draft.
+3. Duplicate delivery never inserts text twice. A length limit leaves existing text intact and reports that the transcript cannot fit; it does not silently truncate speech.
+4. Sending during recording/transcription requires stopping or cancelling it first. A later result cannot populate a newly cleared draft.
+
+### US-03 — Cancel, navigate, or switch computers safely (P0, first release)
+
+As a user, I can leave a chat without recording continuing or its transcript appearing elsewhere.
+
+**Independent test**: Change chat, presentation, or computer while microphone permission or transcription is pending.
+
+**Acceptance**:
+1. Cancel, sign-out, computer switch, chat/draft switch, and closing the owning surface stop capture and cancel pending work.
+2. Late microphone permission results release their tracks immediately.
+3. Late transcription results cannot alter another chat, account, runtime, or draft generation.
+4. A supported presentation change may preserve the explicitly owned draft; it must not create a second recording session.
+
+### US-04 — Read progressive replies on Native Mobile (P0, companion workstream)
+
+As a Native Mobile user, I see assistant text and activity as they arrive.
+
+**Independent test**: Run the same prompt on Native Mobile and Electron Desktop against one gateway, comparing ordered text, activity, and terminal outcome.
+
+**Acceptance**:
+1. Text appears progressively, without replacing accumulated output with stale snapshots.
+2. Tool activity, approvals, failures, cancellation, and completion match the gateway's canonical state.
+3. The selected chat and runtime retain isolation during streaming.
+
+### US-05 — Resume after interruption (P0, companion workstream)
+
+As a Native Mobile user, I can background the app or lose connectivity and recover the correct conversation.
+
+**Independent test**: Background during a run, disconnect networking, and return after completion.
+
+**Acceptance**:
+1. Reconnection refreshes authentication and catches up from a valid cursor.
+2. A missing replay window triggers snapshot recovery. Duplicate or out-of-order delivery does not duplicate or lose text.
+3. A stalled connection becomes recoverable; completion does not leave a permanent spinner.
+4. Background/foreground transitions release and re-establish transport resources deliberately.
+
+### US-06 — Speak naturally (P1, first release quality)
+
+As a multilingual user, I can dictate ordinary language and technical terms.
+
+**Independent test**: Evaluate representative recordings with names, product terms, mixed-language phrases, punctuation, and background noise.
+
+**Acceptance**:
+1. Automatic language detection is the default; a supported language hint can be selected without requiring provider setup.
+2. Speech is transcribed, not silently translated, rewritten, summarized, or interpreted as a tool instruction.
+3. Silence and unintelligible recordings produce an understandable empty/failure state, not an invented message.
+4. Technical vocabulary hints are optional and bounded; full private chat history is not sent just to improve recognition.
+
+### US-07 — Understand readiness and failures (P0, first release)
+
+As a user, I know when speech is available and how to recover when it fails.
+
+**Independent test**: Exercise permission denial, unsupported device, missing service configuration, timeout, and exhausted allowance.
+
+**Acceptance**:
+1. There is no requirement for the user to paste an OpenAI key into their computer.
+2. The composer shows accurate unavailable, requesting permission, recording, transcribing, ready, cancelled, and failed states.
+3. Failure preserves the draft. Retry is deliberate and does not silently create repeated billable requests.
+4. User errors are understandable and do not expose provider responses, credentials, or filesystem paths.
+
+### US-08 — Understand recording and retention (P0, first release)
+
+As a user, I know when my microphone is active and what is retained.
+
+**Independent test**: Cancel before and after upload; inspect persisted application state and operational logs.
+
+**Acceptance**:
+1. Capture begins only after an explicit action. No hidden or automatic background recording occurs.
+2. Matrix does not persist raw dictation audio by default. Temporary buffers are bounded and released on completion, cancellation, timeout, and shutdown.
+3. Dictation text stays in the draft until ordinary Send. Operational records contain usage metadata, not audio or transcript text.
+4. Product copy distinguishes Matrix retention from the upstream provider's applicable processing/retention terms; it does not promise unverified zero retention.
+
+### US-09 — Change speech providers centrally (P0 architecture, first release)
+
+As a platform operator, I can change the transcription provider/model without changing clients or distributing credentials.
+
+**Independent test**: Run the same client against two test adapters and then a configured OpenAI adapter.
+
+**Acceptance**:
+1. Platform policy selects the provider, model, capability availability, and funding/limits.
+2. Long-lived provider credentials remain in platform-controlled infrastructure, never client bundles, per-user VPS environment files, or owner home files.
+3. Existing speech entry points use the same service. Legacy endpoints, if retained for compatibility, only delegate to it.
+4. A provider change applies to new requests/sessions. Existing sessions retain their configuration until they end; they are not silently restarted with another provider.
+5. Rejected or unsupported capabilities fail explicitly. A fallback cannot change provider/data-processing destination invisibly.
+
+### US-10 — See live dictation (P1, follow-on enhancement)
+
+As a user, I can see words while speaking and correct the final transcript before sending.
+
+**Independent test**: Speak across several pauses, observe provisional text, stop, and compare the finalized draft.
+
+**Acceptance**:
+1. Provisional text is visibly distinct from finalized text and never becomes a submitted message by itself.
+2. Provider revisions replace the relevant provisional segment, rather than append duplicates.
+3. Cancel removes only this recording's pending text and preserves pre-existing draft content.
+4. Live session failure preserves finalized segments and explains whether re-recording is necessary. It never presents a partial result as a complete transcript.
+5. This enhancement is not a blocker for record → stop → transcribe. Showing partial text after Stop is a useful first enhancement, but is not called live dictation.
+
+### US-11 — Interview me by voice (P2, later phase)
+
+As a user, I can start an interview about an idea, answer follow-up questions, and turn it into an editable brief.
+
+**Independent test**: Start an interview on Web Canvas and Electron Desktop, interrupt an answer, then finish and review a brief.
+
+**Acceptance**:
+1. Web Canvas, Web Desktop, and Electron Desktop offer the same entry point, transcript, mute, interrupt, end, and error behavior through shared presentation components.
+2. The interview follows the chosen topic, asks follow-up questions, and tolerates pauses. The user can interrupt spoken playback.
+3. Ending presents a reviewable summary/brief and an explicit save/start-work action.
+4. Interview answers are not automatically promoted into identity or long-term memory; saving such facts is a deliberate action.
+5. OpenAI and Grok are platform adapter candidates. Provider switching does not require a new interview UI. A new provider session may resume from confirmed text context, not assumed audio-state portability.
+
+### US-12 — Ask the computer to act by voice (P2, later phase)
+
+As a user, I can ask the computer to open an app or perform a task during a voice session.
+
+**Independent test**: Request an allowed action, a denied action, and an action requiring approval while observing canonical chat activity.
+
+**Acceptance**:
+1. Voice requests use the same ownership, tool permissions, approvals, and execution state as typed requests.
+2. Interview mode does not start work merely because the user describes an idea. Execution is a distinct intent.
+3. A request that needs approval remains pending until the normal approval is given; spoken provider output cannot bypass that decision.
+4. Tool requests have stable identities so retries/reconnections cannot execute them twice.
+5. Progress and errors are visible in chat and the voice session. The voice model does not become a second independent execution engine.
+
+### Edge Cases
+
+- Permission resolves after cancellation; device removed mid-recording; another app owns the microphone.
+- No speech, unsupported encoding, large recording, extremely long transcript, or upload cut off partway.
+- User types, sends, navigates, signs out, or changes runtime while audio is in flight.
+- A paid provider request succeeds but the response connection is lost; a retry must not invisibly double-charge/repeat it.
+- Language changes mid-sentence; punctuation and names need correction; partial live transcripts revise prior text.
+- User speaks over playback; an interrupted output must not continue playing from a queued audio buffer.
+- Platform restart leaves a usage reservation uncertain; preserve its bounded hold for reconciliation rather than assume free usage.
+- Native Mobile returns to a chat that completed in the background; replay cursor is missing or expired.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Implement US-01–09 before enabling the first speech release, with US-04–05 tracked as a separately shippable mobile repair.
+- **FR-002**: There is one platform speech service with capability-specific adapters for completed recording transcription, optional live transcription, and later voice conversation.
+- **FR-003**: All active transcription entry points, including chat, channel voice notes, and the kernel transcription tool, delegate to that service. Remove redundant provider integrations after migration verification.
+- **FR-004**: The initial transcription provider is OpenAI using a platform-held credential. End-user provider accounts and selected chat harnesses do not determine dictation availability.
+- **FR-005**: Initial recording limits are proposed as 120 seconds and 10 MiB, enforced by the service as well as the client. Availability exposes effective limits. Longer imported recordings are explicitly unsupported until separately designed.
+- **FR-006**: Every request/session is associated with an authenticated owner, computer, runtime, capability, and unique request identity.
+- **FR-007**: Platform speech allowance and concurrency admission occur before provider work. Usage settlement is idempotent and based on verified usage, never solely client-claimed duration.
+- **FR-008**: Speech credits/eligibility are an explicit capability policy. Do not infer eligibility from an unrelated chat model or accidentally require an Anthropic account to use OpenAI dictation.
+- **FR-009**: Transcription is available independently of which chat harness is selected, while message sending continues to honor chat readiness.
+- **FR-010**: Keyboard, screen-reader labels, microphone state, cancellation, and failure recovery are included on every applicable surface.
+- **FR-011**: US-10 is an enhancement gated by device, latency, recovery, and metering validation. US-11–12 are later delivery phases using the same service boundaries.
+- **FR-012**: Existing telephony and standalone text-to-speech must remain functional during migration; their STT dependencies must use the canonical service. They are not prerequisites for releasing chat dictation.
+- **FR-013**: Maintain one source of truth for chat stream merging and terminal outcomes across clients; do not create a separate speech-specific chat ledger.
+
+### Surface Scope
+
+| Capability | Web Canvas | Web Desktop | Electron Desktop | Web Mobile | Native Mobile |
+|---|---|---|---|---|---|
+| Record/stop/transcribe | First release | First release | First release | Same shared chat feature | Follow-on native capture adapter |
+| Live dictation | Enhancement | Enhancement | Enhancement | Where capture supported | Later native validation |
+| Voice interview and actions | Later, required | Later, required | Later, required | Adapt after primary validation | Later |
+| Chat streaming repair | Shared contract regression coverage | Shared contract regression coverage | Reference behavior | Shared contract regression coverage | First companion workstream |
+
+Native Mobile microphone capture is explicitly outside the initial recording scope; the original Native Mobile request concerns reply streaming. Its future capture adapter must reuse the platform service and shared contracts.
+
+### Key Entities
+
+- **Speech capability policy**: enabled operations, operator-selected adapter/model, language/encoding support, effective limits, budget and readiness.
+- **Dictation attempt**: request identity, owner/computer/runtime, destination draft generation, lifecycle, ephemeral audio and transcript.
+- **Usage reservation**: bounded cost hold, operation/provider identity, settlement state, idempotency reference; no audio or transcript.
+- **Voice session**: topic/mode, owner/computer, pinned provider configuration, transcript segments, audio state, tool requests, end reason.
+- **Interview brief**: owner-controlled text produced for review and explicit save or task creation.
+
+## Assumptions and Dependencies
+
+- This document records a design, not a claim that live speech or platform funding is deployed.
+- Platform operators provide and enable the transcription credential in platform infrastructure. No credential value is needed in this document.
+- Speech is platform-funded within an explicit bounded allowance. Commercial pricing and allowance amounts remain operator policy; no new paid SKU or arbitrary customer charge is introduced by this specification.
+- Existing owner-controlled chat/draft persistence is reused. Interviews require an explicit decision to save the final brief.
+- API/model availability must be tested in the actual platform account before rollout. Documentation feasibility is not a live credential check.
+- A separate public documentation PR in `FinnaAI/matrix-os-site`, under `content/docs/`, is a required implementation deliverable.
+- The design intentionally supersedes the paused runtime-local transcription prototype. It must not be shipped unchanged.
+
+## Success Criteria
+
+- **SC-001**: All cancellation/navigation/draft-preservation acceptance scenarios pass on Web Canvas, Web Desktop, and Electron Desktop, with zero wrong-chat insertion or automatic sends.
+- **SC-002**: A 30-second reference recording yields an editable final transcript within 5 seconds of Stop at p95 on the agreed healthy-network test setup. This is a release target to measure, not a provider guarantee.
+- **SC-003**: Manual cancellation releases microphone tracks within one second; automated tests detect no remaining capture, timers, or playback after teardown.
+- **SC-004**: Every active transcription caller uses the canonical service, and no platform speech key is present in generated runtime configuration or renderer assets.
+- **SC-005**: The multilingual evaluation set has at least 30 consented/synthetic recordings spanning selected languages, mixed speech, and technical vocabulary. At least 90% need no correction that changes intended meaning; publish measured results before rollout.
+- **SC-006**: Native Mobile matches final text and terminal state after every tested disconnect, replay gap, duplicate event, and background/foreground scenario; streamed updates do not regress visible text.
+- **SC-007**: A provider adapter swap passes the same contract fixtures without UI changes. OpenAI/Grok live prototypes separately demonstrate interruption and one correctly authorized tool call before interview rollout.
+- **SC-008**: No raw audio/transcript appears in platform operational logs, usage records, or analytics in the privacy validation suite.
+
+## Technical Design and Evidence
+
+See [research.md](research.md) for the current implementation inventory and provider feasibility, and [plan.md](plan.md) for service boundaries, endpoint authentication, migration, tests, and delivery phases.

--- a/specs/120-platform-speech/spec.md
+++ b/specs/120-platform-speech/spec.md
@@ -172,11 +172,11 @@ As a user, I can ask the computer to open an app or perform a task during a voic
 
 ### Functional Requirements
 
-- **FR-001**: Implement US-01–09 before enabling the first speech release, with US-04–05 tracked as a separately shippable mobile repair.
+- **FR-001**: Implement US-01–03 and US-06–09 before enabling the first speech release. US-04–05 are a separately shippable mobile repair and do not gate speech availability.
 - **FR-002**: There is one platform speech service with capability-specific adapters for completed recording transcription, optional live transcription, and later voice conversation.
 - **FR-003**: All active transcription entry points, including chat, channel voice notes, and the kernel transcription tool, delegate to that service. Remove redundant provider integrations after migration verification.
 - **FR-004**: The initial transcription provider is OpenAI using a platform-held credential. End-user provider accounts and selected chat harnesses do not determine dictation availability.
-- **FR-005**: Initial recording limits are proposed as 120 seconds and 10 MiB, enforced by the service as well as the client. Availability exposes effective limits. Longer imported recordings are explicitly unsupported until separately designed.
+- **FR-005**: Initial recording limits are proposed as 120 seconds and 10 MiB, enforced by the service as well as the client. Availability exposes effective limits. These are dictation limits. Existing kernel/channel imports require a separately bounded owner-audio policy and compatibility review before migration; never silently apply the dictation limit to them.
 - **FR-006**: Every request/session is associated with an authenticated owner, computer, runtime, capability, and unique request identity.
 - **FR-007**: Platform speech allowance and concurrency admission occur before provider work. Usage settlement is idempotent and based on verified usage, never solely client-claimed duration.
 - **FR-008**: Speech credits/eligibility are an explicit capability policy. Do not infer eligibility from an unrelated chat model or accidentally require an Anthropic account to use OpenAI dictation.
@@ -228,4 +228,4 @@ Native Mobile microphone capture is explicitly outside the initial recording sco
 
 ## Technical Design and Evidence
 
-See [research.md](research.md) for the current implementation inventory and provider feasibility, and [plan.md](plan.md) for service boundaries, endpoint authentication, migration, tests, and delivery phases.
+See [research.md](research.md) for the current implementation inventory and provider feasibility, [plan.md](plan.md) for service boundaries and phases, and [implementation.md](implementation.md) for the self-review findings, concrete contracts, race handling and delivery gates.


### PR DESCRIPTION
## Readiness — 2026-09-20

Clarified server-side owner/runtime request identity and client-side chat/draft generation fencing. Documentation diff checked; current-head Greptile approval remains required.

Canonical Graphite order: #1611 → #1615 → #1617 → #1620 → #1662 → #1670 → #1672. Superseded siblings #1618/#1619 are not separate merge candidates. The stack is refreshed onto main `94985f02e`.

Current-head Greptile 5/5 and CI remain required. Current visual/preview acceptance and physical Native Mobile validation are not claimed complete; Native Mobile TypeScript has outstanding baseline SDK/type errors. No merge or production rollout performed.


Defines one platform-managed speech service to replace disconnected chat capture and direct runtime transcription. The first release records audio, stops capture, and transcribes into an editable draft using a platform-held OpenAI credential. All twelve user stories are retained; live dictation and shared Web Canvas/Web Desktop/Electron Desktop interviews follow separately.

The design includes a source inventory, migration plan and a concrete implementation blueprint based on a deep self-review. It specifies runtime-bound authentication, speech-specific funding policy, durable dispatch claims, cancellation/status contracts, atomic draft insertion, media admission and source-audio preservation. Native Mobile reply streaming remains independently shippable.

This PR changes documentation only. It does not enable credentials or change runtime behavior.

### Invariants

- Platform policy owns speech routing and allowance. Existing machine-scoped funding remains authoritative; text inference permissions are not broadened implicitly.
- A dispatch claim permits at most one application dispatch attempt. Ledger effects are idempotent; uncertain provider outcomes require bounded reconciliation.
- Platform operational persistence contains metadata, not recordings/transcripts. Existing owner-controlled source attachments retain their semantics.
- Draft generations prevent late insertion after cancel, navigation or account/runtime changes. Sending remains explicit.
- Future voice actions use canonical kernel permissions and approvals. Batch delivery does not require rebuilding the live voice engine.

### Validation and remaining gates

- Checked the design against current auth, metering, channel retention and Native Mobile stream source at the recorded baseline.
- Rechecked official OpenAI file/realtime documentation; no paid provider calls or microphone/device tests.
- Local documentation links resolve and `git diff --check` passes.
- Media/usage spikes, operator allowance/reconciliation policy and packaged-device validation are explicitly unchecked implementation gates.
- No product tests run for this documentation-only change. Implementation includes a separate public documentation PR in `FinnaAI/matrix-os-site`.
