### PR TITLE
fix(billing): validate portal redirects consistently across clients

### DIFF
--- a/apps/mobile/__tests__/billing-portal-redirect.test.ts
+++ b/apps/mobile/__tests__/billing-portal-redirect.test.ts
@@ -1,0 +1,78 @@
+jest.mock("@/lib/storage", () => ({
+  HOSTED_GATEWAY_URL: "https://app.matrix-os.com",
+}));
+
+// The @matrix-os/contracts barrel reaches chat-sharing.ts -> ESM-only micromark,
+// which Jest cannot transform here. That is unrelated to billing, so re-export
+// the real billing schema module directly rather than stubbing the validation
+// under test.
+jest.mock("@matrix-os/contracts", () => require("../../../packages/contracts/src/billing-public"));
+
+import { Linking } from "react-native";
+
+import { createMobileBillingPortal } from "@/lib/requests/settings";
+
+const portalResponse = (body: unknown) => ({
+  ok: true,
+  json: jest.fn().mockResolvedValue(body),
+}) as unknown as Response;
+
+describe("Native Mobile billing portal redirect", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns a normal Stripe HTTPS redirect", async () => {
+    const url = "https://billing.stripe.com/p/session/live_abc123";
+    jest.spyOn(global, "fetch").mockResolvedValue(portalResponse({ url }));
+
+    await expect(createMobileBillingPortal("clerk-token")).resolves.toBe(url);
+  });
+
+  it.each([
+    ["a relative path", "/billing/portal"],
+    ["a plaintext URL", "http://billing.stripe.com/p/session"],
+    // eslint-disable-next-line no-script-url
+    ["an executable scheme", "javascript:alert(1)"],
+    ["a data URL", "data:text/html,<script>alert(1)</script>"],
+    ["an overlong URL", `https://billing.stripe.com/p/${"a".repeat(2048)}`],
+  ])("rejects %s instead of returning it", async (_label, url) => {
+    jest.spyOn(global, "fetch").mockResolvedValue(portalResponse({ url }));
+
+    await expect(createMobileBillingPortal("clerk-token")).rejects.toThrow();
+  });
+
+  it("rejects a missing redirect URL", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(portalResponse({}));
+
+    await expect(createMobileBillingPortal("clerk-token")).rejects.toThrow();
+  });
+
+  // The billing screen calls `await Linking.openURL(await openPortal())`, so a
+  // rejected redirect must reject before openURL is ever reached.
+  it("never passes an unsafe redirect to Linking.openURL", async () => {
+    const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined as never);
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      // eslint-disable-next-line no-script-url
+      portalResponse({ url: "javascript:alert(1)" }),
+    );
+
+    await expect(
+      (async () => {
+        await Linking.openURL(await createMobileBillingPortal("clerk-token"));
+      })(),
+    ).rejects.toThrow();
+    expect(openURL).not.toHaveBeenCalled();
+  });
+
+  it("does not expose the upstream response in the surfaced error", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      // eslint-disable-next-line no-script-url
+      portalResponse({ url: "javascript:alert(1)" }),
+    );
+
+    await expect(createMobileBillingPortal("clerk-token")).rejects.not.toThrow(
+      /javascript:|stripe|billing\.stripe/i,
+    );
+  });
+});

--- a/apps/mobile/__tests__/billing-portal-redirect.test.ts
+++ b/apps/mobile/__tests__/billing-portal-redirect.test.ts
@@ -71,8 +71,10 @@ describe("Native Mobile billing portal redirect", () => {
       portalResponse({ url: "javascript:alert(1)" }),
     );
 
-    await expect(createMobileBillingPortal("clerk-token")).rejects.not.toThrow(
-      /javascript:|stripe|billing\.stripe/i,
+    // Assert the exact generic message rather than the absence of a pattern:
+    // a "does not match" assertion also passes for an unrelated rejection.
+    await expect(createMobileBillingPortal("clerk-token")).rejects.toThrow(
+      "Billing portal unavailable. Try again.",
     );
   });
 });

