### PR TITLE
feat(chat): discover Claude models from the active runtime

### DIFF
--- a/packages/gateway/src/chat/claude-model-catalog.ts
+++ b/packages/gateway/src/chat/claude-model-catalog.ts
@@ -125,8 +125,22 @@ export function createClaudeModelCatalogSource(options: {
       return value;
     };
     const request = Promise.race([Promise.resolve().then(load), deadline])
-      .catch((_error: unknown) => {
-        console.warn("[chat-providers] Claude model discovery unavailable");
+      .catch((error: unknown) => {
+        if (!(error instanceof Error) || error instanceof TypeError
+          || error instanceof ReferenceError || error instanceof RangeError) {
+          console.error("[chat-providers] Unexpected Claude model discovery failure", {
+            category: error instanceof Error ? "programming_error" : "non_error_throw",
+          });
+          // Do not disguise programming failures as cached discovery outages.
+          // The catalog orchestration boundary still normalizes client errors.
+          throw error;
+        }
+        const category = controller.signal.aborted ? "timeout"
+          : error instanceof z.ZodError || error instanceof SyntaxError ? "invalid_metadata"
+            : "discovery_failed";
+        // Metadata/SDK errors may contain owner credentials or native output.
+        // Log only the checked category, never raw error messages or objects.
+        console.warn("[chat-providers] Claude model discovery unavailable", { category });
         const value = hit && hit.staleAt > Date.now() ? hit.value : null;
         if (contextKey) save({ contextKey, value,
           expiresAt: value ? Math.min(Date.now() + 5_000, hit!.staleAt) : Date.now() + 5_000,

--- a/packages/gateway/src/chat/claude-model-catalog.ts
+++ b/packages/gateway/src/chat/claude-model-catalog.ts
@@ -1,0 +1,152 @@
+import type { CodingModelCatalogProjection } from "./provider-catalog.js";
+import { CanonicalChatModelSelectionSchema, CanonicalModelDescriptorSchema, type AgentProviderSummary } from "@matrix-os/contracts";
+import type { RequestPrincipal } from "../request-principal.js";
+import { z } from "zod/v4";
+
+// Maintained fallback, not proof of account entitlement. Native execution remains
+// authoritative and reports unsupported models without silently substituting.
+// https://support.claude.com/en/articles/11940350-claude-code-model-configuration
+export function claudeFallbackCatalog(): CodingModelCatalogProjection {
+  return {
+    models: [
+      ["default", "Claude default"],
+      ["opus", "Claude Opus"],
+      ["sonnet", "Claude Sonnet"],
+    ].map(([id, displayName]) => ({
+      id: id!, displayName: displayName!, capabilities: ["reasoning", "tools", "vision"],
+      supportsVision: true, supportsToolUse: true,
+    })),
+    defaultModel: "default",
+    options: [{
+      id: "effort", label: "Reasoning", kind: "enum",
+      values: ["low", "medium", "high", "max"].map((value) => ({
+        value, label: value.charAt(0).toUpperCase() + value.slice(1),
+      })),
+      defaultValue: "low", placement: "composer",
+    }],
+  };
+}
+
+const ModelInfoSchema = z.object({
+  value: z.string().min(1).max(160),
+  resolvedModel: z.string().min(1).max(160).optional(),
+  displayName: z.string().min(1).max(120).regex(/^[^\u0000-\u001f\u007f]+$/)
+    .pipe(CanonicalModelDescriptorSchema.shape.displayName),
+});
+
+function projectModels(value: unknown): CodingModelCatalogProjection {
+  const rows = z.array(ModelInfoSchema).min(1).max(64).parse(value);
+  const catalog = claudeFallbackCatalog();
+  // Keep legacy aliases/default stable, without claiming that a documented
+  // model absent from this runtime's inventory is available on this account.
+  for (const row of rows) {
+    if (catalog.models.length === 64) break;
+    const id = CanonicalChatModelSelectionSchema.shape.model.safeParse(row.value);
+    const resolved = CanonicalChatModelSelectionSchema.shape.model.safeParse(row.resolvedModel);
+    const model = id.success ? id.data : resolved.success ? resolved.data : null;
+    if (!model || catalog.models.some((entry) => entry.id === model)) continue;
+    catalog.models.push({
+      id: model,
+      // A resolved ID is a separate base-model choice, not an advertised [1m]
+      // option. Never strip qualifiers or rewrite an existing selection.
+      displayName: id.success ? row.displayName : model,
+      capabilities: ["reasoning", "tools", "vision"], supportsVision: true, supportsToolUse: true,
+    });
+  }
+  return catalog;
+}
+
+type Discovery = (signal: AbortSignal) => Promise<unknown>;
+type DiscoveryContext = { key: string; discover: Discovery; retainOnRefresh?: boolean; maxAgeMs?: number };
+type CachedInventory = {
+  contextKey: string;
+  value: CodingModelCatalogProjection | null;
+  expiresAt: number;
+  staleAt: number;
+  retainOnRefresh: boolean;
+};
+
+export function createClaudeModelCatalogSource(options: {
+  discover?: Discovery;
+  resolveContext?: (signal: AbortSignal) => Promise<DiscoveryContext>;
+  cacheTtlMs?: number;
+  timeoutMs?: number;
+}) {
+  if (!options.discover && !options.resolveContext) throw new Error("Claude inventory source is required");
+  const ttl = Math.max(1, Math.min(options.cacheTtlMs ?? 60_000, 300_000));
+  const timeoutMs = Math.max(1, Math.min(options.timeoutMs ?? 5_000, 30_000));
+  const cached = new Map<string, CachedInventory>();
+  // Each map is capped at 32 owner contexts; settled reads leave pending and
+  // insertion-order eviction bounds retained metadata, including failed reads.
+  const pending = new Map<string, { request: Promise<CodingModelCatalogProjection | null>; invalidated: boolean }>();
+  const source = async (provider: AgentProviderSummary, principal: RequestPrincipal): Promise<CodingModelCatalogProjection | null> => {
+    if ((provider.kind !== "claude" && provider.id !== "claude")
+      || provider.availability !== "available") return null;
+    const existing = pending.get(principal.userId);
+    if (existing) {
+      await existing.request;
+      // Resolve identity again before sharing a completed read: credentials may
+      // have changed while the caller was waiting for another request.
+      return source(provider, principal);
+    }
+    if (pending.size >= 32) return null;
+    const state = { request: Promise.resolve<CodingModelCatalogProjection | null>(null), invalidated: false };
+    const save = (entry: CachedInventory) => {
+      if (state.invalidated && !entry.retainOnRefresh) return;
+      if (state.invalidated) entry.expiresAt = 0;
+      if (cached.size >= 32 && !cached.has(principal.userId)) cached.delete(cached.keys().next().value!);
+      cached.set(principal.userId, entry);
+    };
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout>;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        reject(new Error("Claude model discovery timed out"));
+      }, timeoutMs);
+    });
+    let contextKey: string | undefined;
+    let hit: CachedInventory | undefined;
+    const load = async () => {
+      const context = options.resolveContext
+        ? await options.resolveContext(controller.signal)
+        : { key: "runtime", discover: options.discover! };
+      controller.signal.throwIfAborted();
+      contextKey = JSON.stringify([context.key, provider.id, provider.kind, provider.installStatus, provider.authStatus]);
+      const candidate = cached.get(principal.userId);
+      hit = candidate?.contextKey === contextKey ? candidate : undefined;
+      if (hit && hit.expiresAt > Date.now()) return hit.value;
+      const value = projectModels(await context.discover(controller.signal));
+      controller.signal.throwIfAborted();
+      const age = Math.max(1, Math.min(context.maxAgeMs ?? ttl, ttl));
+      const retainOnRefresh = context.retainOnRefresh !== false;
+      save({ contextKey, value, expiresAt: Date.now() + age,
+        staleAt: Date.now() + (retainOnRefresh ? 300_000 : age), retainOnRefresh });
+      return value;
+    };
+    const request = Promise.race([Promise.resolve().then(load), deadline])
+      .catch((_error: unknown) => {
+        console.warn("[chat-providers] Claude model discovery unavailable");
+        const value = hit && hit.staleAt > Date.now() ? hit.value : null;
+        if (contextKey) save({ contextKey, value,
+          expiresAt: value ? Math.min(Date.now() + 5_000, hit!.staleAt) : Date.now() + 5_000,
+          staleAt: hit?.staleAt ?? 0, retainOnRefresh: hit?.retainOnRefresh ?? false });
+        return value;
+      }).finally(() => {
+        clearTimeout(timer);
+        controller.abort();
+        pending.delete(principal.userId);
+      });
+    state.request = request;
+    pending.set(principal.userId, state);
+    return request;
+  };
+  source.invalidate = (principal: RequestPrincipal) => {
+    const hit = cached.get(principal.userId);
+    if (hit?.retainOnRefresh) hit.expiresAt = 0;
+    else cached.delete(principal.userId);
+    const existing = pending.get(principal.userId);
+    if (existing) existing.invalidated = true;
+  };
+  return source;
+}

--- a/packages/gateway/src/chat/claude-runtime-model-catalog.ts
+++ b/packages/gateway/src/chat/claude-runtime-model-catalog.ts
@@ -1,0 +1,39 @@
+import { createHash } from "node:crypto";
+import { readClaudeModelInventory } from "@matrix-os/kernel";
+import { buildAgentLaunch } from "../agent-launcher.js";
+import type { KernelCredentialLaunch } from "../kernel-credentials.js";
+import { createClaudeModelCatalogSource } from "./claude-model-catalog.js";
+
+export function createRuntimeClaudeModelCatalogSource(options: {
+  homePath: string;
+  resolveCredentialLaunch: () => Promise<KernelCredentialLaunch>;
+  readInventory?: typeof readClaudeModelInventory;
+}) {
+  return createClaudeModelCatalogSource({
+    resolveContext: async (signal) => {
+      const launch = buildAgentLaunch({
+        agent: "claude", cwd: options.homePath, runtimeHome: options.homePath,
+        claudePermissionMode: "default",
+        sandbox: { enabled: true, mode: "read-only", writableRoots: [] },
+      });
+      const credentials = await options.resolveCredentialLaunch();
+      signal.throwIfAborted();
+      // Match the actual adapter's credential environment and runtime HOME/PATH.
+      const env = { ...(credentials.env ?? process.env), ...launch.env };
+      const key = createHash("sha256").update(JSON.stringify([
+        launch.command, launch.cwd, Object.entries(env).sort(([a], [b]) => a.localeCompare(b)),
+      ])).digest("hex");
+      const explicitCredential = Boolean(env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN);
+      return {
+        key,
+        // Profile/keychain generation cannot be verified without inspecting
+        // credential stores. Limit its cache to 5s, and discard on Refresh.
+        retainOnRefresh: explicitCredential,
+        maxAgeMs: explicitCredential ? 60_000 : 5_000,
+        discover: (requestSignal) => (options.readInventory ?? readClaudeModelInventory)({
+          executable: launch.command, cwd: launch.cwd, env, signal: requestSignal,
+        }),
+      };
+    },
+  });
+}

--- a/packages/gateway/src/chat/provider-catalog.ts
+++ b/packages/gateway/src/chat/provider-catalog.ts
@@ -35,6 +35,7 @@ import type { CodingAgentProviderRegistry } from "../coding-agents/provider-regi
 import type { RequestPrincipal } from "../request-principal.js";
 import type { AiProviderSnapshotReader } from "../ai-providers/service.js";
 import { ProviderSettingsStoreError } from "../ai-providers/provider-settings-errors.js";
+import { claudeFallbackCatalog } from "./claude-model-catalog.js";
 
 const ADAPTER_VERSION = "1.0.0";
 const SYSTEM_DRIVERS = ["hermes", "openclaw"] as const;
@@ -156,18 +157,7 @@ function codingModels(provider: AgentProviderSummary): CanonicalModelDescriptor[
       : provider.availability === "auth_required"
         ? "auth_required" as const
         : "unavailable" as const;
-    return [
-      ["default", "Claude default"],
-      ["opus", "Claude Opus"],
-      ["sonnet", "Claude Sonnet"],
-    ].map(([id, displayName]) => ({
-      id: id!,
-      displayName: displayName!,
-      availability,
-      capabilities: ["reasoning", "tools", "vision"],
-      supportsVision: true,
-      supportsToolUse: true,
-    }));
+    return claudeFallbackCatalog().models.map((model) => ({ ...model, availability }));
   }
   const parsedModel = provider.defaultModel === undefined
     ? null
@@ -195,9 +185,8 @@ function codingModels(provider: AgentProviderSummary): CanonicalModelDescriptor[
 function codingOptions(provider: AgentProviderSummary): CanonicalProviderOptionDescriptor[] {
   const driverKind = codingDriverKind(provider);
   if (driverKind !== "codex" && driverKind !== "claude_code") return [];
-  const efforts = driverKind === "claude_code"
-    ? ["low", "medium", "high", "max"]
-    : ["low", "medium", "high", "xhigh", "max", "ultra"];
+  if (driverKind === "claude_code") return claudeFallbackCatalog().options;
+  const efforts = ["low", "medium", "high", "xhigh", "max", "ultra"];
   return [{
     id: "effort",
     label: "Reasoning",
@@ -767,9 +756,11 @@ export function createChatProviderCatalogService(options: {
     provider: AgentProviderSummary,
     principal: RequestPrincipal,
   ) => Promise<CodingModelCatalogProjection | null>;
+  invalidateCodingModelCatalog?: (principal: RequestPrincipal) => void;
 }): ChatProviderCatalogService {
   const service: ChatProviderCatalogService = {
     async refresh(principal) {
+      options.invalidateCodingModelCatalog?.(principal);
       options.codingProviders.invalidate(principal.userId);
       options.agentRuntimeSource.invalidate?.();
       for (const source of Object.values(options.systemRuntimeSources ?? {})) {

--- a/packages/gateway/src/chat/runtime-provider-catalog.ts
+++ b/packages/gateway/src/chat/runtime-provider-catalog.ts
@@ -1,0 +1,42 @@
+import { loadSkills } from "@matrix-os/kernel";
+import { buildKernelCredentialLaunch } from "../kernel-credentials.js";
+import type { MatrixFundedCredentialProvider } from "../funded-ai-credential-manager.js";
+import { createRuntimeClaudeModelCatalogSource } from "./claude-runtime-model-catalog.js";
+import { createCodexModelCatalogSource } from "./codex-model-catalog.js";
+import { createNativeCodingModelCatalogSource } from "./native-coding-model-catalog.js";
+import { createChatProviderCatalogService } from "./provider-catalog.js";
+
+type RuntimeCatalogOptions = Omit<Parameters<typeof createChatProviderCatalogService>[0],
+  "skillsSource" | "codingModelCatalogSource" | "invalidateCodingModelCatalog"> & {
+  homePath: string;
+  codexExecutable?: string;
+  fundedCredentialProvider?: MatrixFundedCredentialProvider;
+};
+
+/** Compose runtime metadata sources separately from the gateway entrypoint. */
+export function createGatewayChatProviderCatalog(options: RuntimeCatalogOptions) {
+  const { homePath, codexExecutable, fundedCredentialProvider, ...catalogOptions } = options;
+  const codexModelCatalogSource = codexExecutable
+    ? createCodexModelCatalogSource({ executable: codexExecutable, cwd: homePath })
+    : undefined;
+  const nativeCodingModelCatalogSource = createNativeCodingModelCatalogSource({ homePath });
+  const resolveClaudeCredentialLaunch = () => buildKernelCredentialLaunch(
+    homePath, process.env, undefined, fundedCredentialProvider,
+  );
+  const claudeModelCatalogSource = createRuntimeClaudeModelCatalogSource({
+    homePath, resolveCredentialLaunch: resolveClaudeCredentialLaunch,
+  });
+  const catalog = createChatProviderCatalogService({
+    ...catalogOptions,
+    skillsSource: () => loadSkills(homePath),
+    invalidateCodingModelCatalog: claudeModelCatalogSource.invalidate,
+    codingModelCatalogSource: async (provider, principal) => {
+      const claudeModels = await claudeModelCatalogSource(provider, principal);
+      if (claudeModels) return claudeModels;
+      const codexModels = await codexModelCatalogSource?.(provider);
+      return codexModels ?? nativeCodingModelCatalogSource(provider);
+    },
+  });
+  // Execution and metadata discovery must resolve the same owner credentials.
+  return { catalog, resolveClaudeCredentialLaunch };
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -149,6 +149,7 @@ import { createCodingAgentProviderRegistry } from "./coding-agents/provider-regi
 import { cleanupStaleIsolatedProviderProcesses } from "./coding-agents/provider-process-isolation.js";
 import { createChatProviderCatalogService } from "./chat/provider-catalog.js";
 import { createCodexModelCatalogSource } from "./chat/codex-model-catalog.js";
+import { createRuntimeClaudeModelCatalogSource } from "./chat/claude-runtime-model-catalog.js";
 import { createNativeCodingModelCatalogSource } from "./chat/native-coding-model-catalog.js";
 import { createChatProviderRoutes } from "./chat/provider-routes.js";
 import {
@@ -4300,6 +4301,12 @@ export async function createGateway(config: GatewayConfig) {
     ? createCodexModelCatalogSource({ executable: codexExecutable, cwd: homePath })
     : undefined;
   const nativeCodingModelCatalogSource = createNativeCodingModelCatalogSource({ homePath });
+  const resolveClaudeCredentialLaunch = () => buildKernelCredentialLaunch(
+    homePath, process.env, undefined, fundedCredentialProvider,
+  );
+  const claudeModelCatalogSource = createRuntimeClaudeModelCatalogSource({
+    homePath, resolveCredentialLaunch: resolveClaudeCredentialLaunch,
+  });
   const canonicalChatProviderCatalog = createChatProviderCatalogService({
     codingProviders: codingAgentProviderRegistry,
     agentRuntimeSource: agentRuntimeServices.source,
@@ -4309,7 +4316,10 @@ export async function createGateway(config: GatewayConfig) {
     executableDriverKinds: canonicalExecutableDriverKinds,
     credentialedDriverKinds: ["pi", "opencode"],
     skillsSource: () => loadSkills(homePath),
-    codingModelCatalogSource: async (provider) => {
+    invalidateCodingModelCatalog: claudeModelCatalogSource.invalidate,
+    codingModelCatalogSource: async (provider, principal) => {
+      const claudeModels = await claudeModelCatalogSource(provider, principal);
+      if (claudeModels) return claudeModels;
       const codexModels = await codexModelCatalogSource?.(provider);
       return codexModels ?? nativeCodingModelCatalogSource(provider);
     },
@@ -4328,12 +4338,7 @@ export async function createGateway(config: GatewayConfig) {
     if (codingAgentProviders.some((provider) => provider.providerId === "claude")) {
       canonicalAdapters.push(createClaudeChatProviderAdapter({
         homePath,
-        resolveCredentialLaunch: () => buildKernelCredentialLaunch(
-          homePath,
-          process.env,
-          undefined,
-          fundedCredentialProvider,
-        ),
+        resolveCredentialLaunch: resolveClaudeCredentialLaunch,
       }));
     }
     if (codingAgentThreadStore) {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -20,7 +20,6 @@ import {
   loadFundedAiRuntimeConfig,
 } from "./funded-ai-credential-manager.js";
 import { createFundedAiFundingSummaryClient } from "./funded-ai-funding-summary-client.js";
-import { buildKernelCredentialLaunch } from "./kernel-credentials.js";
 import { createAllowedOriginController } from "./allowed-origins.js";
 import { createAiGenerationRecorder } from "./ai-analytics.js";
 import { createWatcher, type Watcher } from "./watcher.js";
@@ -107,7 +106,6 @@ import {
   generateIconBatch,
   createUsageTracker,
   createMemoryStore,
-  loadSkills,
 } from "@matrix-os/kernel";
 import { createProvisioner } from "./provisioner.js";
 import {
@@ -147,10 +145,7 @@ import { createOwnerCodingAgentProjectWorkspaceStore } from "./coding-agents/pro
 import { createCodingAgentThreadRelationValidator } from "./coding-agents/thread-relations.js";
 import { createCodingAgentProviderRegistry } from "./coding-agents/provider-registry.js";
 import { cleanupStaleIsolatedProviderProcesses } from "./coding-agents/provider-process-isolation.js";
-import { createChatProviderCatalogService } from "./chat/provider-catalog.js";
-import { createCodexModelCatalogSource } from "./chat/codex-model-catalog.js";
-import { createRuntimeClaudeModelCatalogSource } from "./chat/claude-runtime-model-catalog.js";
-import { createNativeCodingModelCatalogSource } from "./chat/native-coding-model-catalog.js";
+import { createGatewayChatProviderCatalog } from "./chat/runtime-provider-catalog.js";
 import { createChatProviderRoutes } from "./chat/provider-routes.js";
 import {
   closeCanonicalChatEventLifecycle,
@@ -4297,17 +4292,12 @@ export async function createGateway(config: GatewayConfig) {
       ? ["opencode" as const]
       : []),
   ];
-  const codexModelCatalogSource = codexExecutable
-    ? createCodexModelCatalogSource({ executable: codexExecutable, cwd: homePath })
-    : undefined;
-  const nativeCodingModelCatalogSource = createNativeCodingModelCatalogSource({ homePath });
-  const resolveClaudeCredentialLaunch = () => buildKernelCredentialLaunch(
-    homePath, process.env, undefined, fundedCredentialProvider,
-  );
-  const claudeModelCatalogSource = createRuntimeClaudeModelCatalogSource({
-    homePath, resolveCredentialLaunch: resolveClaudeCredentialLaunch,
-  });
-  const canonicalChatProviderCatalog = createChatProviderCatalogService({
+  const {
+    catalog: canonicalChatProviderCatalog, resolveClaudeCredentialLaunch,
+  } = createGatewayChatProviderCatalog({
+    homePath,
+    codexExecutable,
+    fundedCredentialProvider,
     codingProviders: codingAgentProviderRegistry,
     agentRuntimeSource: agentRuntimeServices.source,
     systemRuntimeSources: agentRuntimeServices.systemRuntimeSources,
@@ -4315,14 +4305,6 @@ export async function createGateway(config: GatewayConfig) {
     harnessSettingsSource: providerSettingsStore,
     executableDriverKinds: canonicalExecutableDriverKinds,
     credentialedDriverKinds: ["pi", "opencode"],
-    skillsSource: () => loadSkills(homePath),
-    invalidateCodingModelCatalog: claudeModelCatalogSource.invalidate,
-    codingModelCatalogSource: async (provider, principal) => {
-      const claudeModels = await claudeModelCatalogSource(provider, principal);
-      if (claudeModels) return claudeModels;
-      const codexModels = await codexModelCatalogSource?.(provider);
-      return codexModels ?? nativeCodingModelCatalogSource(provider);
-    },
   });
   if (chatRepository) {
     canonicalChatExecutionRoots = createChatExecutionRootResolver({

--- a/packages/kernel/src/claude-model-inventory.ts
+++ b/packages/kernel/src/claude-model-inventory.ts
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+import { query, type Query, type SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+
+type InventoryQueryFactory = (input: Parameters<typeof query>[0]) => Pick<Query, "supportedModels" | "close">;
+const MAX_INVENTORY_OUTPUT_BYTES = 1024 * 1024;
+
+/** Read CLI initialization metadata, never submit a user message or run tools. */
+export async function readClaudeModelInventory(options: {
+  executable: string;
+  cwd: string;
+  env: Record<string, string | undefined>;
+  signal: AbortSignal;
+  queryFn?: InventoryQueryFactory;
+}): Promise<unknown> {
+  options.signal.throwIfAborted();
+  const controller = new AbortController();
+  let releaseInput!: () => void;
+  const finished = new Promise<void>((resolve) => { releaseInput = resolve; });
+  let rejectAborted!: (error: Error) => void;
+  const aborted = new Promise<never>((_resolve, reject) => { rejectAborted = reject; });
+  const fail = (error: Error) => {
+    rejectAborted(error);
+    controller.abort();
+    releaseInput();
+  };
+  const abort = () => fail(new Error("Claude inventory read aborted"));
+  options.signal.addEventListener("abort", abort, { once: true });
+  async function* noUserInput(): AsyncGenerator<SDKUserMessage> { await finished; }
+  let session: Pick<Query, "supportedModels" | "close"> | undefined;
+  try {
+    session = (options.queryFn ?? query)({
+      prompt: noUserInput(),
+      options: {
+        pathToClaudeCodeExecutable: options.executable,
+        cwd: options.cwd, env: options.env, abortController: controller,
+        persistSession: false, tools: [], settingSources: [], strictMcpConfig: true,
+        mcpServers: {}, permissionMode: "default", settings: { disableAllHooks: true },
+        extraArgs: { "no-chrome": null },
+        // Use the selected CLI on the same PATH as canonical Chat, not the SDK's
+        // bundled CLI. Custom spawn also supports an executable resolved by PATH.
+        spawnClaudeCodeProcess: ({ command, args, cwd, env, signal }) => {
+          const child = spawn(command, args, { cwd, env, signal, stdio: ["pipe", "pipe", "pipe"] });
+          // Bound the wire bytes before the SDK's readline/JSON buffering, not
+          // only the projected inventory after parsing has already completed.
+          let outputBytes = 0;
+          const observe = (chunk: Buffer | string) => {
+            outputBytes += Buffer.byteLength(chunk);
+            if (outputBytes <= MAX_INVENTORY_OUTPUT_BYTES) return;
+            fail(new Error("Claude inventory output limit exceeded"));
+            child.stdout.destroy();
+            child.stderr.destroy();
+          };
+          child.stdout.on("data", observe);
+          child.stderr.on("data", observe);
+          return child;
+        },
+      },
+    });
+    return await Promise.race([session.supportedModels(), aborted]);
+  } finally {
+    controller.abort();
+    releaseInput();
+    options.signal.removeEventListener("abort", abort);
+    session?.close();
+  }
+}

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,4 +1,5 @@
 export { spawnKernel } from "./kernel.js";
+export { readClaudeModelInventory } from "./claude-model-inventory.js";
 export type { KernelEvent, KernelResult } from "./kernel.js";
 export { parseFrontmatter } from "./agents.js";
 export {

--- a/tests/desktop/claude-model-picker.test.tsx
+++ b/tests/desktop/claude-model-picker.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import React, { useState } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { CanonicalProviderCatalog } from "@matrix-os/contracts";
+import { ProviderModelPicker } from "../../desktop/src/renderer/src/features/chat/ProviderModelPicker";
+import { createCanonicalComposerSelection } from "../../desktop/src/renderer/src/features/chat/canonical-composer-state";
+import { createChatProviderCatalogService } from "../../packages/gateway/src/chat/provider-catalog.js";
+import { createClaudeModelCatalogSource } from "../../packages/gateway/src/chat/claude-model-catalog.js";
+
+afterEach(cleanup);
+
+it("selects the gateway's exact Fable model and preserves it when the shared picker catalog refreshes", async () => {
+  let inventory = [{ value: "claude-fable-5", displayName: "Claude Fable 5" }];
+  const source = createClaudeModelCatalogSource({ discover: async () => inventory });
+  const service = createChatProviderCatalogService({
+    codingProviders: { invalidate() {}, listProviders: async () => [{
+      id: "claude", kind: "claude", displayName: "Claude Code", availability: "available",
+      installStatus: "installed", authStatus: "authenticated", supportedModes: ["default"],
+      defaultMode: "default", setupActions: [],
+    }] },
+    agentRuntimeSource: async () => ({ runtime: { selected: "hermes", options: [], transition: null },
+      providers: [], messaging: { runtime: "hermes", provider: null, model: null, configured: false } }),
+    executableDriverKinds: ["claude_code"], codingModelCatalogSource: source,
+    invalidateCodingModelCatalog: source.invalidate,
+  });
+  const principal = { userId: "owner_picker", source: "jwt" as const };
+  const onChange = vi.fn();
+  function Picker({ catalog }: { catalog: CanonicalProviderCatalog }) {
+    const [selection, setSelection] = useState(() => createCanonicalComposerSelection(catalog));
+    return <ProviderModelPicker catalog={catalog} selection={selection} instanceLocked onChange={(next) => {
+      setSelection(next); onChange(next);
+    }} />;
+  }
+  const view = render(<Picker catalog={await service.getCatalog(principal)} />);
+  fireEvent.click(screen.getByRole("button", { name: "Choose model and provider" }));
+  fireEvent.click(screen.getByRole("option", { name: /Claude Fable 5/ }));
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ instanceId: "claude_code_default", model: "claude-fable-5" }));
+  inventory = [...inventory, { value: "claude-fable-5-1", displayName: "Claude Fable 5.1" }];
+  view.rerender(<Picker catalog={await service.refresh(principal)} />);
+  expect(screen.getByRole("button", { name: "Choose model and provider" }).getAttribute("data-model"))
+    .toBe("claude-fable-5");
+  fireEvent.click(screen.getByRole("button", { name: "Choose model and provider" }));
+  expect(screen.getByRole("option", { name: /Claude Fable 5\.1/ })).toBeTruthy();
+  expect(onChange).toHaveBeenCalledTimes(1);
+});

--- a/tests/fixtures/claude-model-inventory.mjs
+++ b/tests/fixtures/claude-model-inventory.mjs
@@ -1,0 +1,24 @@
+import { createInterface } from "node:readline";
+
+// External CLI boundary fixture. No real Claude process or credentials used.
+const input = createInterface({ input: process.stdin });
+input.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.type === "user") process.exit(2);
+  if (message.type !== "control_request" || message.request.subtype !== "initialize") return;
+  if (process.env.MATRIX_TEST_INVENTORY_OVERSIZE) {
+    const output = process.env.MATRIX_TEST_INVENTORY_OVERSIZE === "stderr" ? process.stderr : process.stdout;
+    output.write(" ".repeat(1_048_577) + "\n");
+    // Keep initialization pending: ordering across stderr/stdout pipes is not
+    // guaranteed, so a control response must not race the stderr observation.
+    if (output === process.stderr) return;
+  }
+  process.stdout.write(JSON.stringify({ type: "control_response", response: {
+    subtype: "success", request_id: message.request_id, response: {
+      commands: [], agents: [], account: {}, output_style: "default", available_output_styles: [],
+      models: [{ value: process.env.ANTHROPIC_API_KEY ? "unexpected-ambient-credential" : "claude-fable-5",
+        displayName: "Fable", description: "" }],
+    },
+  } }) + "\n");
+});
+input.on("close", () => process.exit(0));

--- a/tests/gateway/chat-claude-catalog-errors.test.ts
+++ b/tests/gateway/chat-claude-catalog-errors.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentProviderSummary } from "@matrix-os/contracts";
+import { createClaudeModelCatalogSource } from "../../packages/gateway/src/chat/claude-model-catalog.js";
+
+const principal = { userId: "owner_catalog_errors", source: "jwt" as const };
+const provider = { id: "claude", kind: "claude", availability: "available" } as AgentProviderSummary;
+const inventory = [{ value: "claude-fable-5", displayName: "Fable" }];
+
+describe("Claude metadata failure classification", () => {
+  afterEach(() => { vi.restoreAllMocks(); vi.useRealTimers(); });
+
+  it("logs a bounded operational category and retains validated stale inventory", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const discover = vi.fn().mockResolvedValueOnce(inventory)
+      .mockRejectedValueOnce(new Error("private upstream credential detail"));
+    const source = createClaudeModelCatalogSource({ discover });
+    const first = await source(provider, principal);
+    source.invalidate(principal);
+    await expect(source(provider, principal)).resolves.toBe(first);
+    expect(warn).toHaveBeenCalledWith("[chat-providers] Claude model discovery unavailable", { category: "discovery_failed" });
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("private upstream");
+  });
+
+  it.each([
+    ["schema", () => Promise.resolve([{ displayName: "missing model ID" }])],
+    ["wire JSON", () => Promise.reject(new SyntaxError("private invalid wire bytes"))],
+  ] as const)("classifies invalid %s metadata without leaking it", async (_kind, discover) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = createClaudeModelCatalogSource({ discover });
+    await expect(source(provider, principal)).resolves.toBeNull();
+    expect(warn).toHaveBeenCalledWith("[chat-providers] Claude model discovery unavailable", { category: "invalid_metadata" });
+  });
+
+  it("classifies its bounded deadline separately from upstream failure", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const source = createClaudeModelCatalogSource({ timeoutMs: 10, discover: () => new Promise(() => {}) });
+    const result = source(provider, principal);
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(result).resolves.toBeNull();
+    expect(warn).toHaveBeenCalledWith("[chat-providers] Claude model discovery unavailable", { category: "timeout" });
+  });
+
+  it.each([
+    new TypeError("private programming failure"),
+    new ReferenceError("private programming failure"),
+    new RangeError("private programming failure"),
+    "private non-Error failure",
+    { detail: "private non-Error failure" },
+  ])("propagates unexpected failures without negatively caching or leaking them %#", async (failure) => {
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const discover = vi.fn().mockRejectedValueOnce(failure).mockResolvedValue(inventory);
+    const source = createClaudeModelCatalogSource({ discover });
+    await expect(source(provider, principal)).rejects.toBe(failure);
+    expect(log).toHaveBeenCalledWith("[chat-providers] Unexpected Claude model discovery failure", {
+      category: failure instanceof Error ? "programming_error" : "non_error_throw",
+    });
+    expect(warn).not.toHaveBeenCalled();
+    expect(JSON.stringify(log.mock.calls)).not.toContain("private");
+    expect((await source(provider, principal))?.models.some((model) => model.id === "claude-fable-5")).toBe(true);
+    expect(discover).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/gateway/chat-claude-catalog.test.ts
+++ b/tests/gateway/chat-claude-catalog.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentProviderSummary } from "@matrix-os/contracts";
+import { buildAgentLaunch } from "../../packages/gateway/src/agent-launcher.js";
+import { createChatProviderCatalogService, validateChatProviderSelection } from "../../packages/gateway/src/chat/provider-catalog.js";
+import { createClaudeModelCatalogSource } from "../../packages/gateway/src/chat/claude-model-catalog.js";
+import { EventEmitter } from "node:events";
+import { KyselyPGlite } from "kysely-pglite";
+import { CanonicalChatOrchestrator } from "../../packages/gateway/src/chat/orchestrator.js";
+import { CanonicalChatProviderRegistry } from "../../packages/gateway/src/chat/provider-adapter.js";
+import { createClaudeChatProviderAdapter } from "../../packages/gateway/src/chat/claude-provider-adapter.js";
+import { ChatRepository } from "../../packages/gateway/src/chat/repository.js";
+
+const principal = { userId: "owner_catalog", source: "jwt" as const };
+const provider: AgentProviderSummary = {
+  id: "claude", kind: "claude", displayName: "Claude Code", availability: "available",
+  installStatus: "installed", authStatus: "authenticated", supportedModes: ["default", "review"],
+  defaultMode: "default", setupActions: [],
+};
+
+function catalogService(overrides: Partial<Parameters<typeof createChatProviderCatalogService>[0]> = {}) {
+  return createChatProviderCatalogService({
+    codingProviders: { listProviders: async () => [provider], invalidate() {} },
+    agentRuntimeSource: async () => ({
+      runtime: { selected: "hermes", options: [], transition: null }, providers: [],
+      messaging: { runtime: "hermes", provider: null, model: null, configured: false },
+    }),
+    executableDriverKinds: ["claude_code"],
+    ...overrides,
+  });
+}
+
+describe("Claude catalog selection and CLI handoff", () => {
+  afterEach(() => vi.useRealTimers());
+  it("admits the runtime's resolved Fable ID unchanged without claiming its context qualifier", async () => {
+    const source = createClaudeModelCatalogSource({ discover: async () => [
+      { value: "default", resolvedModel: "claude-opus-5[1m]", displayName: "Default (recommended)" },
+      { value: "opus[1m]", resolvedModel: "claude-opus-5[1m]", displayName: "Opus (1M context)" },
+      { value: "claude-fable-5[1m]", resolvedModel: "claude-fable-5", displayName: "Fable" },
+      { value: "sonnet", resolvedModel: "claude-sonnet-5", displayName: "Sonnet" },
+      { value: "haiku", resolvedModel: "claude-haiku-4-5-20251001", displayName: "Haiku" },
+    ] });
+    const catalog = await catalogService({ codingModelCatalogSource: source }).getCatalog(principal);
+    const instance = catalog.instances.find((entry) => entry.id === "claude_code_default")!;
+    expect(instance.defaultSelection?.model).toBe("default");
+    expect(instance.models.map((model) => model.id)).not.toContain("claude-fable-5-1");
+    for (const model of ["claude-fable-5", "default", "opus", "sonnet"]) {
+      const admitted = validateChatProviderSelection({
+        catalog, boundInstanceId: "claude_code_default",
+        selection: { instanceId: "claude_code_default", model },
+      });
+      expect(admitted.ok, model).toBe(true);
+      if (!admitted.ok) throw new Error("Model rejected");
+      const launch = buildAgentLaunch({
+        agent: "claude", cwd: "/workspace", runtimeHome: "/runtime-home", prompt: "Read only",
+        model: admitted.selection.model, mode: "default", approvalPolicy: "on-request",
+        sandbox: { enabled: true, mode: "workspace-write", writableRoots: ["/workspace"] },
+        claudeOutputFormat: "stream-json", claudeIncludePartialMessages: true,
+      });
+      expect(launch.args[launch.args.indexOf("--model") + 1]).toBe(model);
+      expect(launch.args).toContain("--include-partial-messages");
+      expect(launch.args).toContain("--strict-mcp-config");
+    }
+    expect(validateChatProviderSelection({ catalog, selection: {
+      instanceId: "claude_code_default", model: "claude-unadvertised",
+    } })).toMatchObject({ ok: false, error: { code: "model_unavailable", retryable: false } });
+  });
+
+  it("refreshes discovered models without replacing a valid selection and retains last good data on failure", async () => {
+    let models: unknown = [{ value: "claude-fable-5", displayName: "Claude Fable 5" }];
+    let requests = 0;
+    const source = createClaudeModelCatalogSource({ discover: async () => {
+      requests++;
+      if (models instanceof Error) throw models;
+      return models;
+    } });
+    const service = catalogService({ codingModelCatalogSource: source, invalidateCodingModelCatalog: source.invalidate });
+    const first = await service.getCatalog(principal);
+    models = [{ value: "claude-fable-5", displayName: "Claude Fable 5" },
+      { value: "claude-fable-5-1", displayName: "Claude Fable 5.1" }];
+    expect((await service.getCatalog(principal)).revision).toBe(first.revision);
+    expect(requests).toBe(1);
+    const refreshed = await service.refresh(principal);
+    expect(refreshed.revision).not.toBe(first.revision);
+    expect(validateChatProviderSelection({ catalog: refreshed, selection: {
+      instanceId: "claude_code_default", model: "claude-fable-5",
+    } })).toMatchObject({ ok: true, selection: { model: "claude-fable-5" } });
+    models = new Error("secret upstream failure");
+    expect((await service.refresh(principal)).revision).toBe(refreshed.revision);
+  });
+
+  it("coalesces concurrent discovery and bounds a hung inventory read before falling back", async () => {
+    vi.useFakeTimers();
+    let requests = 0;
+    const signals: AbortSignal[] = [];
+    const source = createClaudeModelCatalogSource({ timeoutMs: 50, discover: async (signal) => {
+      requests++;
+      signals.push(signal);
+      return new Promise(() => {});
+    } });
+    const service = catalogService({ codingModelCatalogSource: source });
+    const first = service.getCatalog(principal);
+    const second = service.getCatalog(principal);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(requests).toBe(1);
+    const results = await Promise.all([first, second]);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(results[0].instances.find((entry) => entry.id === "claude_code_default")?.models.map((entry) => entry.id))
+      .toEqual(["default", "opus", "sonnet"]);
+  });
+
+  it("never reuses an inventory across owners or changed credential contexts", async () => {
+    let context = "credential_generation_one";
+    const source = createClaudeModelCatalogSource({
+      discover: async () => [{ value: "claude-fable-5", displayName: "Fable" }],
+      resolveContext: async () => ({ key: context, discover: async () => {
+        if (context !== "credential_generation_one") throw new Error("private account detail");
+        return [{ value: "claude-fable-5", displayName: "Fable" }];
+      } }),
+    });
+    const service = catalogService({ codingModelCatalogSource: source });
+    expect((await service.getCatalog(principal)).instances.find((entry) => entry.id === "claude_code_default")?.models
+      .some((entry) => entry.id === "claude-fable-5")).toBe(true);
+    context = "credential_generation_two";
+    for (const ownerId of [principal.userId, "another_owner"]) {
+      const catalog = await service.getCatalog({ ...principal, userId: ownerId });
+      expect(catalog.instances.find((entry) => entry.id === "claude_code_default")?.models.map((entry) => entry.id))
+        .toEqual(["default", "opus", "sonnet"]);
+    }
+  });
+
+  it("fails closed on explicit profile refresh when credential generation cannot be verified", async () => {
+    let available = true;
+    const source = createClaudeModelCatalogSource({ resolveContext: async () => ({
+      key: "owner_profile", retainOnRefresh: false, maxAgeMs: 5_000,
+      discover: async () => {
+        if (!available) throw new Error("private upstream detail");
+        return [{ value: "claude-fable-5", displayName: "Fable" }];
+      },
+    }) });
+    const service = catalogService({ codingModelCatalogSource: source, invalidateCodingModelCatalog: source.invalidate });
+    await service.getCatalog(principal);
+    available = false;
+    expect((await service.refresh(principal)).instances.find((entry) => entry.id === "claude_code_default")?.models
+      .map((entry) => entry.id)).toEqual(["default", "opus", "sonnet"]);
+  });
+
+  it("persists an admitted Fable selection and passes it unchanged on the resumed native session", async () => {
+    const database = await KyselyPGlite.create();
+    const repository = new ChatRepository(database.dialect);
+    const owner = { type: "personal" as const, ownerId: principal.userId };
+    const launches: string[][] = [];
+    const adapter = createClaudeChatProviderAdapter({
+      homePath: "/runtime-home", resolveCredentialEnv: async () => ({}),
+      spawnFn: (_command, args) => {
+        launches.push([...args]);
+        const child = Object.assign(new EventEmitter(), {
+          stdout: new EventEmitter(), stderr: new EventEmitter(),
+          kill(signal: NodeJS.Signals) { this.emit("exit", null, signal); },
+        });
+        queueMicrotask(() => {
+          child.stdout.emit("data", Buffer.from([
+            JSON.stringify({ type: "system", subtype: "init", session_id: "session_catalog", model: "claude-fable-5" }),
+            JSON.stringify({ type: "result", subtype: "success", is_error: false, result: "Done" }), "",
+          ].join("\n")));
+          child.emit("exit", 0, null);
+        });
+        return child;
+      },
+    });
+    const source = createClaudeModelCatalogSource({ discover: async () => [
+      { value: "claude-fable-5[1m]", resolvedModel: "claude-fable-5", displayName: "Fable" },
+    ] });
+    const orchestrator = new CanonicalChatOrchestrator({ repository,
+      catalog: catalogService({ codingModelCatalogSource: source }),
+      adapters: new CanonicalChatProviderRegistry([adapter]),
+    });
+    try {
+      await repository.bootstrap();
+      await repository.create(owner, { id: "chat_catalog", clientRequestId: "req_create_catalog", title: "Catalog" });
+      for (let turn = 0; turn < 2; turn++) {
+        const chat = await repository.get(owner, "chat_catalog");
+        const selection = chat?.chat.currentSelection ?? { instanceId: "claude_code_default", model: "claude-fable-5" };
+        const admitted = await orchestrator.admitTurn(principal, owner, "chat_catalog", {
+          clientRequestId: `req_catalog_turn_${turn}`, baseRevision: chat!.chat.revision,
+          parts: [{ type: "text", text: "Read only" }], selection,
+          interactionMode: "default", permissionMode: "supervised",
+        });
+        expect(admitted.admission).toBe("accepted");
+        await orchestrator.drain();
+        expect((await repository.get(owner, "chat_catalog"))?.chat.currentSelection)
+          .toMatchObject({ instanceId: "claude_code_default", model: "claude-fable-5" });
+      }
+      expect(launches).toHaveLength(2);
+      for (const args of launches) expect(args[args.indexOf("--model") + 1]).toBe("claude-fable-5");
+      expect(launches[1]![launches[1]!.indexOf("--resume") + 1]).toBe("session_catalog");
+    } finally {
+      await orchestrator.drain();
+      await repository.kysely.destroy();
+    }
+  });
+
+  it.each([
+    { label: "empty", inventory: [] },
+    { label: "oversized", inventory: Array.from({ length: 65 }, (_, index) => ({ value: `model-${index}`, displayName: "Model" })) },
+    { label: "unsafe", inventory: [{ value: "claude-fable-5", displayName: "private\nraw output" }] },
+  ])("falls back safely for $label runtime metadata", async ({ inventory }) => {
+    const source = createClaudeModelCatalogSource({ discover: async () => inventory });
+    const result = await catalogService({ codingModelCatalogSource: source }).getCatalog(principal);
+    expect(result.instances.find((entry) => entry.id === "claude_code_default")?.models.map((entry) => entry.id))
+      .toEqual(["default", "opus", "sonnet"]);
+  });
+
+  it("expires last-good data and deduplicates metadata without leaking stale account models", async () => {
+    vi.useFakeTimers();
+    let fail = false;
+    const source = createClaudeModelCatalogSource({ cacheTtlMs: 10, discover: async () => {
+      if (fail) throw new Error("private failure");
+      return [{ value: "claude-fable-5", displayName: "Fable" }, { value: "claude-fable-5", displayName: "Fable duplicate" }];
+    } });
+    const service = catalogService({ codingModelCatalogSource: source });
+    const first = await service.getCatalog(principal);
+    expect(first.instances.find((entry) => entry.id === "claude_code_default")?.models
+      .filter((entry) => entry.id === "claude-fable-5")).toHaveLength(1);
+    fail = true;
+    await vi.advanceTimersByTimeAsync(300_001);
+    expect((await service.getCatalog(principal)).instances.find((entry) => entry.id === "claude_code_default")?.models
+      .map((entry) => entry.id)).toEqual(["default", "opus", "sonnet"]);
+  });
+
+  it("keeps the complete projected inventory within the public catalog limit", async () => {
+    const source = createClaudeModelCatalogSource({ discover: async () => Array.from({ length: 64 }, (_, index) => ({
+      value: `claude-model-${index}`, displayName: `Model ${index}`,
+    })) });
+    const catalog = await catalogService({ codingModelCatalogSource: source }).getCatalog(principal);
+    expect(catalog.instances.find((entry) => entry.id === "claude_code_default")?.models).toHaveLength(64);
+  });
+
+  it("evicts old owner inventories instead of retaining an unbounded model cache", async () => {
+    let requests = 0;
+    const source = createClaudeModelCatalogSource({ discover: async () => [{
+      value: `claude-model-${++requests}`, displayName: "Model",
+    }] });
+    const service = catalogService({ codingModelCatalogSource: source });
+    for (let owner = 0; owner < 33; owner++) await service.getCatalog({ ...principal, userId: `owner_${owner}` });
+    const reloaded = await service.getCatalog({ ...principal, userId: "owner_0" });
+    expect(reloaded.instances.find((entry) => entry.id === "claude_code_default")?.models
+      .some((entry) => entry.id === "claude-model-34")).toBe(true);
+  });
+
+  it("does not resurrect a profile inventory invalidated while discovery was in flight", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let reads = 0;
+    const source = createClaudeModelCatalogSource({ resolveContext: async () => ({
+      key: "profile", retainOnRefresh: false, discover: async () => {
+        if (++reads > 1) throw new Error("metadata unavailable");
+        await gate;
+        return [{ value: "claude-fable-5", displayName: "Fable" }];
+      },
+    }) });
+    const service = catalogService({ codingModelCatalogSource: source, invalidateCodingModelCatalog: source.invalidate });
+    const first = service.getCatalog(principal);
+    await vi.waitFor(() => expect(reads).toBe(1));
+    const refreshed = service.refresh(principal);
+    release();
+    await first;
+    expect((await refreshed).instances.find((entry) => entry.id === "claude_code_default")?.models
+      .map((entry) => entry.id)).toEqual(["default", "opus", "sonnet"]);
+  });
+});

--- a/tests/gateway/chat-claude-sdk-catalog.test.ts
+++ b/tests/gateway/chat-claude-sdk-catalog.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { readClaudeModelInventory } from "../../packages/kernel/src/claude-model-inventory.js";
+import { createClaudeModelCatalogSource } from "../../packages/gateway/src/chat/claude-model-catalog.js";
+import { createRuntimeClaudeModelCatalogSource } from "../../packages/gateway/src/chat/claude-runtime-model-catalog.js";
+import { fileURLToPath } from "node:url";
+
+describe("Claude SDK catalog metadata boundary", () => {
+  it.each(["stdout", "stderr"])("rejects oversized native %s during metadata initialization", async (output) => {
+    const controller = new AbortController();
+    try {
+      await expect(readClaudeModelInventory({
+        executable: fileURLToPath(new URL("../fixtures/claude-model-inventory.mjs", import.meta.url)),
+        cwd: process.cwd(), env: { PATH: process.env.PATH, MATRIX_TEST_INVENTORY_OVERSIZE: output },
+        signal: AbortSignal.any([controller.signal, AbortSignal.timeout(2_000)]),
+      })).rejects.toThrow("Claude inventory output limit exceeded");
+    } finally { controller.abort(); }
+  });
+
+  it("reads supportedModels without submitting user input and closes the metadata session", async () => {
+    let closed = false;
+    let userMessages = 0;
+    let consumption: Promise<void> | undefined;
+    const source = createClaudeModelCatalogSource({ discover: (signal) => readClaudeModelInventory({
+      executable: "claude", cwd: "/runtime-home", env: { HOME: "/runtime-home" }, signal,
+      queryFn: (input) => {
+        expect(input.options).toMatchObject({
+          pathToClaudeCodeExecutable: "claude", cwd: "/runtime-home", persistSession: false,
+          tools: [], settingSources: [], strictMcpConfig: true, mcpServers: {},
+          settings: { disableAllHooks: true }, permissionMode: "default",
+        });
+        if (typeof input.prompt === "string") throw new Error("Metadata must not send a prompt");
+        consumption = (async () => { for await (const _message of input.prompt) userMessages++; })();
+        return {
+          supportedModels: async () => [{ value: "claude-fable-5", displayName: "Fable", description: "" }],
+          close: () => { closed = true; },
+        };
+      },
+    }) });
+    const catalog = await source({ id: "claude", kind: "claude", availability: "available" } as never,
+      { userId: "owner_sdk_catalog", source: "jwt" });
+    await consumption;
+    expect(catalog?.models.map((model) => model.id)).toContain("claude-fable-5");
+    expect(userMessages).toBe(0);
+    expect(closed).toBe(true);
+  });
+
+  it("uses canonical Chat's launch scope and changes inventory when its API credential changes", async () => {
+    let key = "synthetic-key-one";
+    const source = createRuntimeClaudeModelCatalogSource({
+      homePath: "/runtime-home",
+      resolveCredentialLaunch: async () => ({ env: { HOME: "/wrong-home", ANTHROPIC_API_KEY: key } }),
+      readInventory: async (input) => {
+        expect(input.executable).toBe("claude");
+        expect(input.cwd).toBe("/runtime-home");
+        expect(input.env.HOME).toBe("/runtime-home");
+        expect(input.env.ANTHROPIC_API_KEY).toBe(key);
+        return [{ value: key === "synthetic-key-one" ? "claude-fable-5" : "claude-fable-5-1", displayName: "Fable" }];
+      },
+    });
+    const provider = { id: "claude", kind: "claude", availability: "available" } as never;
+    const principal = { userId: "owner_sdk_catalog", source: "jwt" as const };
+    expect((await source(provider, principal))?.models.map((model) => model.id)).toContain("claude-fable-5");
+    key = "synthetic-key-two";
+    expect((await source(provider, principal))?.models.map((model) => model.id)).toContain("claude-fable-5-1");
+  });
+
+  it("closes an unresponsive SDK metadata session when its catalog deadline expires", async () => {
+    vi.useFakeTimers();
+    let closed = false;
+    try {
+      const source = createClaudeModelCatalogSource({ timeoutMs: 10, discover: (signal) => readClaudeModelInventory({
+        executable: "claude", cwd: "/runtime-home", env: {}, signal,
+        queryFn: () => ({ supportedModels: () => new Promise(() => {}), close: () => { closed = true; } }),
+      }) });
+      const result = source({ id: "claude", kind: "claude", availability: "available" } as never,
+        { userId: "owner_sdk_catalog", source: "jwt" });
+      await vi.advanceTimersByTimeAsync(20);
+      await expect(result).resolves.toBeNull();
+      expect(closed).toBe(true);
+    } finally { vi.useRealTimers(); }
+  });
+
+  it("uses the real SDK initialization protocol without inheriting removed service credentials", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "synthetic-ambient-key");
+    try {
+      const source = createClaudeModelCatalogSource({ discover: (signal) => readClaudeModelInventory({
+        executable: fileURLToPath(new URL("../fixtures/claude-model-inventory.mjs", import.meta.url)),
+        cwd: process.cwd(), env: { PATH: process.env.PATH }, signal,
+      }) });
+      const catalog = await source({ id: "claude", kind: "claude", availability: "available" } as never,
+        { userId: "owner_sdk_protocol", source: "jwt" });
+      expect(catalog?.models.map((model) => model.id)).toContain("claude-fable-5");
+      expect(catalog?.models.map((model) => model.id)).not.toContain("unexpected-ambient-credential");
+    } finally { vi.unstubAllEnvs(); }
+  });
+});

--- a/tests/gateway/chat-runtime-catalog-wiring.test.ts
+++ b/tests/gateway/chat-runtime-catalog-wiring.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { createChatProviderCatalogService } from "../../packages/gateway/src/chat/provider-catalog.js";
+
+const mocks = vi.hoisted(() => ({
+  claude: Object.assign(vi.fn(), { invalidate: vi.fn() }),
+  codex: vi.fn(), native: vi.fn(), credentials: vi.fn(), skills: vi.fn(),
+  createClaude: vi.fn(), createCodex: vi.fn(), createNative: vi.fn(),
+  catalog: vi.fn(),
+}));
+vi.mock("../../packages/gateway/src/chat/claude-runtime-model-catalog.js", () => ({
+  createRuntimeClaudeModelCatalogSource: mocks.createClaude,
+}));
+vi.mock("../../packages/gateway/src/chat/codex-model-catalog.js", () => ({
+  createCodexModelCatalogSource: mocks.createCodex,
+}));
+vi.mock("../../packages/gateway/src/chat/native-coding-model-catalog.js", () => ({
+  createNativeCodingModelCatalogSource: mocks.createNative,
+}));
+vi.mock("../../packages/gateway/src/chat/provider-catalog.js", () => ({
+  createChatProviderCatalogService: mocks.catalog,
+}));
+vi.mock("../../packages/gateway/src/kernel-credentials.js", () => ({
+  buildKernelCredentialLaunch: mocks.credentials,
+}));
+vi.mock("@matrix-os/kernel", () => ({ loadSkills: mocks.skills }));
+
+import { createGatewayChatProviderCatalog } from "../../packages/gateway/src/chat/runtime-provider-catalog.js";
+
+type CatalogOptions = Parameters<typeof createChatProviderCatalogService>[0];
+const principal = { userId: "owner_catalog_wiring", source: "jwt" as const };
+const provider = { id: "claude", kind: "claude", availability: "available" } as never;
+const projection = { models: [], options: [], defaultModel: "synthetic-model" };
+const dependencies = {
+  codingProviders: { listProviders: vi.fn(), invalidate: vi.fn() },
+  agentRuntimeSource: {} as CatalogOptions["agentRuntimeSource"],
+  executableDriverKinds: ["codex", "claude_code"] as const,
+};
+
+function compose(codexExecutable?: string) {
+  const result = createGatewayChatProviderCatalog({
+    ...dependencies, homePath: "/runtime-home", codexExecutable,
+  });
+  const options = mocks.catalog.mock.calls[0][0] as CatalogOptions;
+  return { ...result, options, source: options.codingModelCatalogSource! };
+}
+
+describe("gateway Chat runtime catalog composition", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.createClaude.mockReturnValue(mocks.claude);
+    mocks.createCodex.mockReturnValue(mocks.codex);
+    mocks.createNative.mockReturnValue(mocks.native);
+    mocks.claude.mockResolvedValue(null);
+    mocks.codex.mockResolvedValue(null);
+    mocks.native.mockResolvedValue(null);
+  });
+
+  it("shares the execution credential factory with metadata discovery and preserves service dependencies", async () => {
+    const { resolveClaudeCredentialLaunch, options } = compose("/runtime/codex");
+    expect(mocks.createClaude).toHaveBeenCalledWith({ homePath: "/runtime-home", resolveCredentialLaunch: resolveClaudeCredentialLaunch });
+    await resolveClaudeCredentialLaunch();
+    expect(mocks.credentials).toHaveBeenCalledWith("/runtime-home", process.env, undefined, undefined);
+    expect(options).toMatchObject(dependencies);
+    options.skillsSource?.();
+    expect(mocks.skills).toHaveBeenCalledWith("/runtime-home");
+    expect(mocks.createCodex).toHaveBeenCalledWith({ executable: "/runtime/codex", cwd: "/runtime-home" });
+    expect(mocks.createNative).toHaveBeenCalledWith({ homePath: "/runtime-home" });
+  });
+
+  it("returns owner-scoped Claude metadata without querying fallback sources", async () => {
+    mocks.claude.mockResolvedValue(projection);
+    const { source } = compose("/runtime/codex");
+    await expect(source(provider, principal)).resolves.toBe(projection);
+    expect(mocks.claude).toHaveBeenCalledWith(provider, principal);
+    expect(mocks.codex).not.toHaveBeenCalled();
+    expect(mocks.native).not.toHaveBeenCalled();
+  });
+
+  it("retains Codex priority over native metadata", async () => {
+    mocks.codex.mockResolvedValue(projection);
+    const { source } = compose("/runtime/codex");
+    await expect(source(provider, principal)).resolves.toBe(projection);
+    expect(mocks.codex).toHaveBeenCalledWith(provider);
+    expect(mocks.native).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, "/runtime/codex"])("uses the native fallback with executable %s", async (executable) => {
+    mocks.native.mockResolvedValue(projection);
+    const { source } = compose(executable);
+    await expect(source(provider, principal)).resolves.toBe(projection);
+    expect(mocks.native).toHaveBeenCalledWith(provider);
+    expect(mocks.createCodex).toHaveBeenCalledTimes(executable ? 1 : 0);
+  });
+
+  it("forwards owner-scoped refresh invalidation", () => {
+    const { options } = compose();
+    options.invalidateCodingModelCatalog?.(principal);
+    expect(mocks.claude.invalidate).toHaveBeenCalledWith(principal);
+  });
+});


### PR DESCRIPTION
## Summary

- Stack 1/2 for OM-234; #1609 is the runtime recovery/streaming layer. This independent slice owns model discovery and its focused runtime composition.
- Discover Claude model metadata using the same runtime executable, owner credential context and execution home as Chat, without submitting a generation prompt.
- Bound metadata reads, output and model counts; cache by owner/context, coalesce requests, fence invalidated in-flight reads and retain validated fallback choices.
- Preserve the exact selected model through catalog refresh and native resumed-session handoff. Metadata is not proof of account entitlement.

## Tests

- Parent-only catalog composition, discovery/error classification, SDK-boundary, Electron model-picker and provider-catalog suites: 87 tests across 6 files pass via `bun run test`. Nine new failure-classification regressions failed before the fix and now pass; the earlier six composition checks were also added before extraction.
- Operational discovery outages, invalid metadata and deadlines log bounded categories and retain the validated fallback policy. Programming exceptions and non-Error throws propagate to the existing safe orchestration boundary without being negatively cached; no raw native message, credential or error object is logged by discovery.
- Previous combined stack: 155 focused tests across 17 files passed before this mechanical extraction. Final-stack validation is recorded in #1609; complete CI must validate the new head.
- Complete Linux CI and fresh Greptile 5/5 are required before landing this head. Live Claude generation is excluded by the owner; SDK tests use controlled metadata fixtures.
- The combined broad macOS run has documented unrelated platform/fixture failures in #1609 and is not reported as green.

## Surface matrix and visual scope

| Surface | Catalog path and behavior | Validation boundary |
| --- | --- | --- |
| Web Canvas | Existing ChatApp provider state consumes `/api/chat-providers`; server inventory is shared. | No Web Canvas renderer, layout or copy changes. |
| Web Desktop | Same ChatApp provider state and gateway catalog as Web Canvas. | No Web Desktop renderer, layout or copy changes. |
| Electron Desktop | Existing ProviderModelPicker consumes the canonical catalog, preserves the selected model and exposes refreshed choices. | Current parent-only picker regression plus catalog-to-native-handoff tests pass. |
| Web Mobile | Existing ChatApp mobile presentation consumes the same catalog. | No Web Mobile renderer, layout or copy changes. |
| Native Mobile | `use-chat-provider-catalog` calls the same canonical `/api/chat-providers` request. | No Native Mobile implementation or device-runtime changes. |

This is a backend metadata/data-flow slice, not a visual redesign: there are no changes under `shell/`, `desktop/src/`, `apps/mobile/` or `packages/ui/`. The only changed `.tsx` file is a regression test of the existing picker. No new styling, layout, frontend copy, app surface, or screenshot is introduced. Therefore no changed visual implementation is claimed; the exact inventory/selection behavior is covered by controlled current-head tests. Live Claude-specific Preview acceptance is explicitly excluded by the owner, so this PR does not substitute an unrelated screenshot or claim live Fable entitlement.

## Entrypoint extraction boundary

This review fix mechanically removes model-source construction, ordered fallback routing, refresh invalidation and the shared credential-launch factory from `server.ts` into the 42-line `chat/runtime-provider-catalog.ts`. The gateway entrypoint now only passes existing dependencies and gives the returned credential factory to the Claude execution adapter. The extraction is in this lower catalog layer, before #1609's execution behavior; it changes no cache, credential, authorization or fallback semantics.

`server.ts` remains an oversized composition root (4,790 lines), but this change reduces it rather than adding discovery behavior there. Other route families and lifecycle orchestration are deliberately not moved in this PR. Future behavior in those areas must first extract its own domain composition with characterization tests; wholesale server decomposition is not part of this recovery fix. `provider-catalog.ts` remains a single 1,000-line projection/service module; native discovery, runtime credential context and process ownership live in their focused modules, not that projection.

## Invariants

### Source of truth

Native SDK metadata supplies the runtime model inventory. Existing owner Postgres remains canonical for admitted selections and Chat state. Discovery does not establish generation entitlement or restore allowance.

### Lock/transaction scope

Discovery runs outside database transactions. Bounded owner/context-keyed pending reads are coalesced; explicit invalidation fences stale in-flight responses. Existing admission transactions and exact model selection validation are unchanged.

### Acceptable orphan states

Cache and pending maps are capped at 32 contexts, with bounded stale retention. Failed, empty or unsafe discovery returns only validated fallback choices. Cancellation closes the metadata session; no user prompt is sent.

### Auth source of truth

Existing verified principals and provider credential launch resolution remain authoritative. Context digests are internal cache keys, never public diagnostics. No new endpoint, permission bypass, credential-store inspection or account switching.

### Deferred scope

Startup retries, execution cleanup and quota-error classification are in #1609. External allowance restoration, live Claude acceptance and Fable 5.1 entitlement are not claimed. The owner paused the separate site documentation PR: https://github.com/FinnaAI/matrix-os-site/pull/98.

## Review/Monitoring

Land with Graphite, one reviewed layer at a time, only after current-head Greptile 5/5, resolved review threads and green complete CI. Do not merge #1609 into this branch; wait for its base to become main after this layer lands.
