### PR TITLE
fix(apps): validate launches and improve builder craft

### DIFF
--- a/desktop/src/main/embeds/app-launch.ts
+++ b/desktop/src/main/embeds/app-launch.ts
@@ -1,0 +1,29 @@
+import type { LaunchToken } from "./launch-token-cache";
+
+export class AppLaunchError extends Error {
+  constructor(readonly state: "auth-required" | "failed") {
+    super("App launch unavailable");
+    this.name = "AppLaunchError";
+  }
+}
+
+// Only a rejected owner credential asks for login. Policy, manifest, transport,
+// and server failures must not send the user into a sign-in loop.
+export async function requestAppLaunchToken(
+  request: () => Promise<{ status: number; body: string }>,
+): Promise<LaunchToken> {
+  const response = await request();
+  if (response.status === 401) throw new AppLaunchError("auth-required");
+  if (response.status < 200 || response.status >= 300) {
+    console.warn("[embed-service] app launch rejected:", response.status);
+    throw new AppLaunchError("failed");
+  }
+  const parsed: unknown = JSON.parse(response.body);
+  if (
+    parsed && typeof parsed === "object" &&
+    "launchUrl" in parsed && typeof parsed.launchUrl === "string" &&
+    "expiresAt" in parsed && typeof parsed.expiresAt === "number" &&
+    Number.isFinite(parsed.expiresAt) && parsed.expiresAt > Date.now()
+  ) return { launchUrl: parsed.launchUrl, expiresAt: parsed.expiresAt };
+  throw new AppLaunchError("failed");
+}

--- a/desktop/src/main/embeds/embed-service.ts
+++ b/desktop/src/main/embeds/embed-service.ts
@@ -17,6 +17,7 @@ import {
 } from "../../shared/runtime-browser-url";
 import { EmbedManager, type Bounds } from "./embed-manager";
 import { LaunchTokenCache } from "./launch-token-cache";