--- a/apps/mobile/lib/requests/settings.ts
+++ b/apps/mobile/lib/requests/settings.ts
@@ -17,7 +17,6 @@ const SystemInfoSchema = z.object({
 }).passthrough();
 
 const OkResponseSchema = z.object({ ok: z.literal(true) }).passthrough();
-const BillingPortalSchema = MatrixBillingRedirectSchema;
 
 export type MobileSystemInfo = z.infer<typeof SystemInfoSchema>;
 export type MobileBillingStatus = MatrixBillingStatus;
@@ -52,7 +51,7 @@ export async function createMobileBillingPortal(clerkToken: string): Promise<str
   const response = await fetchAuthenticatedJson({
     url: `${HOSTED_GATEWAY_URL}/billing/portal`,
     token: clerkToken,
-    schema: BillingPortalSchema,
+    schema: MatrixBillingRedirectSchema,
     errorMessage: "Billing portal unavailable. Try again.",
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/mobile/lib/requests/settings.ts
+++ b/apps/mobile/lib/requests/settings.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import {
+  MatrixBillingRedirectSchema,
   MatrixBillingStatusSchema,
   type MatrixBillingStatus,
 } from "@matrix-os/contracts";
@@ -16,7 +17,7 @@ const SystemInfoSchema = z.object({
 }).passthrough();
 
 const OkResponseSchema = z.object({ ok: z.literal(true) }).passthrough();
-const BillingPortalSchema = z.object({ url: z.url() }).strict();
+const BillingPortalSchema = MatrixBillingRedirectSchema;
 
 export type MobileSystemInfo = z.infer<typeof SystemInfoSchema>;
 export type MobileBillingStatus = MatrixBillingStatus;

--- a/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
+++ b/desktop/src/renderer/src/features/settings/sections/BillingSection.tsx
@@ -2,22 +2,15 @@ import { CreditCard, ExternalLink } from "@renderer/lib/hugeicons";
 import {
   MatrixBillingStatusSchema,
   closestMatrixRegionSlug,
+  parseBillingRedirectUrl,
   type MatrixBillingPublicEntitlement,
   type MatrixBillingStatus,
 } from "@matrix-os/contracts";
 import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
-import { z } from "zod/v4";
 import { Button } from "../../../design/primitives";
 import { invoke } from "../../../lib/operator";
 import { useConnection } from "../../../stores/connection";
 import { Card, Row, SettingsSectionHeader } from "./section-kit";
-
-const BillingRedirectSchema = z.strictObject({
-  url: z
-    .url()
-    .max(2048)
-    .refine((url) => new URL(url).protocol === "https:", "Billing redirects must use HTTPS"),
-});
 
 type BillingEntitlement = MatrixBillingPublicEntitlement;
 type BillingInterval = "monthly";
@@ -171,8 +164,9 @@ export default function BillingSection() {
         interval: ui.interval,
         regionSlug: ui.region,
       });
-      const parsed = BillingRedirectSchema.parse(raw);
-      await openBillingUrl(parsed.url);
+      const target = parseBillingRedirectUrl(raw);
+      if (!target) throw new Error("checkout_unavailable");
+      await openBillingUrl(target);
       dispatchUi({ type: "finish-action" });
     } catch (err: unknown) {
       console.warn("[billing] checkout unavailable:", err instanceof Error ? err.message : String(err));
@@ -185,8 +179,9 @@ export default function BillingSection() {
     dispatchUi({ type: "start-action", action: "portal" });
     try {
       const raw = await api.post<unknown>("/billing/portal", {});
-      const parsed = BillingRedirectSchema.parse(raw);
-      await openBillingUrl(parsed.url);
+      const target = parseBillingRedirectUrl(raw);
+      if (!target) throw new Error("portal_unavailable");
+      await openBillingUrl(target);
       dispatchUi({ type: "finish-action" });
     } catch (err: unknown) {
       console.warn("[billing] portal unavailable:", err instanceof Error ? err.message : String(err));

--- a/packages/contracts/src/billing-public.ts
+++ b/packages/contracts/src/billing-public.ts
@@ -73,3 +73,53 @@ export const MatrixBillingStatusSchema = z.object({
 
 export type MatrixBillingPublicEntitlement = z.infer<typeof MatrixBillingPublicEntitlementSchema>;
 export type MatrixBillingStatus = z.infer<typeof MatrixBillingStatusSchema>;
+
+/**
+ * Maximum accepted length of a billing redirect target.
+ *
+ * Stripe-hosted portal and checkout URLs are far shorter than this; the bound
+ * exists so a regressed or hostile upstream response cannot hand a client an
+ * unbounded string to navigate to.
+ */
+export const MATRIX_BILLING_REDIRECT_MAX_LENGTH = 2048;
+
+/**
+ * Shared contract for billing portal and checkout redirect responses.
+ *
+ * Every client (Web, Electron Desktop, Native Mobile) must validate through
+ * this schema before navigating or opening a browser. The platform normally
+ * returns a trusted Stripe HTTPS URL, so this is defense in depth: a relative,
+ * HTTP, or executable-scheme URL must never reach a navigation call.
+ */
+export const MatrixBillingRedirectSchema = z.strictObject({
+  url: z
+    .string()
+    .max(MATRIX_BILLING_REDIRECT_MAX_LENGTH)
+    .refine((value) => {
+      // `URL.parse` would avoid the catch, but it is not available on the
+      // ES2022 target or React Native's Hermes engine, and this schema ships
+      // to Native Mobile.
+      try {
+        return new URL(value).protocol === "https:";
+      } catch (err: unknown) {
+        // A relative path or malformed value is not a navigable target.
+        // Anything other than the expected parse failure is a real fault.
+        if (err instanceof TypeError) return false;
+        throw err;
+      }
+    }, "Billing redirects must be absolute HTTPS URLs"),
+});
+
+export type MatrixBillingRedirect = z.infer<typeof MatrixBillingRedirectSchema>;
+
+/**
+ * Parse an untrusted billing redirect response body.
+ *
+ * Returns the safe HTTPS URL, or `null` for any response that is missing,
+ * malformed, or unsafe to navigate to. Callers should surface a generic,
+ * retryable error on `null` and must not echo the upstream response.
+ */
+export function parseBillingRedirectUrl(body: unknown): string | null {
+  const result = MatrixBillingRedirectSchema.safeParse(body);
+  return result.success ? result.data.url : null;
+}

--- a/packages/contracts/src/billing-public.ts
+++ b/packages/contracts/src/billing-public.ts
@@ -91,22 +91,43 @@ export const MATRIX_BILLING_REDIRECT_MAX_LENGTH = 2048;
  * returns a trusted Stripe HTTPS URL, so this is defense in depth: a relative,
  * HTTP, or executable-scheme URL must never reach a navigation call.
  */
+/**
+ * Parse a redirect candidate, returning `null` instead of throwing.
+ *
+ * Any parse failure is a rejection rather than a rethrow: a relative path or
+ * malformed value simply is not a navigable target, React Native's URL polyfill
+ * does not reliably throw `TypeError`, and `parseBillingRedirectUrl` is
+ * documented never to throw. The failure is deliberately neither logged nor
+ * surfaced, because it can embed the untrusted redirect value and every caller
+ * already reports a generic error.
+ *
+ * (`URL.parse` would express this directly, but it is unavailable on the ES2022
+ * target and on Hermes, and this module ships to Native Mobile.)
+ */
+function parseAbsoluteUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch (err: unknown) {
+    // Every URL implementation in play (V8, JSC, Hermes and its polyfill)
+    // reports a bad URL as an `Error`. Anything else is not a parse failure
+    // this function can interpret, so it propagates rather than being silently
+    // reported as "not a valid URL".
+    if (err instanceof Error) return null;
+    throw err;
+  }
+}
+
 export const MatrixBillingRedirectSchema = z.strictObject({
   url: z
     .string()
     .max(MATRIX_BILLING_REDIRECT_MAX_LENGTH)
     .refine((value) => {
-      // `URL.parse` would avoid the catch, but it is not available on the
-      // ES2022 target or React Native's Hermes engine, and this schema ships
-      // to Native Mobile.
-      try {
-        return new URL(value).protocol === "https:";
-      } catch (err: unknown) {
-        // A relative path or malformed value is not a navigable target.
-        // Anything other than the expected parse failure is a real fault.
-        if (err instanceof TypeError) return false;
-        throw err;
-      }
+      const parsed = parseAbsoluteUrl(value);
+      if (parsed === null) return false;
+      // Reject embedded credentials: `https://evil.example@billing.stripe.com`
+      // parses as https but renders an attacker-controlled authority.
+      if (parsed.username !== "" || parsed.password !== "") return false;
+      return parsed.protocol === "https:";
     }, "Billing redirects must be absolute HTTPS URLs"),
 });
 

--- a/shell/src/components/settings/sections/BillingCheckoutPanel.tsx
+++ b/shell/src/components/settings/sections/BillingCheckoutPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { parseBillingRedirectUrl } from "@matrix-os/contracts";
 import {
   CreditCardIcon,
   Loader2Icon,
@@ -175,11 +176,12 @@ export function BillingCheckoutPanel({
         reportCheckoutError(`http_${response.status}`);
         return;
       }
-      if (typeof body?.url !== "string" || body.url.length === 0) {
+      const target = parseBillingRedirectUrl(body);
+      if (!target) {
         reportCheckoutError("invalid_response");
         return;
       }
-      (onCheckoutNavigate ?? ((target: string) => window.location.assign(target)))(body.url);
+      (onCheckoutNavigate ?? ((redirect: string) => window.location.assign(redirect)))(target);
     } catch (error: unknown) {
       reportCheckoutError(error instanceof Error ? error.name : typeof error);
     } finally {

--- a/shell/src/components/settings/sections/BillingManagementPanel.tsx
+++ b/shell/src/components/settings/sections/BillingManagementPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
+import { parseBillingRedirectUrl } from "@matrix-os/contracts";
 import { ArrowUpRightIcon, ExternalLinkIcon, Loader2Icon, PlusIcon, ReceiptTextIcon, XCircleIcon } from "@/lib/hugeicons";
 import { MATRIX_BILLING_SERVER_PROFILES } from "@/lib/billing";
 import type { BillingEntitlementSummary } from "@/hooks/useMatrixBillingAccess";
@@ -63,19 +64,20 @@ export function BillingPortalButton({
         signal: controller.signal,
       });
       const body = response.ok
-        ? (await response.json().catch((err: unknown) => {
+        ? await response.json().catch((err: unknown) => {
           capturePostHogLog("warn", "billing portal_response_parse_error", {
             source: "settings-billing",
             error_kind: err instanceof Error ? err.name : typeof err,
           });
           return null;
-        })) as { url?: string } | null
+        })
         : null;
-      if (!response.ok || !body?.url) {
+      const target = response.ok ? parseBillingRedirectUrl(body) : null;
+      if (!target) {
         // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler bailout on the throw inside try/catch; intentional control flow routing an unusable portal response into the catch handler. The code is correct.
         throw new Error("portal_unavailable");
       }
-      window.location.assign(body.url);
+      window.location.assign(target);
     } catch (err: unknown) {
       setError("Billing portal is unavailable. Try again in a moment.");
       capturePostHogLog("error", "billing portal_error", {

--- a/tests/contracts/billing-public.test.ts
+++ b/tests/contracts/billing-public.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { MatrixBillingStatusSchema } from "@matrix-os/contracts";
+import {
+  MatrixBillingRedirectSchema,
+  MatrixBillingStatusSchema,
+  parseBillingRedirectUrl,
+} from "@matrix-os/contracts";
 
 describe("public billing status contract", () => {
   it("accepts provider-neutral entitlement metadata", () => {
@@ -91,5 +95,62 @@ describe("public billing status contract", () => {
         trialOffer: { eligible: false, durationDays: 3 },
       })).toThrow();
     }
+  });
+});
+
+describe("billing redirect contract", () => {
+  const httpsUrl = "https://billing.stripe.com/p/session/live_abc123";
+
+  it("accepts a normal Stripe HTTPS redirect", () => {
+    expect(MatrixBillingRedirectSchema.parse({ url: httpsUrl })).toEqual({ url: httpsUrl });
+    expect(parseBillingRedirectUrl({ url: httpsUrl })).toBe(httpsUrl);
+  });
+
+  it("rejects redirects that could navigate a client somewhere unsafe", () => {
+    for (const url of [
+      "/billing/portal",
+      "billing.stripe.com/p/session",
+      "http://billing.stripe.com/p/session",
+      // eslint-disable-next-line no-script-url
+      "javascript:alert(1)",
+      "data:text/html,<script>alert(1)</script>",
+      "file:///etc/passwd",
+      "",
+      `https://billing.stripe.com/p/${"a".repeat(2048)}`,
+    ]) {
+      expect(MatrixBillingRedirectSchema.safeParse({ url }).success, url).toBe(false);
+      expect(parseBillingRedirectUrl({ url }), url).toBeNull();
+    }
+  });
+
+  it("rejects malformed or missing redirect bodies without throwing", () => {
+    for (const body of [null, undefined, {}, { url: 42 }, { url: null }, "https://ok.example"]) {
+      expect(parseBillingRedirectUrl(body)).toBeNull();
+    }
+  });
+
+  it("rejects unexpected fields so a regressed response cannot smuggle data", () => {
+    expect(
+      MatrixBillingRedirectSchema.safeParse({ url: httpsUrl, redirect: "https://evil.example" })
+        .success,
+    ).toBe(false);
+  });
+
+  // Native Mobile parses the portal response with this schema directly
+  // (apps/mobile/lib/requests/settings.ts), and fetchAuthenticatedJson turns a
+  // schema failure into the generic "Billing portal unavailable" message. The
+  // mobile Jest suite cannot import @matrix-os/contracts today, so this is the
+  // executable coverage for that client's rejection behavior.
+  it("rejects the unsafe redirects Native Mobile previously accepted", () => {
+    for (const url of ["http://billing.stripe.com/p/session", "billing.stripe.com/p"]) {
+      expect(MatrixBillingRedirectSchema.safeParse({ url }).success).toBe(false);
+    }
+  });
+
+  it("allows a redirect exactly at the length bound", () => {
+    const prefix = "https://billing.stripe.com/p/";
+    const maxUrl = prefix + "a".repeat(2048 - prefix.length);
+    expect(maxUrl).toHaveLength(2048);
+    expect(parseBillingRedirectUrl({ url: maxUrl })).toBe(maxUrl);
   });
 });

--- a/tests/contracts/billing-public.test.ts
+++ b/tests/contracts/billing-public.test.ts
@@ -137,10 +137,9 @@ describe("billing redirect contract", () => {
   });
 
   // Native Mobile parses the portal response with this schema directly
-  // (apps/mobile/lib/requests/settings.ts), and fetchAuthenticatedJson turns a
-  // schema failure into the generic "Billing portal unavailable" message. The
-  // mobile Jest suite cannot import @matrix-os/contracts today, so this is the
-  // executable coverage for that client's rejection behavior.
+  // (apps/mobile/lib/requests/settings.ts). Client-level coverage, including the
+  // guarantee that a rejected redirect never reaches Linking.openURL, lives in
+  // apps/mobile/__tests__/billing-portal-redirect.test.ts.
   it("rejects the unsafe redirects Native Mobile previously accepted", () => {
     for (const url of ["http://billing.stripe.com/p/session", "billing.stripe.com/p"]) {
       expect(MatrixBillingRedirectSchema.safeParse({ url }).success).toBe(false);

--- a/tests/contracts/billing-public.test.ts
+++ b/tests/contracts/billing-public.test.ts
@@ -117,6 +117,10 @@ describe("billing redirect contract", () => {
       "file:///etc/passwd",
       "",
       `https://billing.stripe.com/p/${"a".repeat(2048)}`,
+      // Embedded credentials render an attacker-controlled authority while
+      // still parsing as https.
+      "https://evil.example@billing.stripe.com/p/session",
+      "https://billing.stripe.com:pass@evil.example/p/session",
     ]) {
       expect(MatrixBillingRedirectSchema.safeParse({ url }).success, url).toBe(false);
       expect(parseBillingRedirectUrl({ url }), url).toBeNull();
@@ -146,10 +150,16 @@ describe("billing redirect contract", () => {
     }
   });
 
-  it("allows a redirect exactly at the length bound", () => {
+  it("pins the length bound at exactly 2048 characters", () => {
     const prefix = "https://billing.stripe.com/p/";
     const maxUrl = prefix + "a".repeat(2048 - prefix.length);
     expect(maxUrl).toHaveLength(2048);
     expect(parseBillingRedirectUrl({ url: maxUrl })).toBe(maxUrl);
+
+    // One character over must be rejected, so the bound is pinned rather than
+    // merely "long strings fail".
+    const overUrl = `${maxUrl}a`;
+    expect(overUrl).toHaveLength(2049);
+    expect(parseBillingRedirectUrl({ url: overUrl })).toBeNull();
   });
 });

--- a/tests/shell/billing-portal-access.test.tsx
+++ b/tests/shell/billing-portal-access.test.tsx
@@ -36,4 +36,50 @@ describe('Web Desktop and Web Canvas billing portal access', () => {
   render(<BillingPanel active={false} entitlement={{...entitlement, source: 'stripe', status}} mode="settings" />);
   expect((screen.getByRole('button', {name: 'View receipts'}) as HTMLButtonElement).disabled).toBe(false);
  });
+
+ // A malformed or regressed platform response must never navigate the shell to a
+ // relative, plaintext, or executable-scheme target.
+ it.each([
+  ['a relative path', '/billing/portal'],
+  ['a plaintext URL', 'http://billing.stripe.com/p/session'],
+  // eslint-disable-next-line no-script-url
+  ['an executable scheme', 'javascript:alert(1)'],
+  ['a data URL', 'data:text/html,<script>alert(1)</script>'],
+  ['an overlong URL', `https://billing.stripe.com/p/${'a'.repeat(2048)}`],
+  ['a missing URL', undefined],
+ ])('refuses to navigate to %s returned by the portal endpoint', async (_label, url) => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+   new Response(JSON.stringify(url === undefined ? {} : {url}), {status: 200}),
+  );
+  const assign = vi.fn();
+  const original = window.location;
+  Object.defineProperty(window, 'location', {configurable: true, value: {...original, assign}});
+  try {
+   render(<BillingPanel active entitlement={entitlement} mode="settings" />);
+   fireEvent.click(screen.getByRole('button', {name: 'View receipts'}));
+   await waitFor(() =>
+    expect(screen.getByText('Billing portal is unavailable. Try again in a moment.')).toBeTruthy(),
+   );
+   expect(assign).not.toHaveBeenCalled();
+  } finally {
+   Object.defineProperty(window, 'location', {configurable: true, value: original});
+  }
+ });
+
+ it('navigates to a normal Stripe HTTPS portal redirect', async () => {
+  const target = 'https://billing.stripe.com/p/session/live_abc123';
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+   new Response(JSON.stringify({url: target}), {status: 200}),
+  );
+  const assign = vi.fn();
+  const original = window.location;
+  Object.defineProperty(window, 'location', {configurable: true, value: {...original, assign}});
+  try {
+   render(<BillingPanel active entitlement={entitlement} mode="settings" />);
+   fireEvent.click(screen.getByRole('button', {name: 'View receipts'}));
+   await waitFor(() => expect(assign).toHaveBeenCalledWith(target));
+  } finally {
+   Object.defineProperty(window, 'location', {configurable: true, value: original});
+  }
+ });
 });

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -563,6 +563,46 @@ describe("BillingSection", () => {
     expect(onCheckoutNavigate).toHaveBeenCalledWith("https://checkout.stripe.test/session");
   });
 
+  // A malformed or regressed platform response must never navigate the shell to
+  // a relative, plaintext, or executable-scheme checkout target.
+  it.each([
+    ["a relative path", "/billing/checkout"],
+    ["a plaintext URL", "http://checkout.stripe.test/session"],
+    // eslint-disable-next-line no-script-url
+    ["an executable scheme", "javascript:alert(1)"],
+    ["a data URL", "data:text/html,<script>alert(1)</script>"],
+    ["an overlong URL", `https://checkout.stripe.test/${"a".repeat(2048)}`],
+  ])("refuses to navigate checkout to %s", async (_label, url) => {
+    clerkState.isLoaded = true;
+    clerkState.activePlan = null;
+    let resolveCheckout!: (response: Response) => void;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      if (input === "/billing/checkout") {
+        return await new Promise<Response>((resolve) => { resolveCheckout = resolve; });
+      }
+      return new Response(JSON.stringify({ access: { runtimeProxyAllowed: false } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const { BillingSection } = await loadBillingSection();
+
+    const onCheckoutNavigate = vi.fn();
+    render(<BillingSection mode="provisioning" onCheckoutNavigate={onCheckoutNavigate} />);
+    await waitForBillingConfigurator();
+    fireEvent.click(screen.getByRole("button", { name: "Continue to pay" }));
+
+    expect(await screen.findByRole("button", { name: "Opening secure checkout" })).toBeTruthy();
+    await act(async () => {
+      resolveCheckout(new Response(JSON.stringify({ url }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+    });
+
+    expect(onCheckoutNavigate).not.toHaveBeenCalled();
+  });
+
   it("closes only the picker on Escape without dismissing the Settings panel", async () => {
     clerkState.isLoaded = true;
     clerkState.activePlan = null;


### PR DESCRIPTION
## Summary

Fixes #1557.

Billing portal redirect responses were validated inconsistently across clients:

- **Electron Desktop** required a valid, bounded (2,048 char) HTTPS URL.
- **Web** checked only that the response contained a truthy `url` before passing it to `window.location.assign` — on both the portal and the checkout path.
- **Native Mobile** validated general URL syntax via `z.url()`, which accepts `http://` and `javascript:` and has no length bound.

The platform normally returns a trusted Stripe-hosted URL, so this is defense in depth rather than evidence of an active exploit. A malformed or regressed upstream response should nevertheless be unable to navigate a client to a relative, plaintext, or executable-scheme URL.

## Change

Promote the existing Electron schema into `@matrix-os/contracts` as the single billing redirect contract and apply it in all three clients:

- `MatrixBillingRedirectSchema` — strict object; `url` must be a syntactically valid absolute HTTPS URL of at most `MATRIX_BILLING_REDIRECT_MAX_LENGTH` (2,048) characters.
- `parseBillingRedirectUrl(body)` — parses an untrusted response body and returns the safe URL or `null`.

All four navigating call sites now validate through the shared contract: Web portal (`BillingManagementPanel.tsx`), Web checkout (`BillingCheckoutPanel.tsx`), and both Electron checkout and portal (`BillingSection.tsx`). Rejected responses surface the existing generic, retryable error. No provider response or raw error is exposed to the user. Portal eligibility and billing authorization are unchanged and remain server-side and owner-scoped.

Per the issue's scope note, no Stripe-host allowlist was added, since supported Stripe portal/custom-domain behavior has not been verified here.

## Acceptance criteria

- [x] Define or reuse one shared billing redirect response schema
- [x] Require a syntactically valid HTTPS URL with a maximum length of 2,048 characters
- [x] Apply the schema consistently in Web, Electron Desktop, and Native Mobile
- [x] Reject relative URLs, HTTP URLs, executable schemes such as `javascript:`, missing URLs, and overlong URLs
- [x] Do not expose provider responses or raw errors in user-facing messages
- [x] Add regression tests proving every applicable client rejects unsafe redirects and accepts a normal Stripe HTTPS redirect

## Validation

- `pnpm exec vitest run tests/contracts/billing-public.test.ts tests/shell/billing-portal-access.test.tsx` — 20/20 pass
- `pnpm --dir apps/mobile exec jest __tests__/billing-portal-redirect.test.ts` — 9/9 pass (mobile suite: passing suites 44 -> 45, passing tests 282 -> 291; failures unchanged)
- `pnpm exec vitest run tests/shell/billing-section.test.tsx` — 5 new Web checkout rejection cases pass (33 -> 38 passing; the 3 pre-existing failures in this file are unchanged). Reverting only the checkout fix raises failures from 3 to 8, confirming the new cases are non-vacuous.
- `bun run typecheck` — passes for all packages, including `desktop`
- `bun run check:patterns` — 0 violations (5 pre-existing warnings in untouched files)
- `npx react-doctor@latest shell` and `... desktop` — finding counts byte-identical to baseline in every category

**The new tests were confirmed to actually catch the defect.** Reverting only the Web fix to the previous truthy-`url` check makes 5 of the new cases fail, demonstrating the shell really did navigate to `javascript:`, `data:`, relative, plaintext, and overlong URLs before this change.

### Pre-existing failures (verified against clean `main`, not introduced here)

- 4 failing tests in `tests/shell/billing-gate.test.tsx` / `billing-section.test.tsx`
- 11 `tsc` errors and 14 failing Jest suites under `apps/mobile/` (the documented `pnpm.packageExtensions` workspace-resolution gotcha)

### Native Mobile client-level coverage

`apps/mobile/__tests__/billing-portal-redirect.test.ts` — 9 tests covering the changed Native Mobile request wiring directly:

- a normal Stripe HTTPS redirect is returned
- relative, plaintext, executable-scheme, `data:`, overlong, and missing redirects are all rejected
- **a rejected redirect never reaches `Linking.openURL`** (the billing screen calls `await Linking.openURL(await openPortal())`)
- the surfaced error does not echo the upstream response

The `@matrix-os/contracts` barrel reaches `chat-sharing.ts` -> ESM-only `micromark`, which Jest cannot transform in `apps/mobile`. That is unrelated to billing, so the test re-exports the real `billing-public` schema module directly rather than stubbing the validation under test — the assertions exercise the actual schema.

Reverting only the mobile schema to the previous `z.url()` makes 6 of these 9 fail, including the `Linking.openURL` guard, confirming `javascript:alert(1)` would previously have reached `openURL` on Native Mobile.

## Surface matrix

| Surface | UI | Behavior | State/recovery | Automated tests | Real evidence |
| --- | --- | --- | --- | --- | --- |
| Web Canvas | N/A | pass | pass | pass | N/A |
| Web Desktop | N/A | pass | pass | pass | N/A |
| Electron Desktop | N/A | pass | pass | pass | N/A |
| Web Mobile | N/A | pass | pass | pass | N/A |
| Native Mobile | N/A | pass | pass | pass | N/A |

**UI `N/A` rationale**: no user-visible UI, copy, layout, or styling changes. The only behavioral change on the rejection path reuses the existing generic error string already rendered by each surface, so there is no new visual state to screenshot.

**Real evidence `N/A`**: reproducing this path against a live surface requires the platform to return a malformed redirect, which it does not do in normal operation. The behavior is instead proven executably by the revert check described under Validation.

## Invariants

- **Source of truth**: the platform billing service remains authoritative for portal eligibility and redirect targets. `MatrixBillingRedirectSchema` in `@matrix-os/contracts` is the single source of truth for what shape of redirect a client may act on; no client re-derives that rule.
- **Lock/transaction scope**: none. This is client-side response validation with no database writes and no new network calls.
- **Acceptable orphan states**: none introduced. Validation happens after the request completes and before navigation, so a rejected redirect leaves the client exactly as it was before the action, with the action re-runnable.
- **Auth source of truth**: unchanged. The portal endpoint stays owner-scoped and server-authorized; this change never widens who may open a portal, only which redirect targets are honored.
- **Deferred scope**: no Stripe-host allowlist (see the issue's scope note); no change to portal eligibility, billing authorization, or checkout flow semantics.

## Deployment note

Per `CLAUDE.md`, the billing-locked Settings UI is served by the platform-owned `app.matrix-os.com` shell surface before a user has an active VPS. Reaching users on that pre-VPS path requires a platform/app-shell deployment; a host-bundle publish alone will not update it.
