### PR TITLE
fix(desktop): compare native host release provenance

### DIFF
--- a/docs/dev/desktop-release.md
+++ b/docs/dev/desktop-release.md
@@ -108,13 +108,25 @@ workflow's package-version stamping is exempt; dirty local builds report unknown
 provenance. This metadata is exposed through the bounded `app:get-version`
 IPC response; installed apps do not need Git or GitHub access to compare releases.
 
-The update reminder compares that source with the running gateway's
-`/api/system/info.build.sha`, which is already present in older host bundles.
+The update reminder first compares that source with the running gateway's
+`/api/system/info.build.sha`. Native host bundles may return `"unknown"` for
+this legacy image-environment field. In that case the shared contract reads
+`release.gitCommit` only from a schema-1 host bundle whose `release.version`,
+`version`, and explicit `runningVersion` all match. Missing running versions or
+an installation awaiting gateway restart cannot establish source identity.
+`installedVersion` is template/package metadata and is not used for this check.
 Different commits trigger an advisory reminder even when both releases advertise
 the same legacy protocol number. An ancestor identifies missing cloud changes;
 different branches or history beyond the bounded window remain different without
 inventing an ordering. Matching source proves release alignment, not that every
 configuration, external provider, or feature is operational.
+
+Regression coverage includes the captured public provenance fields from a native
+host response, the actual `getSystemInfo` producer without image build variables,
+and built-Electron replay through the preload IPC and update dialog. The producer
+test also replaces release metadata before simulating gateway restart, after its
+file cache expires. Verify against a real authenticated VPS before release; an
+idealized fixture with a populated `build.sha` cannot prove host compatibility.
 
 Checks run at startup, computer switches, and reconnect. Focus checks have a
 15-minute cooldown, and there is no periodic alignment poll. Network failures and

--- a/packages/contracts/src/release-alignment.ts
+++ b/packages/contracts/src/release-alignment.ts
@@ -11,15 +11,32 @@ export type BuildSource = z.infer<typeof BuildSourceSchema>;
 export type ReleaseAlignmentStatus =
   | "aligned" | "runtime-update-required" | "different-releases" | "unavailable";
 
+const Version = z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/);
 const RunningBuild = z.object({
-  version: z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/),
+  version: Version,
   build: z.object({ sha: Commit }),
 });
+const RunningHostRelease = z.object({
+  version: Version,
+  runningVersion: Version,
+  release: z.object({
+    schemaVersion: z.literal(1),
+    kind: z.literal("matrix-os-host-bundle"),
+    version: Version,
+    gitCommit: Commit,
+  }),
+}).refine(({ version, runningVersion, release }) =>
+  version === runningVersion && release.version === runningVersion);
 
-/** Uses the running gateway's process build identity, including older releases. */
+/** Image builds expose an env SHA; native host bundles expose release.json. */
 export function readRunningCommit(info: unknown): string | null {
   const parsed = RunningBuild.safeParse(info);
-  return parsed.success ? parsed.data.build.sha : null;
+  if (parsed.success) return parsed.data.build.sha;
+  // release.json may already describe the next installation. Its immutable
+  // version must match the process-start version before using its commit.
+  // installedVersion is template/package metadata, not process provenance.
+  const host = RunningHostRelease.safeParse(info);
+  return host.success ? host.data.release.gitCommit : null;
 }
 
 /** Release alignment is source identity, not a claim about every runtime feature. */

--- a/specs/094-electron-macos-shell/contracts/ipc-contract.md
+++ b/specs/094-electron-macos-shell/contracts/ipc-contract.md
@@ -43,7 +43,11 @@ logged (FR-081). The preload exposes exactly this surface via `contextBridge` as
   [-16384, 16384]; arrays capped.
 - `app:get-version.source` is captured from the checkout during the Electron build,
   not read from a user's Git repository at runtime. The renderer compares it with