+import { AppLaunchError, requestAppLaunchToken } from "./app-launch";
 import {
   HOSTED_SHELL_SESSION_REFRESH_RETRY_MS,
   computeHostedShellSessionRefreshDelay,
@@ -547,8 +548,8 @@ export class EmbedService {
         this.pendingActive.get(embedId) ?? true,
         () => this.pendingApps.has(embedId),
       );
-      if (!opened) {
-        if (this.pendingApps.has(embedId)) this.deps.emitState(embedId, "auth-required");
+      if (opened !== "loading") {
+        if (this.pendingApps.has(embedId)) this.deps.emitState(embedId, opened);
         return false;
       }
       this.pendingApps.delete(embedId);
@@ -820,9 +821,9 @@ export class EmbedService {
   ): Promise<OpenResult> {
     const embedId = randomUUID();
     const opened = await this.createAppEmbed(gatewayOrigin, slug, appIdentity, bounds, embedId, active);
-    if (!opened) {
+    if (opened !== "loading") {
       this.rememberPendingApp(embedId, { slug, appIdentity, bounds }, active);
-      return { embedId, state: "auth-required" };
+      return { embedId, state: opened };
     }
     return { embedId, state: "loading" };
   }
@@ -846,22 +847,28 @@ export class EmbedService {
     embedId: string,
     active = true,
     shouldAttach: () => boolean = () => true,
-  ): Promise<boolean> {
+  ): Promise<"loading" | "auth-required" | "failed"> {
     let cached = this.tokenCache.get(slug);
     if (!cached) {
-      const token = await this.fetchLaunchToken(gatewayOrigin, slug);
+      let token;
+      try {
+        token = await this.fetchLaunchToken(gatewayOrigin, slug);
+      } catch (err: unknown) {
+        console.warn("[embed-service] app launch failed:", err instanceof Error ? err.name : "UnknownError");
+        return err instanceof AppLaunchError ? err.state : "failed";
+      }
       if (token) {
         this.tokenCache.set(slug, token);
         cached = token;
       }
     }
-    if (!cached) return false;
-    if (!shouldAttach()) return false;
+    if (!cached) return "failed";
+    if (!shouldAttach()) return "failed";
     const resolved = resolveLaunchUrl(cached.launchUrl, gatewayOrigin);
     if (!resolved) {
-      console.warn("[embed-service] app launch url failed origin check:", cached.launchUrl);
+      console.warn("[embed-service] app launch url failed origin check");
       this.tokenCache.delete(slug);
-      return false;
+      return "failed";
     }
     this.manager.open("app", appIdentity, bounds, resolved, {
       id: embedId,
@@ -869,37 +876,17 @@ export class EmbedService {
       routeSlug: slug,
       onState: (state) => this.deps.emitState(embedId, state),
     });
-    return true;
+    return "loading";
   }
 
   private async fetchLaunchToken(
     gatewayOrigin: string,
     slug: string,
   ): Promise<{ launchUrl: string; expiresAt: number } | null> {
-    try {
-      const response = await this.gatewayRequest(
-        `${gatewayOrigin}/api/apps/${encodeURIComponent(slug)}/session-token`,
-        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
-      );
-      if (response.status < 200 || response.status >= 300) return null;
-      const parsed: unknown = JSON.parse(response.body);
-      if (
-        parsed &&
-        typeof parsed === "object" &&
-        typeof (parsed as { launchUrl?: unknown }).launchUrl === "string" &&
-        typeof (parsed as { expiresAt?: unknown }).expiresAt === "number"
-      ) {
-        const { launchUrl, expiresAt } = parsed as { launchUrl: string; expiresAt: number };
-        return { launchUrl, expiresAt };
-      }
-      return null;
-    } catch (err: unknown) {
-      console.warn(
-        "[embed-service] launch token fetch failed:",
-        err instanceof Error ? err.message : String(err),
-      );
-      return null;
-    }
+    return requestAppLaunchToken(() => this.gatewayRequest(
+      `${gatewayOrigin}/api/apps/${encodeURIComponent(slug)}/session-token`,
+      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+    ));
   }
 
   private gatewayRequest(

--- a/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
+++ b/desktop/src/renderer/src/features/embeds/EmbedHost.tsx
@@ -239,7 +239,7 @@ export default function EmbedHost({
                   .then((result) => {
                     if (embedIdRef.current !== id) return;
                     if (result.ok) reportBounds();
-                    else setState("auth-required");
+                    else setState((current) => current === "loading" ? "auth-required" : current);
                   })
                   .catch(() => {
                     if (embedIdRef.current === id) setState("auth-required");

--- a/docs/dev/agent-matrix-skills.md
+++ b/docs/dev/agent-matrix-skills.md
@@ -231,3 +231,30 @@ Skills are enough for instruction-heavy workflows. For reliable authenticated ac
 - `matrix.get_preview_url`
 
 The skills can then prefer those tools and fall back to shell/curl when the toolset is unavailable.
+
+## App build quality and launch verification
+
+The app-builder skill ships `scripts/verify-app.mjs`. Run it with the absolute app
+directory after the production build. It checks the owner-built Vite contract, including
+`listingTrust: "first_party"`, personal scope, and `dist/index.html`. Missing trust causes
+a policy rejection even when compilation succeeds. The verifier is read-only and must
+never be used to relabel imported/community apps. Only HTTP 401 from the native app launch
+request should ask for login; policy, manifest, network, and server failures are app failures.
+
+Builders must then launch through Matrix, verify the icon/assets and bridge, save and
+reopen data, and inspect the main flow at normal and narrow sizes. Record untested surfaces.
+A local Vite preview or successful build does not prove an authenticated Matrix launch.
+
+Design guidance lives in the builder's `references/app-craft.md`, with Matrix tokens and
+layout guidance in its companion skills. The runtime builder and kernel prompts route
+UI work through the installed `emil-design-eng`, `apple-design`, and task-specific `animate`
+skills from [Emil Kowalski's skills](https://github.com/emilkowalski/skills). Discover actual
+paths via the harness catalog; the external skills are separate from the Matrix pack.
+If absent, report that and use the shipped craft reference. Do not overwrite user-managed
+skills while syncing Matrix-owned skills.
+
+Choose task-specific layouts, clear typography, truthful states, and useful interactions.
+Gradients, glass, capsule controls, and mount staggering are not universal requirements.
+Frequent and keyboard actions stay immediate; occasional motion communicates state or
+spatial relationships and respects reduced motion. Verify in Web Canvas, Web Desktop,
+and Electron Desktop where available, plus supported mobile surfaces.

--- a/home/agents/custom/builder.md
+++ b/home/agents/custom/builder.md
@@ -21,9 +21,9 @@ You are the Matrix OS builder agent. You generate software from natural language
 
 WORKFLOW:
 1. Claim the task using claim_task
-2. Determine output type: React app in `~/apps/<slug>/` (default), React module in `~/modules/<name>/` (explicit/special-case), or HTML app in `~/apps/<slug>/` (simple tools only)
-3. Read ~/agents/knowledge/app-generation.md for templates and decision guide
-4. Build the software following the rules below
+2. Determine output type: React app in `~/apps/<slug>/` (default), React module in `~/modules/<name>/` (explicit/special-case), or HTML app in `~/apps/<slug>/` (only when explicitly requested)
+3. Read the installed `matrix-app-builder` skill (including its app-craft reference), `emil-design-eng`, and `apple-design`; discover their paths from the skill catalog. Read ~/agents/knowledge/app-generation.md for runtime templates. If a craft skill is missing, use the app-craft reference and say which skill was unavailable.
+4. Choose the layout and visual hierarchy for the primary task, build the core flow, then inspect and refine it in Matrix. Follow the rules below.
 5. Call complete_task with structured JSON output
 
 REACT APPS (~/apps/<slug>/) -- DEFAULT:
@@ -45,11 +45,16 @@ REACT MODULES (~/modules/<name>/) -- EXPLICIT / SPECIAL CASE:
 - See ~/agents/knowledge/app-generation.md for full templates
 
 HTML APPS (~/apps/<slug>/) -- SIMPLE ALTERNATIVE:
-- Only for trivial single-screen tools (calculators, clocks, simple widgets)
-- Only when user explicitly asks for something "quick" or "simple"
+- Only when the user explicitly requests plain HTML; “quick” or “simple” still means Vite React by default
 - App directory with `matrix.json` and `index.html`
 - Keep HTML self-contained when possible (inline CSS/JS is fine)
-- Use CDN imports (esm.sh, unpkg, cdnjs) instead of npm packages
+- Bundle scripts and assets locally; no remote JavaScript or font CDNs
+
+APP CRAFT:
+- Use a task-specific layout: reading surface, board, timeline, focused tool, or data view. Avoid filling every app with generic dashboards, welcome banners, and decorative statistics.
+- Use inherited fonts, deliberate spacing and hierarchy, truthful content, and clear empty/loading/error/saving states. Solid theme-aware surfaces are valid; gradients, glass, capsule controls, and staggered entrances are not mandatory.
+- Apply Emil’s frequency/purpose test before motion. Keep keyboard actions immediate; use short ease-out transitions for occasional changes and interruptible springs for gestures. Respect reduced motion and never delay input for animation.
+- Verify the main flow, narrow windows, light/dark, keyboard navigation, and persistence in Matrix. Inspect screenshots, fix the largest visual issues, and report any untested surfaces.
 
 THEME INTEGRATION:
 - Use CSS custom properties: var(--bg), var(--fg), var(--accent), var(--surface), var(--border)
@@ -82,7 +87,9 @@ SERVING:
 VERIFICATION (REQUIRED):
 - For React apps/modules: verify dist/index.html exists after build
 - For HTML apps: verify index.html and matrix.json exist
-- Read back matrix.json to confirm slug, runtime, runtimeVersion, listingTrust, and build output
+- Read back matrix.json to confirm slug, runtime, runtimeVersion, listingTrust, personal scope, and build output. Run the loaded matrix-app-builder skill’s `scripts/verify-app.mjs` for owner-built Vite apps.
+- Missing `listingTrust` is a launch policy failure, not a login request. Set `first_party` only for apps built for this owner; never promote imports or copy gateway credentials.
+- Open the app through the Matrix launcher; file existence alone does not verify launch. Report pending checks honestly.
 - Verify the gateway launch path is /apps/<slug>/
 - Report the exact absolute paths of all files written
 - If pnpm install or pnpm build fails, read the error output and fix before retrying

--- a/home/agents/knowledge/app-generation.md
+++ b/home/agents/knowledge/app-generation.md
@@ -6,13 +6,28 @@ The default output type is a **pre-built React app** using Vite in `~/apps/<slug
 
 Use `~/modules/<name>/` only when the user explicitly wants a module, when the app must follow existing module conventions, or when you are extending an existing module-based app. Do not default to `~/modules/` for new user-facing apps.
 
+### Design and launch contract
+
+Read the installed `matrix-app-builder` skill and its `references/app-craft.md`, plus
+`emil-design-eng` and `apple-design`, before UI work. Use the current skill catalog to
+resolve paths. Select layout and density for the user’s primary task; inherit Matrix
+tokens and fonts. Do not apply gradients, glass cards, pill inputs, or mount staggering
+universally. Inspect the running app and refine its typography, spacing, states, and motion.
+
+Owner-built manifests require `listingTrust: "first_party"` and personal scope. Missing
+trust causes a launch policy rejection, even after a successful build; it does not mean
+the user needs another login. Do not promote imported apps or expose gateway credentials.
+Run the builder skill’s `scripts/verify-app.mjs` against the app directory, then open it
+from Matrix and verify assets, bridge operations, persistence, and visual states.
+
 ### Scaffold Steps
 
 1. Create app directory: `~/apps/<slug>/`
 2. Write project files (see structure below)
 3. Run: `cd ~/apps/<slug> && pnpm install --prefer-offline && pnpm build`
 4. Verify `dist/index.html` exists
-5. Verify `matrix.json` has `runtime: "vite"` and `build.output: "dist"`
+5. Run the builder preflight; verify `runtime: "vite"`, `runtimeVersion`, `listingTrust: "first_party"`, personal scope, and `build.output: "dist"`
+6. Verify launch through Matrix and inspect the actual app before reporting success
 
 ### Structure
 ```
@@ -176,7 +191,7 @@ Use explicit app branding only when requested or when the app's domain requires 
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
-  background: linear-gradient(170deg, var(--sand-light) 0%, var(--sand-mid) 30%, #F7F3ED 60%, var(--sand-light) 100%);
+  background: var(--bg);
   color: var(--fg);
   font-family: var(--matrix-font-sans, Inter, system-ui, sans-serif);
 }
@@ -189,7 +204,7 @@ button {
   color: var(--primary-fg);
   border: none;
   padding: 10px 24px;
-  border-radius: 50px;
+  border-radius: var(--matrix-radius, 8px);
   font-family: var(--matrix-font-sans, Inter, system-ui, sans-serif);
   font-size: 0.875rem;
   font-weight: 500;
@@ -197,11 +212,11 @@ button {
 }
 
 input, textarea, select {
-  background: rgba(255,255,255,0.8);
+  background: var(--card);
   color: var(--fg);
   border: 1.5px solid var(--border);
   padding: 12px 20px;
-  border-radius: 50px;
+  border-radius: var(--matrix-radius, 8px);
   font-family: var(--matrix-font-sans, Inter, system-ui, sans-serif);
 }
 ```
@@ -230,13 +245,13 @@ For very simple tools (calculators, clocks, single-screen utilities), use `~/app
 - No state management needed
 - No component hierarchy
 - Single screen, no routing
-- User explicitly asks for something "quick" or "simple"
+- User explicitly requests plain HTML
 
 ### Structure
 - One app directory in `~/apps/<slug>/`
 - `matrix.json` manifest
 - `index.html` entry point
-- CSS and JS inline or via CDN imports (esm.sh, unpkg)
+- Local CSS and JS; no remote script or font CDNs
 - Theme integration: CSS custom properties
 
 ### Manifest
@@ -264,8 +279,9 @@ For very simple tools (calculators, clocks, single-screen utilities), use `~/app
 | State management needed | React app in `~/apps/<slug>/` |
 | CRM, roadmap, dashboard, project tracker | React app in `~/apps/<slug>/` |
 | User explicitly wants a module or existing module extension | React module in `~/modules/<name>/` |
-| "quick", "simple", "just a..." | HTML app in `~/apps/<slug>/` |
-| Calculator, clock, single widget | HTML app in `~/apps/<slug>/` |
+| "quick", "simple", "just a..." | React app in `~/apps/<slug>/` |
+| Calculator, clock, single widget | React app in `~/apps/<slug>/` |
+| Explicit plain HTML request | HTML app in `~/apps/<slug>/` |
 
 Do not create Next.js, `.next/`, app router folders, API routes, `runtime: "node"`, or `npm start` unless the user explicitly asks for a server runtime or Next.js.
 
@@ -307,7 +323,7 @@ Apps that display data from external services (Gmail, Calendar, etc.) should fet
 wasteful and stale.
 
 ## Best Practices
-- Default to `~/apps/<slug>/matrix.json` + `index.html` for apps
+- Default to Vite React apps with `~/apps/<slug>/matrix.json` and built `dist/index.html`
 - Use TypeScript strict mode in all React apps/modules
 - Keep components small and focused
 - Use semantic HTML and accessible markup

--- a/home/agents/knowledge/frontend-design.md
+++ b/home/agents/knowledge/frontend-design.md
@@ -1,50 +1,28 @@
-# Frontend Design Philosophy
+# Frontend Design
 
-Always apply when generating any app for Matrix OS. Mirrors the official `frontend-design` skill that ships with Claude Code, contextualized for the Matrix OS builder agent.
+For Matrix apps, read the installed `matrix-app-builder` skill and its
+`references/app-craft.md`, plus `emil-design-eng` and `apple-design`. Read the actual
+skill files through the harness catalog. If unavailable, say so and apply these defaults.
 
-The condensed version of these principles is inlined directly in `BUILDER_PROMPT` (packages/kernel/src/agents.ts) so they're always active without requiring a knowledge-file read. This file is the canonical source for humans browsing the project and for future agents (healer, evolver) that may consult it.
+Start with the user's job and primary action. A reader deserves a quiet document and
+useful outline, a tracker fast entry, a planning tool clear relationships, and a game
+an expressive board. Choose hierarchy, density, and interaction around that purpose.
+Avoid generic welcome heroes, invented statistics, and grids of decorative cards.
 
-## The Core Commitment
+Inherit Matrix theme tokens and fonts. System fonts are appropriate; quality comes from
+type hierarchy, measure, alignment, spacing, and contrast. Solid backgrounds are valid.
+Use glass, gradients, textures, and decorative motion only when they serve the chosen
+direction. Do not force every app into pills and glass cards or override dark mode.
 
-Before writing any code, commit to a BOLD aesthetic direction. Pick an extreme:
+Choose one useful signature detail and execute it well. Make empty, loading, populated,
+saving, error, and retry states intentional. Keep content truthful and labels specific.
 
-- Brutally minimal (Linear, iA Writer)
-- Refined-luxury (Apple, Stripe)
-- Retro-futuristic (early-internet wonder, evolved)
-- Editorial / magazine (NYT, Substack)
-- Playful / toy-like (Amie, Tldraw)
-- Brutalist / raw (anti-design, deliberately rough)
-- Organic / natural (warm tones, soft shapes)
-- Soft / pastel (dreamy, gentle)
-- Art-deco / geometric (precise, layered)
-- Industrial / utilitarian (Figma, dev tools)
+Motion must earn its time. Repeated navigation and keyboard actions should be immediate.
+Use brief ease-out transitions for occasional feedback and interruptible springs for
+continuous gestures. Never block input for animation. Respect reduced motion, visible
+keyboard focus, and comfortable touch targets.
 
-Don't half-commit. The bold commitment is what separates memorable apps from generic AI output. The "safe middle" is the trap.
-
-## Match Implementation Complexity to Aesthetic Vision
-
-- **Maximalist directions**: need elaborate code -- animations, layered effects, distinctive details. Restraint here looks unfinished.
-- **Refined / minimal directions**: need precision and restraint -- careful spacing, hairline borders, minimal motion. Decoration here looks cluttered.
-
-Elegance comes from executing the vision well, not from picking a "safer" middle.
-
-## NEVER
-
-- **Generic font families.** Inter alone, Roboto, Arial, "system-ui" alone are AI-slop tells. Pair a distinctive display font with a refined body font.
-- **Cliched color schemes.** Purple-on-white gradients, "modern SaaS pastels," tech-blue everywhere, evenly-distributed timid palettes. Dominant colors with sharp accents outperform balanced palettes.
-- **Cookie-cutter components.** Centered card with title + paragraph + button is the AI default. Compose with intent for the app's specific purpose.
-- **Predictable layouts.** Header + sidebar + main grid every single time is generic. Use asymmetry, overlap, generous space, controlled density.
-- **Convergence across generations.** If you generated a "habit tracker" yesterday and another today, they should differ in details. Vary fonts, themes, vibes aggressively.
-- **Solid-color backgrounds as the default.** They are the floor, not the ceiling.
-
-## ALWAYS
-
-- **Pick ONE distinctive detail someone would remember.** A signature animation, a bold typographic moment, an unusual layout choice. The thing they'd describe to a friend.
-- **Use atmosphere and depth.** Gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, grain overlays.
-- **Treat the page-load as ONE orchestrated moment.** Staggered reveals on initial render beat scattered micro-interactions everywhere.
-- **Use CSS variables for color/spacing/radius consistency.** Apps that mix tokens with hardcoded values feel sloppy.
-- **Vary aggressively across themes.** Light/dark, serif/sans/mono, rigid/playful. Apps should feel like they came from different studios.
-
-## Don't Hold Back
-
-You are capable of extraordinary creative work. The default tendency is to play it safe -- to hedge toward the median. Resist that. Every app is a portfolio piece for Matrix OS.
+Build the primary flow, open it in Matrix, inspect screenshots and interactions, refine,
+and inspect again. Verify small windows, light/dark, long content, and save/reopen.
+Report untested surfaces honestly. A production build is necessary but does not prove
+that the app launches or feels good to use.

--- a/home/agents/knowledge/matrix-design-system.md
+++ b/home/agents/knowledge/matrix-design-system.md
@@ -52,10 +52,10 @@ The shell injects `--matrix-*` variables into app iframes via the bridge. Apps t
 2. **Forest is structural.** Headers, primary buttons, nav active states, icons.
 3. **Cream is warmth.** Secondary fills, hover states, sidebar backgrounds.
 4. **Deep is text.** Never use pure black `#000000`.
-5. **Backgrounds are GRADIENT, not flat.** Blend sand shades for warmth.
+5. **Backgrounds inherit the active theme.** Solid content surfaces are valid; gradients are optional depth treatments.
 6. **Shadows use Deep-tinted** `rgba(50,53,46,X)`, never pure black.
 
-### Gradient Backgrounds
+### Optional Gradient Backgrounds (fallback examples only)
 
 ```css
 /* App page background — warm sand wash (DEFAULT for all apps) */
@@ -78,13 +78,11 @@ background: linear-gradient(135deg, #32352E 0%, #434E3F 40%, #D6AB8B 100%);
 | `--matrix-font-display`  | `"Orbitron", system-ui, sans-serif` | H1/H2 display headings and large stat numbers  |
 | `--matrix-font-mono`     | `"JetBrains Mono", monospace`       | Code, data, terminal                           |
 
-### Orbitron Rules (CRITICAL)
+### App Typography
 
-Orbitron is the Matrix OS brand typeface. Use it **minimally**:
-
-- **Use for:** H1, H2 display headings, large metric/stat numbers (1.5rem+)
-- **NEVER use for:** subtitles (H3+), card titles, descriptions, button labels, navigation, form labels, body text, or anything below 16px
-- **H3 and below are ALWAYS Inter weight 600.**
+Use inherited shell fonts for app headings and controls. Display fonts are optional
+for explicit art direction, never mandatory. Create hierarchy with weight, size,
+leading, measure, and alignment. Do not load remote fonts.
 
 ### Type Scale
 
@@ -110,8 +108,8 @@ Use inherited shell font tokens in app CSS: `var(--matrix-font-sans, Inter, syst
 
 | Element   | Border Radius | Notes                        |
 |-----------|---------------|------------------------------|
-| Buttons   | 50px          | Full capsule, always         |
-| Inputs    | 50px          | Full capsule                 |
+| Buttons   | 6-12px        | Match function and density   |
+| Inputs    | 6-12px        | Keep forms legible           |
 | Cards     | 22px          | Soft rounded                 |
 | Inner UI  | 14-16px       | Nested elements, icon bgs    |
 | Badges    | 9999px        | Perfect pill                 |
@@ -172,70 +170,22 @@ Default to simple line-style SVGs for all UI icons. Only use specialist bundled 
 
 Never exceed 500ms. Always respect `prefers-reduced-motion`.
 
-### Page Mount — Staggered Fade Up (signature animation)
-
-```css
-@keyframes fadeUp {
-  from { opacity: 0; transform: translateY(12px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-.animate-in { animation: fadeUp 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) both; }
-/* Stagger: 60ms gap between siblings */
-.stagger > :nth-child(1) { animation-delay: 0s; }
-.stagger > :nth-child(2) { animation-delay: 0.06s; }
-.stagger > :nth-child(3) { animation-delay: 0.12s; }
-.stagger > :nth-child(4) { animation-delay: 0.18s; }
-.stagger > :nth-child(5) { animation-delay: 0.24s; }
-```
-
-### Hover Lift (all clickable elements)
-
-```css
-.hoverable { transition: transform 0.2s ease, box-shadow 0.2s ease; }
-.hoverable:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(50,53,46,0.08); }
-.hoverable:active { transform: translateY(0); transition-duration: 0.1s; }
-```
-
-### Skeleton Loading — Warm Shimmer
-
-```css
-@keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
-.skeleton {
-  background: linear-gradient(90deg, var(--matrix-muted) 25%, #F7F1E7 50%, var(--matrix-muted) 75%);
-  background-size: 200% 100%;
-  animation: shimmer 1.8s ease-in-out infinite;
-  border-radius: 10px;
-}
-```
-
-Use warm sand tones in the shimmer, not gray or white.
-
-### Progress Bars
-
-```css
-.progress-fill { transition: width 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94); }
-```
-
-Animate width from 0 to target on mount.
-
-### Animation Rules
-
-- Page load = one orchestrated wave (stagger all top-level elements)
-- Hover lift on every clickable card and button
-- Loading always uses warm-tinted skeletons, never blank space
-- Spinners: use a local CSS/SVG spinner, never a remote script
-- Reduced motion fallback is mandatory
+Read the installed emil-design-eng and apple-design skills, plus the matrix-app-builder
+app-craft reference. Keep frequent actions immediate. Use short ease-out transitions
+for occasional changes, interruptible springs for gestures, and static or opacity-only
+reduced-motion alternatives. Do not stagger all content on mount, lift every control,
+or show invented progress. Stable, theme-aware loading placeholders are enough.
 
 ## Component Patterns
 
 ### Buttons
 
-Capsule-shaped with clear hierarchy:
+Use clear hierarchy and a radius appropriate to the control:
 
 ```css
 button {
   padding: 10px 24px;
-  border-radius: 50px;
+  border-radius: 8px;
   font-family: 'Inter', system-ui, sans-serif;
   font-size: 0.875rem;
   font-weight: 500;
@@ -278,7 +228,7 @@ Glass card with gradient background showing through:
 input, select {
   background: rgba(255, 255, 255, 0.8);
   border: 1.5px solid rgba(214, 211, 200, 0.6);
-  border-radius: 50px;
+  border-radius: 8px;
   padding: 13px 22px;
   font-family: 'Inter', system-ui, sans-serif;
   font-size: 0.875rem;
@@ -329,8 +279,8 @@ Always use flexbox centering and inline SVG or bundled local icons:
 6. **All inputs need visible focus states.** Never just `outline:none` with no replacement.
 7. **All buttons need hover + active states.** No flat state-free buttons.
 8. **Don't mix border-radius values** on adjacent elements.
-9. **Backgrounds must be gradient**, not flat. Use the sand wash as default.
-10. **Orbitron only for H1/H2.** Subtitles, card titles, and everything else use Inter.
+9. **Backgrounds must honor the active theme.** Use gradients only with a purpose.
+10. **Inherit shell fonts.** Establish hierarchy through size, weight, leading, and spacing.
 
 ## Bridge API Patterns
 

--- a/home/agents/system-prompt.md
+++ b/home/agents/system-prompt.md
@@ -6,7 +6,7 @@ You receive user requests and either handle them directly (simple tasks) or dele
 
 ## Routing Rules
 
-- **Build/create/generate requests** -> delegate to `builder` agent via Task tool
+- **Build/create/generate requests** -> delegate to `builder` agent via Task tool. Require the installed `matrix-app-builder` skill plus `emil-design-eng` and `apple-design` for UI work: task-specific layout, purposeful motion, manifest preflight, and in-Matrix launch/visual verification. Report missing skills or untested surfaces honestly.
 - **Research/search/find requests** -> delegate to `researcher` agent via Task tool
 - **Fix/heal/repair requests** -> delegate to `healer` agent via Task tool
 - **Simple questions, status, file reads** -> handle directly

--- a/packages/kernel/src/agents.ts
+++ b/packages/kernel/src/agents.ts
@@ -142,9 +142,9 @@ const BUILDER_PROMPT = `You are the Matrix OS builder agent. You generate softwa
 
 WORKFLOW:
 1. Claim the task using claim_task
-2. Determine output type: React module (default) or HTML app (simple tools only)
-3. Apply the DESIGN PHILOSOPHY below (always-on, mirrors the frontend-design skill)
-4. Build the software using the templates below (do NOT read knowledge files)
+2. Default to a Vite React app; modules and plain HTML require an explicit request
+3. Read the installed matrix-app-builder skill and its app-craft reference, plus emil-design-eng and apple-design. Resolve skills through the harness catalog; use animate for specific motion work. Report missing skills and use the craft defaults below.
+4. Choose a design direction for the primary task, build the core flow, then inspect and refine it in Matrix
 5. Call complete_task with structured JSON output
 
 MATRIX OS DESIGN SYSTEM (always apply -- non-negotiable):
@@ -173,52 +173,19 @@ TYPOGRAPHY:
 - Do not load remote font stylesheets from generated apps.
 - Use compact headings that fit app windows; avoid oversized marketing typography inside tools.
 
-SHAPES & ELEVATION:
-- Border radius: 22px for cards/windows, 50px (capsule) for buttons/inputs/pills. No sharp corners.
-- Shadows use Deep-tinted rgba(50,53,46,X) — never pure black shadows.
-- Glass-morphism for cards: background rgba(255,255,255,0.55) + backdrop-filter blur(12px) + border.
-- Backgrounds are GRADIENT, not flat — use warm gradient washes blending sand shades (#F7F1E7, #F3EAE0, #D6AB8B).
-
-ICONS:
-- Use inline SVG or bundled local icon assets only.
-- Do not load icon scripts, CDNs, remote fonts, or third-party JavaScript from generated apps.
-- NEVER use text characters as icons (+, ×, →, ✓). Always center icon buttons with display:flex; align-items:center; justify-content:center.
-
-ANIMATIONS (subtle, clean):
-- Page mount: stagger fade-up (opacity 0→1, translateY 12px→0, 0.5s ease, 60ms delay between siblings)
-- Hover: translateY(-2px) + shadow lift on cards and buttons
-- Loading: warm shimmer skeleton (sand-tinted #F7F1E7, not gray)
-- Progress bars: animate width from 0 to target
-- Always respect prefers-reduced-motion
-
-COMPONENT PATTERNS:
-- Buttons: capsule-shaped (border-radius: 50px), Forest bg primary, Ember bg accent CTA, transparent+border secondary.
-- Cards: glass bg (rgba(255,255,255,0.55) + blur), 1px border, 22px radius, 20-24px padding. Horizontal layout for compact cards (icon + text side by side).
-- Inputs: capsule (border-radius: 50px), 1.5px border, focus ring in Forest. background rgba(255,255,255,0.8).
-- Stat cards: horizontal layout (icon container + label/value/sub). Components must fill space intentionally — no empty whitespace corners.
-
-DO:
-- Use gradient backgrounds (warm sand washes), not flat colors
-- Use Inter for all text including subtitles, card titles, descriptions
-- Use Orbitron only for H1/H2 display and large stat numbers
-- Capsule-round all buttons and inputs (50px)
-- Stagger-animate elements on page mount
-- Use inline SVG or bundled local icons for all icons (never text characters)
-
-DON'T:
-- Use dark backgrounds (this is a light-mode OS)
-- Use sharp corners anywhere
-- Use Orbitron for subtitles, body, card titles, or labels
-- Use text characters as icons (+, ×, →)
-- Use more than one Ember CTA per view
-- Use pure black (#000000) for text or shadows
-- Leave components with excessive unused whitespace
+APP CRAFT:
+- Choose layout and density for the job: reading surface, board, timeline, focused tool, or data view. Use a dashboard only when real summaries help a decision.
+- Use inherited typography with deliberate hierarchy, spacing, alignment, and readable measure. Solid theme-aware surfaces are valid; gradients, glass, and pill controls are optional.
+- Avoid generic welcome heroes, decorative statistics, fake content, and cards around every section. Give the app one useful signature interaction and complete empty/loading/error/saving states.
+- Read Emil’s motion frequency/purpose framework and Apple’s fluid interaction guidance. Keep typing, keyboard actions, and repeated navigation immediate. Occasional transitions should be short and ease-out; gestures should track directly and use interruptible springs. Respect reduced motion and never lock input for animation.
+- Use inline SVG or bundled local icons, with centered, labeled icon buttons. No remote font, icon, or JavaScript CDNs.
+- Open the app in Matrix, inspect screenshots and the primary flow, refine the largest visual problems, and check narrow windows, light/dark, keyboard focus, reduced motion, and persistence. Report untested surfaces honestly.
 
 DECISION GUIDE:
-- Default: Vite React SPA in ~/apps/<slug>/ | "quick"/"simple"/single widget: HTML app
+- Default, including quick/simple tools: Vite React SPA in ~/apps/<slug>/
 - Multiple screens, state management, complex UI: Vite React SPA
 - CRM, roadmap, dashboard, admin, and data-heavy apps are still Vite React SPAs. Use Matrix bridge APIs for persistence and integrations.
-- Calculator, clock, single widget: HTML app
+- Plain HTML only when explicitly requested; modules only when requested in ~/modules/<name>/
 - Do not create Next.js, .next, app router files, API routes, runtime:"node", serve.start, npm install, or npm start unless the user explicitly asks for a server runtime or Next.js.
 
 VITE REACT APP SCAFFOLD (~/apps/<slug>/):
@@ -239,10 +206,10 @@ index.html:
 src/main.tsx:
 import{StrictMode}from"react";import{createRoot}from"react-dom/client";import App from"./App";import"./App.css";createRoot(document.getElementById("root")!).render(<StrictMode><App/></StrictMode>);
 
-matrix.json: {"name":"<name>","slug":"<slug>","description":"...","icon":"<slug>","version":"1.0.0","runtime":"vite","runtimeVersion":"^1.0.0","listingTrust":"first_party","build":{"command":"pnpm build","output":"dist"}}
+matrix.json: {"name":"<name>","slug":"<slug>","description":"...","icon":"<slug>","version":"1.0.0","runtime":"vite","runtimeVersion":"^1.0.0","listingTrust":"first_party","scope":"personal","build":{"command":"pnpm build","output":"dist"}}
 
 Then write src/App.tsx and src/App.css with the actual app logic.
-App icons are auto-generated by the system after the build completes — do not create icons manually.
+Verify the manifest icon resolves to an asset in ~/system/icons/; do not assume an icon was generated.
 
 HTML APP SCAFFOLD (~/apps/<slug>/):
 Two files: matrix.json + index.html. No build step, served as-is.
@@ -253,7 +220,7 @@ index.html: single self-contained HTML file with inline CSS+JS. No CDN imports.
 
 THEME (both types — Matrix OS design system):
 :root{--bg:var(--matrix-bg,#FAFAF9);--fg:var(--matrix-fg,#32352E);--primary:var(--matrix-primary,#434E3F);--primary-fg:var(--matrix-primary-fg,#FAFAF5);--accent:var(--matrix-accent,#D06F25);--accent-fg:var(--matrix-accent-fg,#FAFAF5);--secondary:var(--matrix-secondary,#F1F0E3);--muted:var(--matrix-muted,#E1E1D0);--muted-fg:var(--matrix-muted-fg,#747668);--card:var(--matrix-card,#FCFCF8);--border:var(--matrix-border,#D8D6C7);--success:var(--matrix-success,#3A7D44);--warning:var(--matrix-warning,#E0A12E);--danger:var(--matrix-destructive,#D74A3A);--sand-light:#F7F1E7;--sand-mid:#F3EAE0;--sand-warm:#D6AB8B;--radius:22px;--shadow:0 2px 4px rgba(50,53,46,0.06)}
-*{margin:0;padding:0;box-sizing:border-box}body{background:linear-gradient(170deg,var(--sand-light) 0%,var(--sand-mid) 30%,#F7F3ED 60%,var(--sand-light) 100%);color:var(--fg);font-family:var(--matrix-font-sans,Inter,system-ui,sans-serif);min-height:100vh}h1,h2,h3,h4,h5,h6{font-family:var(--matrix-font-sans,Inter,system-ui,sans-serif);color:var(--fg)}h3,h4,h5,h6{font-weight:600}button{background:var(--primary);color:var(--primary-fg);border:none;padding:10px 24px;border-radius:50px;cursor:pointer;font-family:var(--matrix-font-sans,Inter,system-ui,sans-serif);font-size:0.875rem;font-weight:500;transition:all 0.2s}button:hover{transform:translateY(-1px);box-shadow:0 4px 12px rgba(50,53,46,0.1)}input,textarea,select{background:var(--card);color:var(--fg);border:1.5px solid var(--border);padding:12px 20px;border-radius:50px;font-family:var(--matrix-font-sans,Inter,system-ui,sans-serif);width:100%;outline:none;transition:all 0.2s}input:focus,textarea:focus,select:focus{border-color:var(--primary);box-shadow:0 0 0 3px rgba(67,78,63,0.08)}
+*{margin:0;padding:0;box-sizing:border-box}body{background:var(--bg);color:var(--fg);font-family:var(--matrix-font-sans,Inter,system-ui,sans-serif);min-height:100vh}h1,h2,h3,h4,h5,h6{font-family:var(--matrix-font-sans,Inter,system-ui,sans-serif);color:var(--fg)}h3,h4,h5,h6{font-weight:600}button{background:var(--primary);color:var(--primary-fg);border:none;padding:10px 24px;border-radius:8px;cursor:pointer;font-family:var(--matrix-font-sans,Inter,system-ui,sans-serif);font-size:0.875rem;font-weight:500;transition:background-color 120ms ease, border-color 120ms ease}button:focus-visible{outline:2px solid var(--primary);outline-offset:2px}input,textarea,select{background:var(--card);color:var(--fg);border:1.5px solid var(--border);padding:12px 20px;border-radius:8px;font-family:var(--matrix-font-sans,Inter,system-ui,sans-serif);width:100%;outline:none;transition:background-color 120ms ease, border-color 120ms ease}input:focus,textarea:focus,select:focus{border-color:var(--primary);box-shadow:0 0 0 3px rgba(67,78,63,0.08)}
 
 BRIDGE API (persistent data):
 Use Matrix bridge APIs for app data. Do not add app-owned API routes or a Node server just to persist CRM, roadmap, task, or dashboard data.
@@ -284,7 +251,7 @@ SERVING: gateway dispatches at /apps/<slug>/ with per-app session cookies. Apps 
 
 ERROR RECOVERY: If build fails, read error, fix, rebuild. Max 2 retries. If still failing, report the build failure with the failing command and file paths. Do not silently switch a requested Vite app to Next.js or node runtime.
 
-VERIFICATION: For vite apps, confirm dist/index.html exists; for static apps, confirm index.html at the app root. Read matrix.json to confirm slug and runtime, report absolute paths.`;
+VERIFICATION: Run the loaded matrix-app-builder skill’s scripts/verify-app.mjs on the owner-built Vite app. Confirm dist/index.html, slug, runtimeVersion, build output, personal scope, and listingTrust:first_party. For explicitly requested static apps, verify index.html and the same manifest fields. Missing trust blocks launch; it is not a login failure. Never relabel imported apps to bypass policy or expose gateway credentials. Open the app via the Matrix launcher, verify assets/bridge/save-and-reopen, and inspect visual states. Report absolute paths and any pending checks; a build alone is not launch verification.`;
 
 const RESEARCHER_PROMPT = `You are the Matrix OS researcher agent. You find information and report back concisely.
 

--- a/packages/kernel/src/prompt.ts
+++ b/packages/kernel/src/prompt.ts
@@ -303,12 +303,13 @@ IMPORTANT: Always use http://localhost:4000/api/bridge/query (NOT /api/bridge/da
   sections.push(`\n## Design System (ALWAYS apply when building apps)\n
 Apps must inherit the shell theme by default through injected --matrix-* CSS variables. Use literal Matrix colors only as fallbacks, and add explicit app branding only when the user asks for it or the app has a clear domain reason.
 Palette defaults: Forest #434E3F (primary), Cream #E0E1CA (secondary), Ember #D06F25 (accent CTA — one per view), Deep #32352E (text). Sand shades: #F7F1E7, #F3EAE0, #D6AB8B.
-Background: linear-gradient(170deg, #F7F1E7 0%, #F3EAE0 30%, #F7F3ED 60%, #F7F1E7 100%) — NEVER flat colors.
+Read the installed matrix-app-builder skill and its app-craft reference, plus emil-design-eng and apple-design. Use animate for specific motion tasks. Report missing skills honestly. Choose layout, density, and hierarchy for the primary task; avoid generic dashboards, decorative statistics, and welcome heroes.
 Typography: inherit shell fonts with var(--matrix-font-sans) and var(--matrix-font-mono). Do not load remote font stylesheets from generated apps. Inter is the fallback for UI text; JetBrains Mono is the fallback for code.
-Shapes: buttons/inputs border-radius: 50px (capsule). Cards: 22px. Glass cards: rgba(255,255,255,0.55) + backdrop-filter blur(12px).
+Surfaces: inherit light/dark tokens. Solid backgrounds are valid. Glass, gradients, capsule controls, and cards are optional tools for hierarchy, not requirements.
 Icons: use inline SVG or bundled local icon assets only. Do not load icon scripts, CDNs, remote fonts, or third-party JavaScript from generated apps. NEVER text characters (+, ×, →).
 Launcher app logos: set matrix.json "icon" to the app slug and create ~/system/icons/<slug>.png in the shipped Matrix OS style: light iOS/macOS skeuomorphic artwork, bright warm off-white or pale pastel background, forest/cream/ember/deep accents, glossy ceramic/glass 3D object, no text/logos, no transparency, no empty padding, and no separate icon frame.
-Animation: stagger fade-up on mount (60ms between siblings). Hover lift on cards/buttons.
+Motion: keep keyboard/repeated actions immediate. Use short ease-out transitions for occasional feedback and interruptible springs for gestures. Respect reduced motion; no blanket mount staggering.
+Before claiming completion: run the builder manifest preflight (owner-built apps need listingTrust:first_party), launch in Matrix, inspect the primary flow and visual states, and verify save/reopen. Report any unavailable checks.
 Shadows: rgba(50,53,46,X) — never pure black. Never use #000000.
 Full reference: ~/agents/knowledge/matrix-design-system.md`);
 

--- a/skills/matrix/app-builder/SKILL.md
+++ b/skills/matrix/app-builder/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: matrix-app-builder
 description: Build Matrix OS apps as Vite React TypeScript projects with matrix.json manifests, Matrix theme integration, Postgres-backed app data, and production build verification.
-version: 1.0.0
+version: 1.1.0
 author: Matrix OS
 license: MIT
 platforms: [linux, macos]
 metadata:
   agent:
     tags: [Matrix OS, apps, Vite, React, TypeScript]
-    related_skills: [matrix-design-system, matrix-app-ui-patterns, matrix-integrations, matrix-debug-app]
+    related_skills: [matrix-design-system, matrix-app-ui-patterns, matrix-integrations, matrix-debug-app, emil-design-eng, apple-design, animate]
 ---
 
 # Matrix App Builder
@@ -24,15 +24,19 @@ Use this when the user asks to build, create, fix, redesign, or publish a Matrix
 - CRM, roadmap, dashboard, admin, and data-heavy apps are still Vite React SPAs by default. Use Matrix/Postgres bridge APIs for data instead of creating Next.js API routes.
 - Do not create Next.js, `.next/`, `app/` router files, `runtime: "node"`, `serve.start`, or `npm start` unless the user explicitly requests a server runtime or Next.js.
 - Do not create plain HTML apps unless the user explicitly asks for a plain HTML app.
-- Always create or update `matrix.json`.
+- Always create or update `matrix.json`. For apps built for the owner, include `listingTrust: "first_party"` and `scope: "personal"`; missing trust blocks launch even if the build succeeds. Never relabel downloaded/store/community apps to bypass policy.
 - Always run `pnpm install` when dependencies changed and `pnpm build` before saying the app works.
 - Verify `dist/index.html` exists.
 - Use injected Matrix theme variables and iframe-safe sizing. Custom apps should inherit the shell theme by default; add explicit app branding only when the user asks for it or the app has a clear domain reason.
-- For UI, ALWAYS load and follow `matrix-design-system` and `matrix-app-ui-patterns`. Key rules: inherit shell fonts through `--matrix-font-sans`/`--matrix-font-mono`, use Forest/Cream/Ember/Deep only as fallback palette values, gradient backgrounds (sand washes not flat), capsule buttons/inputs (50px radius), glass cards (22px radius), inline SVG or bundled local icons (never text characters or remote icon scripts), stable window-sized layouts, and stagger animations on mount. No exceptions.
+- For UI, read `matrix-design-system`, `matrix-app-ui-patterns`, and [App craft](references/app-craft.md). Discover and read the installed `emil-design-eng` and `apple-design` SKILL.md files before designing; use `animate` for specific motion work. Preserve Matrix theme/runtime rules and choose layout, materials, and motion for the app’s actual purpose.
 - Store structured app data through Matrix/Postgres bridge APIs, not ad hoc local databases.
 - Never put provider secrets, API keys, or OAuth tokens inside the app directory.
 - Do not use browser `localStorage` as app persistence in the Matrix shell. Sandboxed iframes can throw `SecurityError`; use `window.MatrixOS.db` and keep local fallback paths test-only/no-op.
 - For default or first-party apps under `home/apps/**`, keep manifests deterministic: `runtime: "vite"`, `build.output: "dist"`, schema columns declared in `storage.tables`, and `icon` pointing to a committed asset in `home/system/icons/`.
+
+## Design workflow
+
+Before scaffolding, read the craft reference and installed design skills. Choose a concise design direction and primary user flow. Build the core interaction first, add purposeful feedback, then inspect and refine the running app in Matrix. Avoid a generic welcome hero, decorative statistic cards, repeated glass containers, and automatic staggered entrances. Record which skills and surfaces you actually checked.
 
 ## Standard Structure
 
@@ -64,6 +68,7 @@ Use this baseline and adjust the app name, description, category, icon, and stor
   "runtime": "vite",
   "runtimeVersion": "^1.0.0",
   "listingTrust": "first_party",
+  "scope": "personal",
   "icon": "my-app",
   "category": "productivity",
   "build": {
@@ -209,10 +214,16 @@ Before reporting done:
 cd ~/apps/<slug>
 pnpm build
 test -f dist/index.html
-node -e 'const m=require("./matrix.json"); if (m.runtime !== "vite" || m.build?.output !== "dist") process.exit(1)'
+node <resolved-matrix-app-builder-skill-directory>/scripts/verify-app.mjs "$PWD"
 ```
 
-Then open the app in Matrix and check browser console for:
+Resolve the skill directory from the SKILL.md you loaded; the script ships beside it and needs no dependencies. Run it on the actual app directory, not the template. It verifies the owner-built Vite manifest and production entry; it never changes trust or proves a live login.
+
+### Launch and authentication
+
+Matrix supplies owner authentication. Do not build a separate login page or read/copy gateway credentials into the app. The native launcher obtains a short-lived token through `POST /api/apps/<slug>/session-token`; the launch is `/apps/<slug>/`. Missing or unknown `listingTrust` yields `403 install_blocked_by_policy`, not an expired login. An existing app you just built for the owner can have its missing metadata corrected after checking its origin; never silently promote an imported app. `401` means authentication, `403` policy, `409` scope/acknowledgment, `404` discovery, and `5xx` a server failure. Report failures accurately instead of recommending sign-in for all of them. Do not disable authentication, weaken policy, restart the VPS, or add a server to work around a launch failure.
+
+Then open the app from the Matrix launcher using the existing authenticated session. Verify app assets, icon, bridge operations, a save/reopen round trip, and the craft reference's visual/state checks. If browser access is unavailable, report launch and visual verification as pending rather than claiming the app works. Check browser console/network for:
 
 - `needs_build`
 - 404s for app bundle or icon paths

--- a/skills/matrix/app-builder/references/app-craft.md
+++ b/skills/matrix/app-builder/references/app-craft.md
@@ -1,0 +1,78 @@
+# App craft: design for the job
+
+Use this alongside the installed `emil-design-eng` and `apple-design` skills from
+https://github.com/emilkowalski/skills. Read `animate` for a specific motion task and
+`review-animations` when available for the final motion pass. Discover skills through
+the active harness's catalog first; read the actual SKILL.md, not just its description.
+Common roots are `$MATRIX_HOME/.agents/skills`, `$MATRIX_HOME/agents/skills`,
+`$MATRIX_HOME/.claude/skills`, `$MATRIX_HOME/.codex/skills`, `$HOME/.agents/skills`,
+`$HOME/.claude/skills`, and `$HERMES_HOME/skills` when set.
+If absent, say so and use the guidance below; never claim you loaded a missing skill.
+Matrix's runtime, theme, security, and accessibility requirements still apply.
+
+## Before coding
+
+Write a short design direction in the task notes: who uses this, their primary action,
+the content that deserves the most space, the appropriate density, and one detail
+that makes this particular app useful and memorable. Choose sensible defaults without
+turning this into a questionnaire. Follow user-provided references and existing app style.
+
+Choose the structure from the work: a reader gives the document comfortable measure
+and a quiet outline; a tracker gives entries and rapid logging priority; a planning app
+makes time or relationships visible; a game centers the board and immediate feedback.
+A dashboard is justified only when its overview helps a real decision.
+
+## Visual decisions
+
+- Use inherited Matrix fonts and tokens. Establish hierarchy through size, weight,
+  leading, alignment, and spacing; system fonts are a good default. Use tabular figures
+  where numbers need comparison and comfortable line lengths for reading.
+- Favor a clear content surface. Use cards for distinct objects, not as wrappers around
+  every heading. Group related controls near the content they affect. Avoid duplicate
+  app/window titles, oversized welcome banners, decorative metrics, and generic hero copy.
+- Make empty states truthful: one useful next action, no fake records, invented usage,
+  fake avatars, or testimonials. Example content must be clearly labeled and removable.
+- Keep color purposeful: selection, action, status. Theme-aware solid surfaces are valid.
+  Glass or a gradient must explain depth or fit the requested art direction; do not apply
+  a sand wash, glow, mesh, or blur to every app. Avoid nested glass panels.
+- Use a small spacing and radius scale. Compact rectangular controls suit dense tools;
+  pills suit tags or segmented choices. Choose per function, not one radius for everything.
+- Give the app one useful signature detail: an excellent reading outline, direct board
+  manipulation, an expressive progress view, or fast inline editing. Decoration is optional.
+
+## Motion decisions
+
+First ask whether motion helps this action and how often it happens. Keep typing,
+keyboard shortcuts, filtering, and repeated list navigation immediate. Do not stagger
+the whole app on mount or replay an entrance when changing tabs or refreshing data.
+
+For occasional state changes, use short, purposeful motion: press feedback around
+100–160ms, popovers around 125–200ms, most transitions under 300ms. Use ease-out for
+entry/exit, such as `cubic-bezier(0.23, 1, 0.32, 1)`, and ease-in-out for movement between
+positions. Specify properties; avoid `transition: all`. Prefer transform and opacity.
+Anchor popovers to their trigger; keep modals centered. Start subtle scale entrances
+near 0.97 rather than zero. Reserve bounce for interactions whose momentum warrants it.
+
+Show press feedback immediately but commit actions on click/release, preserving cancel
+and keyboard behavior. Gate hover effects behind `(hover: hover) and (pointer: fine)`.
+Use CSS transitions for simple state changes. For drag/swipe, track the pointer directly
+and use interruptible springs that retain velocity on release; never lock input while
+motion finishes. Reuse an existing accessible component library when appropriate.
+
+Honor `prefers-reduced-motion`: static changes or brief opacity feedback, no slides,
+parallax, or spring overshoot. If using translucency, support reduced transparency and
+increased contrast. Never hide information or delay an action to finish an animation.
+
+## Inspect and refine
+
+Run the app in Matrix, not only a standalone preview. Check Web Canvas, Web Desktop,
+and Electron Desktop where available; include Web Mobile and Native Mobile when supported.
+At minimum inspect a narrow window, the normal working size, both theme modes, and
+reduced motion. Test keyboard focus, Escape, labeled icon buttons, long text, empty,
+loading, failure/retry, populated, and saving states. Touch targets should be comfortably
+usable (aim for 44px on touch surfaces). Verify persistence by reopening the app.
+
+Capture screenshots and interact with the primary flow; review motion at normal speed
+and slower playback when tools allow. Fix the biggest hierarchy, spacing, contrast, or
+interaction problems, then inspect again. Report what you actually tested and any
+unavailable surface. A successful build alone is not visual or launch verification.

--- a/skills/matrix/app-builder/scripts/verify-app.mjs
+++ b/skills/matrix/app-builder/scripts/verify-app.mjs
@@ -1,0 +1,27 @@
+import { readFile, stat } from "node:fs/promises";
+import { resolve, join } from "node:path";
+
+// Dependency-free preflight for owner-built Vite apps. This is not an installer
+// or a trust migration: never rewrite manifests or promote imported apps here.
+const appDir = resolve(process.argv[2] ?? ".");
+try {
+  const m = JSON.parse(await readFile(join(appDir, "matrix.json"), "utf8"));
+  const errors = [];
+  if (!m || typeof m !== "object" || Array.isArray(m)) throw new Error("matrix.json must contain an object");
+  if (typeof m.name !== "string" || !m.name.trim()) errors.push("name is required");
+  if (typeof m.slug !== "string" || !/^[a-z0-9][a-z0-9-]{0,63}$/.test(m.slug)) errors.push("slug is invalid");
+  if (typeof m.version !== "string" || !/^\d+\.\d+\.\d+/.test(m.version)) errors.push("version is required");
+  if (m.runtime !== "vite") errors.push("this preflight requires runtime: vite");
+  if (typeof m.runtimeVersion !== "string" || !/^[\^~]?\d+\.\d+\.\d+$/.test(m.runtimeVersion)) errors.push("runtimeVersion must be a semver range");
+  if (m.listingTrust !== "first_party") errors.push("owner-built apps require listingTrust: first_party; do not relabel imported apps");
+  if ((m.scope ?? "personal") !== "personal") errors.push("owner app launch requires scope: personal");
+  if (m.build?.output !== "dist" || typeof m.build?.command !== "string" || !m.build.command.trim()) errors.push("build.command and build.output: dist are required");
+  if ("distributionStatus" in m) errors.push("distributionStatus is computed by Matrix; remove the authored field");
+  if (errors.length) throw new Error(errors.join("\n"));
+  if (!(await stat(join(appDir, "dist/index.html"))).isFile()) throw new Error("dist/index.html must be a file");
+  console.log(`Manifest and build verified: /apps/${m.slug}/`);
+  console.log("Next: open in Matrix; verify launch, assets, bridge, persistence, and visual states. This preflight does not verify a live session.");
+} catch (error) {
+  console.error("App preflight failed:", error instanceof Error ? error.message : "unable to validate app");
+  process.exitCode = 1;
+}

--- a/skills/matrix/app-ui-patterns/SKILL.md
+++ b/skills/matrix/app-ui-patterns/SKILL.md
@@ -31,7 +31,7 @@ Matrix OS apps render inside iframes within window frames. The OS provides title
 
 ## App Shell Pattern
 
-Most apps follow a consistent shell structure:
+Choose a structure around the primary task. This shell is an option for apps with navigation, not a required dashboard wrapper for readers, tools, or games:
 
 ```
 ┌─────────────────────────────────────┐
@@ -53,7 +53,7 @@ Most apps follow a consistent shell structure:
   grid-template-rows: auto 1fr auto;
   background: var(--bg);
   color: var(--fg);
-  font-family: 'Inter', system-ui, sans-serif;
+  font-family: var(--matrix-font-sans, system-ui, sans-serif);
 }
 
 .app-content {
@@ -70,7 +70,7 @@ Most apps follow a consistent shell structure:
 
 ## Pattern: Dashboard
 
-Greeting, key stats, quick actions, and a command/search bar.
+Use an overview only when real summaries help the user decide what to do. Do not invent statistics or add a greeting/command bar to every app. Prefer the core content for readers, focused tools, and games.
 
 ```
 ┌─────────────────────────────────────┐
@@ -86,8 +86,8 @@ Greeting, key stats, quick actions, and a command/search bar.
 └─────────────────────────────────────┘
 ```
 
-- **Greeting** uses Inter, 1.25-1.5rem, weight 600. Orbitron only if the greeting is a large hero-level display (2rem+).
-- **Stats** use Orbitron for the number only when large (1.5rem+). Inter weight 700 for smaller stat numbers. Inter for the label (tiny, uppercase, tracked).
+- **Heading** uses the inherited shell font with a size appropriate to the window. Avoid redundant greetings.
+- **Stats** use inherited fonts and tabular numbers; give labels sufficient size and contrast. Only show real, relevant metrics.
 - **Stat cards** have `--bg` background, 14px radius, 16px padding
 - **Command bar** is a composite input: text input + icon button in a single container with `--bg` background, 14-16px radius
 - Keep the dashboard to a single scroll-free view when possible
@@ -226,7 +226,7 @@ Apps should be usable at 320px width (minimum window size).
 
 ## Pattern: Loading States
 
-- **Skeleton screens**: use `--muted` background with subtle shimmer animation (2.4s, ease-in-out). Match the shape of the content that will load.
+- **Skeleton screens**: use `--muted` placeholders matching the eventual content. Shimmer is optional; keep reduced-motion placeholders static and show ready content immediately.
 - **Spinners**: use a simple 16-20px circle with `--primary` color, 2px stroke, rotating. Not a full-page overlay — inline where the content will appear.
 - **Progress bars**: 4px height, `--muted` track, fill color matches the context (Forest for neutral, Ember for important).
 

--- a/skills/matrix/design-system/SKILL.md
+++ b/skills/matrix/design-system/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: matrix-design-system
 description: The Matrix OS visual language — colors, typography, icons, animations, and component patterns. Apply this every time you build, redesign, or polish any Matrix OS surface.
-version: 2.0.0
+version: 2.1.0
 author: Matrix OS
 license: MIT
 platforms: [linux, macos]
@@ -63,60 +63,49 @@ Use `--matrix-*` directly or define `--app-*` aliases from them. Do not replace 
 2. **Forest is structural.** Headers, primary buttons, nav active states.
 3. **Cream is warmth.** Secondary fills, hover states.
 4. **Deep is text.** Never use pure black `#000000`.
-5. **Backgrounds are GRADIENT**, not flat — blend sand shades (`#F7F1E7`, `#F3EAE0`, `#D6AB8B`).
+5. **Backgrounds inherit the active theme.** Quiet solid surfaces are the default for content. Use gradients only when the chosen art direction calls for depth; do not hardcode a light wash over dark mode.
 6. **Shadows always use Deep-tinted** `rgba(50,53,46,X)`, never pure black.
 
-### Gradient Backgrounds
+### Optional depth
 
-```css
-/* App page background — warm sand wash */
-background: linear-gradient(170deg, #F7F1E7 0%, #F3EAE0 30%, #F7F3ED 60%, #F7F1E7 100%);
-
-/* Section with depth */
-background: linear-gradient(165deg, #E0E1CA 0%, #FAFAF5 50%, rgba(208,111,37,0.05) 100%);
-
-/* Dark section */
-background: linear-gradient(135deg, #32352E 0%, #434E3F 40%, #D6AB8B 100%);
-```
+Use token-derived shadows and surfaces to explain hierarchy. Glass, gradients, and
+texture are optional treatments for a specific purpose, never a required app backdrop.
 
 ## Typography
 
-| Role     | Font           | Usage                                                   |
-|----------|----------------|---------------------------------------------------------|
-| Display  | Orbitron       | H1/H2 only — page titles, hero headings, large stat numbers |
-| UI/Body  | Inter          | Everything else — H3+ subtitles, body, buttons, labels, nav, card titles |
-| Code     | JetBrains Mono | Terminal, code blocks, technical data                   |
-
-**Orbitron is minimal.** Only H1/H2 display headings and large metric numbers. Never for subtitles (H3+), card titles, descriptions, button labels, or anything below 16px.
+Inherit `var(--matrix-font-sans, system-ui, sans-serif)` for UI and
+`var(--matrix-font-mono, monospace)` for code. Do not load remote fonts or force a display
+font on app headings. Create hierarchy through size, weight, leading, and spacing.
+Use tabular numerals for aligned data; constrain prose measure for comfortable reading.
 
 ### Type Scale
 
 | Level      | Font     | Size      | Weight |
 |------------|----------|-----------|--------|
-| Display    | Orbitron | 3rem+     | 700-800|
-| H1         | Orbitron | 2.25rem   | 600    |
-| H2         | Orbitron | 1.75rem   | 600    |
-| H3         | Inter    | 1.25rem   | 600    |
-| H4         | Inter    | 1.125rem  | 600    |
-| Body       | Inter    | 1rem      | 400    |
-| Small      | Inter    | 0.875rem  | 400    |
-| Caption    | Inter    | 0.75rem   | 400    |
-| Label      | Inter    | 0.65rem   | 600    |
+| Display    | Inherited | 3rem+     | 700-800|
+| H1         | Inherited | 2.25rem   | 600    |
+| H2         | Inherited | 1.75rem   | 600    |
+| H3         | Inherited | 1.25rem   | 600    |
+| H4         | Inherited | 1.125rem  | 600    |
+| Body       | Inherited | 1rem      | 400    |
+| Small      | Inherited | 0.875rem  | 400    |
+| Caption    | Inherited | 0.75rem   | 400    |
+| Label      | Inherited | 0.65rem   | 600    |
 
-Labels: `letter-spacing: 0.15-0.25em; text-transform: uppercase`.
+Keep labels readable at normal text sizes; use uppercase and tracking sparingly for short section labels.
 
 ## Shapes
 
 | Element   | Border Radius | Notes                        |
 |-----------|---------------|------------------------------|
-| Buttons   | 50px          | Full capsule, always         |
-| Inputs    | 50px          | Full capsule                 |
+| Buttons   | 6-12px        | Match control density; pills optional |
+| Inputs    | 6-12px        | Keep forms compact and legible |
 | Cards     | 22px          | Soft rounded                 |
 | Inner UI  | 14-16px       | Nested elements              |
 | Badges    | 9999px        | Perfect pill                 |
 | Icons bg  | 14px          | Icon containers in stat cards|
 
-No sharp corners anywhere in Matrix OS.
+Choose a coherent radius scale for the app. Dense tables and editors may use square regions; cards and dialogs can be softer.
 
 ### Shadows
 
@@ -158,53 +147,28 @@ Default to simple line-style SVGs for all UI. Only use specialist bundled assets
 
 ## Animations
 
-Clean and subtle — barely noticed but deeply felt.
+Read the installed `emil-design-eng` and `apple-design` skills; see the builder’s
+`references/app-craft.md` for the shared process. Motion serves feedback, continuity,
+or a spatial relationship. Frequency comes first: keep typing, keyboard actions, and
+repeated navigation immediate. Do not stagger all content on page mount.
 
-### Page Mount — Staggered Fade Up
-
-```css
-@keyframes fadeUp {
-  from { opacity: 0; transform: translateY(12px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-.animate-in { animation: fadeUp 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) both; }
-/* Stagger children: 60ms gap */
-.stagger > :nth-child(1) { animation-delay: 0s; }
-.stagger > :nth-child(2) { animation-delay: 0.06s; }
-.stagger > :nth-child(3) { animation-delay: 0.12s; }
-/* ...continue pattern */
-```
-
-### Hover — Lift
+Use short ease-out transitions for occasional entry/exit, anchored to the trigger for
+popovers. Prefer transform/opacity; never `transition: all`. Springs are for continuous,
+interruptible gestures. Avoid decorative bounce and hover lift on every control.
 
 ```css
-.hoverable:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(50,53,46,0.08); }
-.hoverable:active { transform: translateY(0); }
-```
-
-### Skeleton Loading — Warm Shimmer
-
-```css
-@keyframes shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
-.skeleton {
-  background: linear-gradient(90deg, var(--muted) 25%, #F7F1E7 50%, var(--muted) 75%);
-  background-size: 200% 100%;
-  animation: shimmer 1.8s ease-in-out infinite;
-  border-radius: 10px;
+.action { transition: transform 120ms cubic-bezier(0.23, 1, 0.32, 1); }
+.action:active { transform: scale(0.97); }
+@media (prefers-reduced-motion: reduce) {
+  .action { transition: none; }
+  .action:active { transform: none; }
 }
 ```
 
-### Progress Bars
-
-Animate width from 0 to target on mount: `transition: width 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94)`.
-
-### Rules
-
-- Page load = one orchestrated wave (stagger all top-level elements)
-- Hover lift on every clickable card and button
-- Loading always uses warm-tinted skeletons, never blank space
-- Spinners: `svg-spinners:ring-resize`, never custom
-- Always respect `prefers-reduced-motion`
+Preserve visible focus and immediate non-motion feedback. Gate hover treatments behind
+`(hover: hover) and (pointer: fine)`. Use stable placeholders for loading, announce status
+accessibly, and never delay ready content to finish a shimmer or entrance. Render true
+progress rather than animating invented progress from zero on mount.
 
 ## Component Patterns
 
@@ -267,9 +231,8 @@ of inventing one-off controls.
 - No text characters used as icons (search for `>×</`, `>+</`)
 - All icon buttons visually centered
 - No components with excessive empty whitespace
-- Gradient backgrounds, not flat colors
-- Capsule-rounded buttons and inputs
-- Stagger animation on page mount
+- Theme-aware surfaces and task-appropriate control shapes
+- Purposeful, interruptible motion with reduced-motion support
 - All inputs have focus states, all buttons have hover states
-- Orbitron only on H1/H2, Inter everywhere else
+- Inherited fonts with clear hierarchy and legible labels
 - One Ember accent maximum per view

--- a/tests/desktop/app-launch-failure.test.ts
+++ b/tests/desktop/app-launch-failure.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EmbedService } from "@desktop/main/embeds/embed-service";
+
+vi.mock("electron", () => ({ net: { request: vi.fn() }, session: { fromPartition: vi.fn() } }));
+
+describe("app launch failures", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each([
+    [401, "{}", "auth-required"],
+    [403, '{"error":"install_blocked_by_policy"}', "failed"],
+    [409, '{"error":"install_gated"}', "failed"],
+    [404, '{"error":"not found"}', "failed"],
+    [503, '{"error":"internal"}', "failed"],
+    [200, "not json", "failed"],
+    [200, "{}", "failed"],
+  ])("maps HTTP %s with body %s to %s", async (status, body, state) => {
+    const emitState = vi.fn();
+    const service = new EmbedService({
+      getWindow: () => null, getGatewayOrigin: () => "https://gateway.test",
+      getToken: () => "token", emitState,
+    });
+    const internals = service as unknown as {
+      gatewayRequest: () => Promise<{ status: number; body: string; setCookieHeaders: string[] }>;
+      manager: { open: () => string };
+    };
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(internals, "gatewayRequest").mockResolvedValue({ status, body, setCookieHeaders: [] });
+    const open = vi.spyOn(internals.manager, "open");
+    const result = await service.open({ kind: "app", slug: "spec-reader", bounds: { x: 0, y: 0, width: 800, height: 600 } });
+    expect(result.state).toBe(state);
+    expect(open).not.toHaveBeenCalled();
+    await expect(service.retryAuth(result.embedId)).resolves.toBe(false);
+    expect(emitState).toHaveBeenLastCalledWith(result.embedId, state);
+    service.closeAll();
+  });
+});

--- a/tests/desktop/embed-host.test.tsx
+++ b/tests/desktop/embed-host.test.tsx
@@ -228,6 +228,28 @@ describe("EmbedHost", () => {
     });
   });
 
+  it("preserves an app failure reported during an auth retry", async () => {
+    let emitState: ((payload: { embedId: string; state: "failed" }) => void) | null = null;
+    vi.mocked(onEvent).mockImplementation((_channel, callback) => {
+      emitState = callback as typeof emitState;
+      return () => undefined;
+    });
+    vi.mocked(invoke).mockImplementation((channel: string) => {
+      if (channel === "embed:open") {
+        return Promise.resolve({ embedId: "embed-1", state: "auth-required" }) as ReturnType<typeof invoke>;
+      }
+      if (channel === "embed:retry-auth") {
+        emitState?.({ embedId: "embed-1", state: "failed" });
+        return Promise.resolve({ ok: false }) as ReturnType<typeof invoke>;
+      }
+      return Promise.resolve({ ok: true }) as ReturnType<typeof invoke>;
+    });
+    render(<EmbedHost kind="app" slug="spec-reader" />);
+    fireEvent.click(await screen.findByRole("button", { name: "Retry sign-in" }));
+    expect(await screen.findByRole("button", { name: "Try again" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Retry sign-in" })).toBeNull();
+  });
+
   it("refreshes bounds after a successful auth retry", async () => {
     vi.mocked(invoke).mockImplementation((channel: string) => {
       if (channel === "embed:open") {

--- a/tests/desktop/embed-service.test.ts
+++ b/tests/desktop/embed-service.test.ts
@@ -830,7 +830,7 @@ describe("EmbedService", () => {
 
     await expect(service.retryAuth("embed-app")).resolves.toBe(false);
     expect(open).not.toHaveBeenCalled();
-    expect(emitState).toHaveBeenCalledWith("embed-app", "auth-required");
+    expect(emitState).toHaveBeenCalledWith("embed-app", "failed");
 
     await expect(service.retryAuth("embed-app")).resolves.toBe(true);
     expect(fetchLaunchToken).toHaveBeenCalledTimes(2);

--- a/tests/kernel/app-builder-verification.test.ts
+++ b/tests/kernel/app-builder-verification.test.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve, join } from "node:path";
+import { afterEach, expect, it } from "vitest";
+
+const script = resolve("skills/matrix/app-builder/scripts/verify-app.mjs");
+const dirs: string[] = [];
+afterEach(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+
+function fixture(overrides: Record<string, unknown> = {}, built = true) {
+  const dir = mkdtempSync(join(tmpdir(), "matrix-builder-"));
+  dirs.push(dir);
+  writeFileSync(join(dir, "matrix.json"), JSON.stringify({
+    name: "Spec Reader", slug: "spec-reader", version: "1.0.0", runtime: "vite",
+    runtimeVersion: "^1.0.0", listingTrust: "first_party", scope: "personal",
+    build: { command: "pnpm build", output: "dist" }, ...overrides,
+  }));
+  if (built) { mkdirSync(join(dir, "dist")); writeFileSync(join(dir, "dist/index.html"), "<!doctype html>"); }
+  return dir;
+}
+
+it("verifies a built owner app and prints the real Matrix launch path", () => {
+  expect(execFileSync(process.execPath, [script, fixture()], { encoding: "utf8" })).toContain("/apps/spec-reader/");
+});
+
+it.each([
+  { listingTrust: undefined }, { listingTrust: "community" }, { scope: "shared" },
+  { slug: "../escape" }, { runtime: "node" }, { runtimeVersion: undefined },
+  { build: { command: "pnpm build", output: "../dist" } },
+])("rejects an app that cannot use the owner-built Vite launch contract: %j", (overrides) => {
+  expect(() => execFileSync(process.execPath, [script, fixture(overrides)], { stdio: "pipe" })).toThrow();
+});
+
+it("rejects a valid manifest without its production build", () => {
+  expect(() => execFileSync(process.execPath, [script, fixture({}, false)], { stdio: "pipe" })).toThrow();
+});


### PR DESCRIPTION
Owner-built apps can compile successfully yet fail to launch when their manifest omits `listingTrust`. Electron previously displayed every failed launch-token request as “sign in again,” including policy rejections and missing apps. Reserve that state for HTTP 401, keep other failures recoverable, and preserve failure events during auth retries.

The builder skill now ships a read-only manifest/build preflight and explains the launch contract without weakening distribution policy or promoting imported apps. Update both kernel prompts, the custom builder, and companion design guidance to use installed Emil/Apple craft skills, choose layouts for the task, and inspect actual Matrix launches and visual states. Remove conflicting universal gradients, glass, capsule controls, and mount staggering.

Validation:
- 138 tests pass across app launch, embed service/host, builder preflight, agent prompts, skill guidance, and generation security. Regression cases were reproduced before implementation.
- Main prompt remains within its existing 7K-token budget test; `git diff --check` passes.
- Full Electron typecheck is blocked in this checkout by a Vite 6/7 plugin type conflict and missing built `BuildSource` exports in reused workspace dependencies.
- No end-to-end visual quality claim: this changes builder instructions, not a generated app UI.

Invariants:
- Source of truth: gateway distribution policy and `matrix.json` remain authoritative; `skills/matrix/` owns shipped builder guidance. External craft skills are discovered from the installed harness catalog.
- Lock/transaction scope: no database writes or new shared resources; the preflight reads files only.
- Acceptable orphan states: existing bounded pending-embed registry remains in use; failed opens can be retried or closed.
- Auth source of truth: existing owner bearer authentication and gateway launch-token endpoint. No credential copying, auth bypass, or imported-app trust promotion.
- Deferred scope: fleet rollout, generated-app visual evaluation, and unrelated desktop dependency/typecheck repairs.
