### PR TITLE
test(chat): update Codex startup terminal fixture

### DIFF
--- a/tests/helpers/codex-startup-stream-harness.ts
+++ b/tests/helpers/codex-startup-stream-harness.ts
@@ -25,6 +25,10 @@ export async function createCodexStartupStreamHarness() {
   const principal = { userId: owner.ownerId, source: "jwt" as const };
   const chatId = "chat_startup";
   const selection = { instanceId: "codex_startup", model: "default", options: [] };
+  const terminalRef = {
+    workspaceId: "tws_00000000000000000000000000000001",
+    tabId: "tt_00000000000000000000000000000001",
+  } as const;
   const fixture = createCanonicalProviderCatalogFixture();
   const catalog = CanonicalProviderCatalogSchema.parse({ ...fixture,
     drivers: [{ ...fixture.drivers[0], kind: "codex", displayName: "Codex" }],
@@ -41,6 +45,7 @@ export async function createCodexStartupStreamHarness() {
     id, kind: "agent" as const, agent: "codex" as const, ownerId: owner.ownerId,
     runtime: { type: "zellij" as const, status: "running" as const, zellijSession: id,
       createdAt: new Date().toISOString() },
+    terminalRef,
     terminalSessionId: id, transcriptPath: codexProviderEventPath(homePath, id),
     attachedClients: 0, writeMode: "owner" as const,
     startedAt: new Date().toISOString(), lastActivityAt: new Date().toISOString(),

--- a/tests/helpers/codex-startup-stream-harness.ts
+++ b/tests/helpers/codex-startup-stream-harness.ts
@@ -29,6 +29,7 @@ export async function createCodexStartupStreamHarness() {
     workspaceId: "tws_00000000000000000000000000000001",
     tabId: "tt_00000000000000000000000000000001",
   } as const;
+  const terminalSessionId = `${terminalRef.workspaceId}:${terminalRef.tabId}`;
   const fixture = createCanonicalProviderCatalogFixture();
   const catalog = CanonicalProviderCatalogSchema.parse({ ...fixture,
     drivers: [{ ...fixture.drivers[0], kind: "codex", displayName: "Codex" }],
@@ -46,7 +47,7 @@ export async function createCodexStartupStreamHarness() {
     runtime: { type: "zellij" as const, status: "running" as const, zellijSession: id,
       createdAt: new Date().toISOString() },
     terminalRef,
-    terminalSessionId: id, transcriptPath: codexProviderEventPath(homePath, id),
+    terminalSessionId, transcriptPath: codexProviderEventPath(homePath, id),
     attachedClients: 0, writeMode: "owner" as const,
     startedAt: new Date().toISOString(), lastActivityAt: new Date().toISOString(),
   });


### PR DESCRIPTION
## Summary

- update the shared Codex startup-stream harness to return the structured `terminalRef` required by the project-scoped terminal runtime
- restore the gateway and Electron transcript regression tests that exercise pre-prompt reconnect behavior
- keep production behavior unchanged; the production session manager already creates this binding

## Validation

- `pnpm install --frozen-lockfile`
- focused startup regressions: 6/6 passes across three repeated runs
- serial post-suite retry: `tests/desktop/codex-startup-transcript.test.tsx` passes
- terminal runtime: 43/43 passes, including the real 23-tab shared-Zellij integration test
- TypeScript checks for kernel, observability, integrations MCP, gateway, platform, proxy, edge router, and desktop
- `pnpm run check:patterns` (0 violations)
- `git diff --check`

`bun` is unavailable in this checkout, so the repository's underlying pnpm/tsc commands were run directly. The repository-wide Vitest run completed 14,545 tests successfully and reported 10 failures across five files after 61 minutes plus two worker crashes. Six load-related failures passed serially. Two unrelated current-`main` files still fail in isolation: `tests/desktop/chat-claude-steer-transcript.test.tsx` (streamed final punctuation truncation) and `tests/plugins/matrix-marketplace.test.ts` (stale `--session`/authentication contract expectations). The changed Codex startup test passes in isolation.

No React source file changed, so React Doctor and screenshot evidence do not apply.

## Invariants

- **Source of truth:** The production `AgentSession` structured `terminalRef` contract remains canonical; this test fixture now mirrors it.
- **Lock/transaction scope:** Unchanged; this patch performs no database or runtime writes.
- **Acceptable orphan states:** Unchanged; no production lifecycle behavior is modified.
- **Auth source of truth:** Unchanged; the harness continues to use the existing owner JWT principal fixture.
- **Deferred scope:** No legacy terminal-ID fallback is added to production. The two independently reproducible current-`main` test drifts listed above are outside this PR.