-  the running gateway's `/api/system/info.build.sha`. Equal sources are aligned;
+  the running gateway's `/api/system/info.build.sha`. Native host bundles without
+  a valid image SHA use `release.gitCommit` only when schema/kind are recognized
+  and `release.version`, `version`, and explicit `runningVersion` all agree.
+  Package/template `installedVersion` does not identify the running process.
+  Equal sources are aligned;
   a cloud source in Desktop's ancestry is behind; other differing sources remain
   different without guessing their order. Missing or invalid provenance is unknown.
   The legacy protocol window is not evidence that two releases contain the same changes.

--- a/tests/contracts/release-alignment.test.ts
+++ b/tests/contracts/release-alignment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { evaluateReleaseAlignment, evaluateDesktopReleaseState, BuildSourceSchema } from "../../packages/contracts/src/release-alignment";
+import hostInfo from "../fixtures/host-release-system-info.json";
 
 const oldCommit = "a".repeat(40);
 const newCommit = "b".repeat(40);
@@ -9,6 +10,29 @@ const info = (sha: string) => ({ version: "v2026.09.09-1199", build: { sha },
   runtimeCompatibility: { schemaVersion: 1, minDesktopProtocol: 1, maxDesktopProtocol: 1 } });
 
 describe("released source comparison", () => {
+  it("compares the captured VPS-native response with no image build environment", () => {
+    expect(evaluateDesktopReleaseState(hostInfo, {
+      commit: newCommit, ancestors: [hostInfo.release.gitCommit],
+    }).status).toBe("runtime-update-required");
+    expect(evaluateReleaseAlignment(hostInfo, {
+      commit: hostInfo.release.gitCommit, ancestors: [],
+    })).toBe("aligned");
+  });
+  it.each([
+    { runningVersion: undefined },
+    { runningVersion: "v2026.09.09-1199" },
+    { version: "v2026.09.10-1206" },
+    { release: { ...hostInfo.release, version: "v2026.09.10-1206" } },
+    { release: { ...hostInfo.release, gitCommit: "unknown" } },
+    { release: { ...hostInfo.release, kind: "container" } },
+    { release: { ...hostInfo.release, schemaVersion: 2 } },
+  ])("does not infer running provenance from an unverified installed bundle: %j", (override) => {
+    expect(evaluateReleaseAlignment({ ...hostInfo, ...override }, source)).toBe("unavailable");
+  });
+  it("prefers explicit running build identity over installed host metadata", () => {
+    expect(evaluateReleaseAlignment({ ...hostInfo, build: { sha: oldCommit },
+      release: { ...hostInfo.release, gitCommit: newCommit } }, source)).toBe("runtime-update-required");
+  });
   it("recognizes a shared source even when product versions and channels differ", () => {
     expect(evaluateReleaseAlignment(info(newCommit), source)).toBe("aligned");
   });

--- a/tests/desktop/release-alignment.test.tsx
+++ b/tests/desktop/release-alignment.test.tsx
@@ -6,6 +6,7 @@ import RuntimeCompatibilityGate from "@renderer/features/updates/RuntimeCompatib
 import { useConnection } from "@renderer/stores/connection";
 import { useUi } from "@renderer/stores/ui";
 import type { ApiClient } from "@renderer/lib/api";
+import hostInfo from "../fixtures/host-release-system-info.json";
 
 const desktopCommit = "5a33ceb47fcdd035c95d8dfedf0cd02a5209106b";
 const cloudCommit = "df546d9ee2f371ac3755550fcaed0bdd53897970";
@@ -29,6 +30,20 @@ beforeEach(() => {
 afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals(); });
 
 describe("released Desktop and cloud content alignment", () => {
+  it("opens the real gate for a VPS response whose build sha is unknown", async () => {
+    vi.stubGlobal("operator", { invoke: vi.fn(async (channel: string) => {
+      if (channel === "app:get-version") return { version: "0.1.0",
+        source: { commit: "b".repeat(40), ancestors: [hostInfo.release.gitCommit] } };
+      if (channel === "update:check") return { status: "up-to-date", channel: "canary" };
+      return { ok: true };
+    }) });
+    const api = { get: vi.fn(async (path: string) => path === "/api/system/update"
+      ? { channel: "dev", updateAvailable: true, latest: { version: "v2026.09.10-1209" } }
+      : hostInfo), forRuntime() { return this; } } as unknown as ApiClient;
+    useConnection.setState({ api });
+    render(<RuntimeCompatibilityGate><div>Workspace</div></RuntimeCompatibilityGate>);
+    expect(await screen.findByRole("dialog", { name: "Update Matrix OS" })).toBeTruthy();
+  });
   it("keeps explicit protocol recovery visible when local provenance is unavailable", async () => {
     vi.stubGlobal("operator", { invoke: vi.fn(async (channel: string) => {
       if (channel === "app:get-version") return { version: "0.1.0", source: null };

--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -6,11 +6,11 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { WebSocketServer, type WebSocket } from "ws";
 import { resolve } from "node:path";
 import { readBuildSource } from "../../../../scripts/release/build-source.mjs";
+import { createSystemInfoFixture } from "./system-info";
 import {
   AgentThreadSnapshotSchema,
   ProjectAgentWorkspaceSchema,
   RuntimeSummarySchema,
-  RUNNING_RUNTIME_COMPATIBILITY,
   type AgentThreadSnapshot,
   type ProjectAgentWorkspace,
   type RuntimeSummary,
@@ -24,6 +24,7 @@ export interface StubGateway {
   setProjectLifecycle(lifecycle: "active" | "archived" | "deleted"): void;
   setKernelResponseDelay(delayMs: number): void;
   setBuildCommit(commit: string): void;
+  setSystemInfo(info: Record<string, unknown>): void;
   disconnectKernel(): void;
   close(): Promise<void>;
   state: {
@@ -579,7 +580,7 @@ export function codingAgentSummary(): RuntimeSummary {
 }
 
 export async function startStubGateway(options: StubGatewayOptions = {}): Promise<StubGateway> {
-  let buildCommit = readBuildSource(resolve(__dirname, "../../../.."))?.commit ?? "unknown";
+  const systemInfo = createSystemInfoFixture(readBuildSource(resolve(__dirname, "../../../.."))?.commit ?? "unknown");
   const tasks = TASKS.map((task) => ({ ...task, tags: [...task.tags] }));
   const terminalTabs: Array<Record<string, unknown>> = [
     {
@@ -1265,14 +1266,7 @@ export async function startStubGateway(options: StubGatewayOptions = {}): Promis
       return;
     }
     if (path === "/api/system/info") {
-      json(res, 200, {
-        version: "stub",
-        build: { sha: buildCommit },
-        runtimeCompatibility: RUNNING_RUNTIME_COMPATIBILITY,
-        uptime: 1,
-        runtime: { handle: "neo", runtimeSlot: "primary" },
-        resources: { cpuCount: 8, memoryTotal: 8e9, memoryFree: 4e9, diskTotal: 1e11, diskFree: 5e10 },
-      });
+      json(res, 200, systemInfo.read());
       return;
     }
     json(res, 404, { error: "not found" });
@@ -1428,7 +1422,8 @@ export async function startStubGateway(options: StubGatewayOptions = {}): Promis
     url: `http://127.0.0.1:${port}`,
     port,
     state,
-    setBuildCommit: (commit) => { buildCommit = commit; },
+    setBuildCommit: systemInfo.setBuildCommit,
+    setSystemInfo: systemInfo.setSystemInfo,
     sendTerminalOutput: (data, session = "matrix-task-1") => activeTerminalOutputs[session]?.(data),
     setConversationBusy: (id, busy) => {
       if (busy) busyHermesConversations.add(id);

--- a/tests/e2e/desktop/fixtures/system-info.ts
+++ b/tests/e2e/desktop/fixtures/system-info.ts
@@ -1,0 +1,18 @@
+import { RUNNING_RUNTIME_COMPATIBILITY } from "@matrix-os/contracts";
+
+/** Serve provenance through HTTP so Electron's auth/CORS layer remains in use. */
+export function createSystemInfoFixture(commit: string) {
+  let info: Record<string, unknown> = {
+    version: "stub",
+    build: { sha: commit },
+    runtimeCompatibility: RUNNING_RUNTIME_COMPATIBILITY,
+    uptime: 1,
+    runtime: { handle: "neo", runtimeSlot: "primary" },
+    resources: { cpuCount: 8, memoryTotal: 8e9, memoryFree: 4e9, diskTotal: 1e11, diskFree: 5e10 },
+  };
+  return {
+    read: () => info,
+    setBuildCommit: (sha: string) => { info = { ...info, build: { sha } }; },
+    setSystemInfo: (value: Record<string, unknown>) => { info = structuredClone(value); },
+  };
+}

--- a/tests/e2e/desktop/release-alignment.e2e.test.ts
+++ b/tests/e2e/desktop/release-alignment.e2e.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { _electron, type ElectronApplication, type Page } from "playwright";
 import { startStubGateway, type StubGateway } from "./fixtures/stub-gateway";
 import { readBuildSource } from "../../../scripts/release/build-source.mjs";
@@ -39,12 +39,20 @@ suite("Desktop release alignment through the built IPC and gateway", () => {
     app = await _electron.launch({ executablePath: requireDesktop("electron") as string, args: [main],
       env: { ...process.env, OPERATOR_GATEWAY_URL: gateway.url, OPERATOR_USER_DATA_DIR: profile } });
     page = await app.firstWindow();
+    page.setDefaultTimeout(8_000);
     // Authentication is confined to the loopback fixture's fake device flow.
     const initialInfo = page.waitForResponse((value) => value.url().endsWith("/api/system/info"));
     await page.getByRole("button", { name: /continue in browser/i }).click();
     await (await initialInfo).finished();
     await page.getByRole("button", { name: "Chat", exact: true }).waitFor({ timeout: 15_000 });
   }, 60_000);
+
+  afterEach(async ({ task }) => {
+    if (task.result?.state === "fail" && page && !page.isClosed()) {
+      mkdirSync(evidence, { recursive: true });
+      await page.screenshot({ path: join(evidence, "failure.png") });
+    }
+  });
 
   afterAll(async () => {
     try {
@@ -87,27 +95,29 @@ suite("Desktop release alignment through the built IPC and gateway", () => {
   it("shows the host-bundle replay and preserves a draft after dismissal", async () => {
     const dialog = page.getByRole("dialog", { name: "Update Matrix OS" });
     await page.getByRole("button", { name: "Chat", exact: true }).dblclick();
+    await page.getByRole("button", { name: "New chat", exact: true }).click();
     const composer = page.getByRole("textbox", { name: "Start a chat" });
     await composer.fill("Unsent release alignment regression draft");
     let response = structuredClone(hostInfo);
-    await page.route("**/api/system/info", (route) => route.fulfill({ json: response }));
+    gateway.setSystemInfo(response);
     await recheck();
     await dialog.waitFor();
     await page.screenshot({ path: join(evidence, "host-bundle-mismatch.png") });
     await dialog.getByRole("button", { name: "Later", exact: true }).click();
-    await expect.poll(() => composer.inputValue()).toBe("Unsent release alignment regression draft");
+    await expect.poll(() => composer.textContent()).toBe("Unsent release alignment regression draft");
     await recheck();
     expect(await dialog.count()).toBe(0);
 
     // A different installed release is not proof that the running process changed.
     response = { ...hostInfo, version: "v2026.09.10-1209",
       release: { ...hostInfo.release, version: "v2026.09.10-1209", gitCommit: source.commit } };
+    gateway.setSystemInfo(response);
     await recheck();
     expect(await dialog.count()).toBe(0);
     response.runningVersion = response.version;
+    gateway.setSystemInfo(response);
     await recheck();
     expect(await dialog.count()).toBe(0);
     await composer.fill("");
-    await page.unroute("**/api/system/info");
   });
 });

--- a/tests/e2e/desktop/release-alignment.e2e.test.ts
+++ b/tests/e2e/desktop/release-alignment.e2e.test.ts
@@ -7,6 +7,7 @@ import { _electron, type ElectronApplication, type Page } from "playwright";
 import { startStubGateway, type StubGateway } from "./fixtures/stub-gateway";
 import { readBuildSource } from "../../../scripts/release/build-source.mjs";
 import { closeElectronApp } from "./fixtures/close-electron";
+import hostInfo from "../../fixtures/host-release-system-info.json";
 
 const root = resolve(__dirname, "../../..");
 const main = join(root, "desktop/out/main/index.js");
@@ -81,5 +82,32 @@ suite("Desktop release alignment through the built IPC and gateway", () => {
     gateway.setBuildCommit(source.commit);
     await recheck();
     expect(await page.getByRole("dialog", { name: "Update Matrix OS" }).count()).toBe(0);
+  });
+
+  it("shows the host-bundle replay and preserves a draft after dismissal", async () => {
+    const dialog = page.getByRole("dialog", { name: "Update Matrix OS" });
+    await page.getByRole("button", { name: "Chat", exact: true }).dblclick();
+    const composer = page.getByRole("textbox", { name: "Start a chat" });
+    await composer.fill("Unsent release alignment regression draft");
+    let response = structuredClone(hostInfo);
+    await page.route("**/api/system/info", (route) => route.fulfill({ json: response }));
+    await recheck();
+    await dialog.waitFor();
+    await page.screenshot({ path: join(evidence, "host-bundle-mismatch.png") });
+    await dialog.getByRole("button", { name: "Later", exact: true }).click();
+    await expect.poll(() => composer.inputValue()).toBe("Unsent release alignment regression draft");
+    await recheck();
+    expect(await dialog.count()).toBe(0);
+
+    // A different installed release is not proof that the running process changed.
+    response = { ...hostInfo, version: "v2026.09.10-1209",
+      release: { ...hostInfo.release, version: "v2026.09.10-1209", gitCommit: source.commit } };
+    await recheck();
+    expect(await dialog.count()).toBe(0);
+    response.runningVersion = response.version;
+    await recheck();
+    expect(await dialog.count()).toBe(0);
+    await composer.fill("");
+    await page.unroute("**/api/system/info");
   });
 });

--- a/tests/fixtures/host-release-system-info.json
+++ b/tests/fixtures/host-release-system-info.json
@@ -1,0 +1,14 @@
+{
+  "version": "v2026.09.10-1205",
+  "runningVersion": "v2026.09.10-1205",
+  "installedVersion": "0.4.0",
+  "build": { "sha": "unknown", "ref": "unknown", "date": "unknown" },
+  "runtimeCompatibility": { "schemaVersion": 1, "minDesktopProtocol": 1, "maxDesktopProtocol": 1 },
+  "release": {
+    "schemaVersion": 1,
+    "kind": "matrix-os-host-bundle",
+    "version": "v2026.09.10-1205",
+    "channel": "dev",
+    "gitCommit": "5a33ceb47fcdd035c95d8dfedf0cd02a5209106b"
+  }
+}

--- a/tests/gateway/host-release-alignment.test.ts
+++ b/tests/gateway/host-release-alignment.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { getSystemInfo } from "../../packages/gateway/src/system-info";
+import { evaluateDesktopReleaseState } from "../../packages/contracts/src/release-alignment";
+import hostInfo from "../fixtures/host-release-system-info.json";
+
+afterEach(() => { vi.unstubAllEnvs(); vi.restoreAllMocks(); });
+
+it("compares the real host system-info producer without container build variables", () => {
+  const home = mkdtempSync(join(tmpdir(), "host-alignment-"));
+  try {
+    mkdirSync(join(home, "system"));
+    const releasePath = join(home, "release.json");
+    vi.stubEnv("MATRIX_RELEASE_FILE", releasePath);
+    vi.stubEnv("MATRIX_BUILD_SHA", undefined);
+    vi.stubEnv("MATRIX_VERSION", undefined);
+    const writeRelease = (version: string, gitCommit: string) => writeFileSync(releasePath,
+      JSON.stringify({ ...hostInfo.release, version, gitCommit, gitRef: "main",
+        buildTime: "2026-09-10T00:00:00.000Z" }));
+    const desktop = { commit: "b".repeat(40), ancestors: [hostInfo.release.gitCommit] };
+    writeRelease(hostInfo.version, hostInfo.release.gitCommit);
+    const running = { runningVersion: hostInfo.runningVersion };
+    const before = getSystemInfo(home, running);
+    expect(before.build.sha).toBe("unknown");
+    expect(evaluateDesktopReleaseState(before, desktop).status).toBe("runtime-update-required");
+
+    // The installer can replace release.json while the old process still runs.
+    writeRelease("v2026.09.10-1209", desktop.commit);
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now + 60_000);
+    expect(evaluateDesktopReleaseState(getSystemInfo(home, running), desktop).status).toBe("unavailable");
+    expect(evaluateDesktopReleaseState(getSystemInfo(home, {
+      runningVersion: "v2026.09.10-1209",
+    }), desktop).status).toBe("aligned");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/tests/plugins/matrix-marketplace.test.ts
+++ b/tests/plugins/matrix-marketplace.test.ts
@@ -106,14 +106,14 @@ describe("Matrix OS Codex marketplace plugin", () => {
     expect(combined).toMatch(/claude --version/);
     expect(combined).toMatch(/claude auth status/);
     expect(readSkill("matrix-github-project")).toMatch(/gh auth status/);
-    expect(combined).toMatch(/auth-codex-<suffix>/);
-    expect(combined).toMatch(/auth-github-<suffix>/);
+    expect(combined).toMatch(/matrix run -it --project main -- codex login/);
+    expect(combined).toMatch(/matrix run -it --project main -- gh auth login/);
     expect(combined).toMatch(/browser\/device/i);
     expect(combined).toMatch(/Never (?:scan|read|upload)[^\n]*credential files/i);
     expect(combined).toMatch(/ask before installing/i);
   });
 
-  it("requires observable sessions, scopes tabs by transport, and sandboxes coding agents", () => {
+  it("requires observable project tabs, scopes hosted tools, and sandboxes coding agents", () => {
     const skill = readSkill("matrix-cloud-run");
     const hostedWorkflows = [
       readSkill("matrix-onboarding"),
@@ -128,16 +128,17 @@ describe("Matrix OS Codex marketplace plugin", () => {
     expect(skill).toMatch(/mkdir[^\n]*apps\/<slug>/);
     expect(skill).toMatch(/-C[^\n]*existing directory/i);
     for (const workflow of workflows) {
-      expect(workflow).toMatch(/matrix run -it --session/);
+      expect(workflow).toMatch(/matrix run -it --project/);
+      expect(workflow).not.toMatch(/matrix run[^\n]*--session/);
       expect(workflow).not.toMatch(/matrix run --json/);
-      expect(workflow).toMatch(/separate[^\n]*session/i);
-      expect(workflow).toMatch(/matrix shell connect/);
+      expect(workflow).toMatch(/(?:separate|another|new)[^\n]*tab/i);
+      expect(workflow).toContain("matrix shell connect --project <project> --tab <tab-id>");
     }
     for (const workflow of hostedWorkflows) {
       expect(workflow).toMatch(/create_terminal_tab/);
-      expect(workflow).toMatch(/CLI workflow does not address tabs directly/i);
+      expect(workflow).toContain("runtimeSlot");
     }
-    expect(standaloneWorkflow).toMatch(/never (?:create or use|use)[^\n]*tabs/i);
+    expect(standaloneWorkflow).toMatch(/Each project owns one Zellij workspace/);
     expect(skill).toMatch(/prompt[^\n]*argument/i);
     expect(skill).toMatch(/--sandbox workspace-write/);
     expect(skill).toMatch(/--sandbox read-only/);
@@ -173,7 +174,7 @@ describe("Matrix OS Codex marketplace plugin", () => {
 
     expect(standalone).toContain("# Matrix OS");
     expect(standalone).toMatch(/^author: Matrix OS$/m);
-    expect(standalone).toMatch(/matrix run -it --session/);
+    expect(standalone).toMatch(/matrix run -it --project/);
     expect(standalone).toMatch(/gh repo clone/);
     expect(standalone).toMatch(/--sandbox workspace-write/);
     expect(standalone).toMatch(/claude[^\n]*--permission-mode auto/i);


### PR DESCRIPTION
## Summary

Native VPS `/api/system/info` responses can contain `build.sha: "unknown"` even though `release.gitCommit` identifies the host bundle. The previous Desktop check treated that response as unavailable and hid the update reminder. Its tests incorrectly assumed the legacy image build environment was populated.

Prefer a valid process build SHA, otherwise compare a validated schema-1 host release only when `version`, `runningVersion`, and `release.version` agree. This supports existing VPS releases without a server upgrade and does not mistake a newly installed bundle for a running process. Template/package `installedVersion` is excluded.

The first full Linux CI run exposed three inherited plugin documentation assertions from the merged project-workspace cutover (#1297). Update those tests to require project tabs and exact-tab reattachment, reject legacy `--session`, and retain authentication and agent sandbox safeguards. No CLI behavior changes. The plugin suite reproduced 3 failures before this adjustment and now passes all 7 tests.

Closes OM-229.

## Tests

- Three regressions failed before the fix: captured host payload, actual gateway `getSystemInfo` output without image build variables, and the Desktop dialog.
- 83 focused contract, gateway, Desktop, and native-embed tests pass, including malformed provenance, explicit protocol recovery, installation before restart, and alignment after restart.
- Full typecheck and pattern checks pass (zero pattern violations). Production Electron build and unsigned arm64 app packaging pass.
- Built Electron E2E passes both scenarios: existing source comparison and native-host HTTP replay with unsent draft preservation and reconnect dismissal. Replay uses the real Electron auth/CORS and preload IPC paths, not browser response interception.
- Live authenticated VPS differential validation on exact head `af980f81364ac974dd75947ff87a8f8becd04972`: the installed prerelease reproduces the missing reminder; the corrected packaged arm64 app passed three cold starts against the same VPS while `build.sha` remained unknown. Each run verified the rendered installed versions, an enabled cloud Update action, dismissal, and a real GET recheck after reconnect. No installer was invoked. Live screenshots stay local; CI artifacts contain synthetic fixture data only.
- The independent Claude review action failed during initialization again on retry (one turn, zero token cost, no review output). Greptile reviewed the final head at 5/5 with no findings; three live cold starts also passed after that review; the standalone service failure is tracked separately from functional CI.
- Local full-suite execution was stopped after unrelated Linux deployment-script failures on macOS (`stat -c` and prerequisite tooling). The isolated golden-snapshot suite reproduces those platform limitations. Complete Linux CI remains the full-suite gate.

- [Complete Linux CI passed](https://github.com/HamedMP/matrix-os/actions/runs/34555795987), including all four unit shards, general E2E, folder-picker, clipboard, and both release-alignment Electron scenarios. [Docker build and smoke passed](https://github.com/HamedMP/matrix-os/actions/runs/34555795933).
- [Final-head Electron screenshot artifact](https://github.com/HamedMP/matrix-os/actions/runs/34555795987/artifacts/10183085537) downloaded and visually checked: source mismatch, host-bundle replay, and dismissed workspace. Synthetic data only, 14-day retention.
- The first E2E attempt failed an unchanged terminal clipboard drag assertion by omitting its first character; the unchanged-head rerun passed all seven clipboard cases. A local run reproduced that assertion plus two existing scrollback/edge-selection failures. The selection helper places its anchor exactly at xterm's half-cell selection boundary, making coordinate rounding a likely contributor. No clipboard product or test code was changed in this PR; this validation limitation is retained explicitly.

## Invariants

- **Source of truth:** process build identity first; native host metadata only with matching explicit running/release versions. Immutable release versions bind the fallback to the running bundle.
- **Lock/transaction scope:** pure bounded parsing; no writes, new network calls, or transactions.
- **Acceptable orphan states:** none introduced; incomplete or mismatched provenance remains unknown, and explicit protocol incompatibility still prompts recovery.
- **Auth source of truth:** existing trusted Electron gateway authentication and bounded API client remain authoritative.
- **Deferred scope:** no production deployment, update-channel changes, or replacement of the installed app. Existing installers are not invoked during verification.
