### PR TITLE
fix(desktop): restore Resource Manager activity reads

### DIFF
--- a/desktop/src/main/embeds/native-app-bridge.ts
+++ b/desktop/src/main/embeds/native-app-bridge.ts
@@ -6,6 +6,12 @@ import {
   type NativeAppQuery,
 } from "../../shared/native-app-bridge";
 
+import {
+  NATIVE_APP_GATEWAY_CHANNEL,
+  NativeAppGatewayRequestSchema,
+  type NativeAppGatewayRequest,
+} from "../../shared/native-app-gateway";
+
 const SAFE_APP_IDENTITY = /^[a-z0-9][a-z0-9_-]*(?:\/[a-z0-9][a-z0-9_-]*)*$/;
 const MAX_APP_IDENTITY_LENGTH = 256;
 const DEFAULT_MAX_SENDERS = 64;
@@ -49,6 +55,7 @@ function isSafeAppIdentity(value: string): boolean {
 
 interface NativeAppBridgeOptions {
   request: (slug: string, query: NativeAppQuery) => Promise<unknown>;
+  gatewayRequest: (slug: string, request: NativeAppGatewayRequest) => Promise<unknown>;
   gatewayOrigin: () => string;
   maxSenders?: number;
 }
@@ -127,6 +134,30 @@ export function createNativeAppQueryRequester(
   };
 }
 
+export function createNativeAppGatewayRequester(
+  options: NativeAppQueryRequesterOptions,
+): (slug: string, request: NativeAppGatewayRequest) => Promise<unknown> {
+  const fetchFn = options.fetchFn ?? fetch;
+  return async (slug, rawRequest) => {
+    if (slug !== "resource-manager") throw new Error("not authorized");
+    const request = NativeAppGatewayRequestSchema.parse(rawRequest);
+    const token = options.getToken();
+    if (!token) throw new Error("desktop authentication required");
+    const origin = new URL(options.getGatewayOrigin());
+    if (origin.protocol !== "https:" && origin.protocol !== "http:") {
+      throw new Error("invalid gateway origin");
+    }
+    const response = await fetchFn(new URL(request.url, origin).toString(), {
+      method: "GET",
+      redirect: "error",
+      headers: { authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) throw new Error(`activity request failed (${response.status})`);
+    return readBoundedJson(response);
+  };
+}
+
 function isSenderAtApp(sender: NativeAppSender, origin: string, slug: string): boolean {
   try {
     const url = new URL(sender.url);
@@ -183,7 +214,28 @@ export class NativeAppBridge {
     return this.options.request(identity.appIdentity, parsed.data);
   }
 
+  async gatewayFetch(sender: NativeAppSender, rawRequest: unknown): Promise<unknown> {
+    const identity = this.senders.get(sender.id);
+    if (
+      identity?.appIdentity !== "resource-manager"
+      || !isSenderAtApp(sender, this.options.gatewayOrigin(), identity.routeSlug)
+    ) throw new Error("not authorized");
+    const parsed = NativeAppGatewayRequestSchema.safeParse(rawRequest);
+    if (!parsed.success) throw new Error("invalid request");
+    return this.options.gatewayRequest(identity.appIdentity, parsed.data);
+  }
+
   registerIpc(ipcMain: Pick<IpcMain, "handle">): void {
+    ipcMain.handle(NATIVE_APP_GATEWAY_CHANNEL, async (event: IpcMainInvokeEvent, rawRequest: unknown) => {
+      try {
+        if (event.senderFrame !== event.sender.mainFrame) throw new Error("not authorized");
+        return await this.gatewayFetch({ id: event.sender.id, url: event.sender.getURL() }, rawRequest);
+      } catch (error: unknown) {
+        console.warn("[native-app-bridge] activity request failed:",
+          error instanceof Error ? error.message : String(error));
+        throw new Error("app gateway request failed");
+      }
+    });
     ipcMain.handle(NATIVE_APP_QUERY_CHANNEL, async (event: IpcMainInvokeEvent, rawQuery: unknown) => {
       try {
         return await this.query({ id: event.sender.id, url: event.sender.getURL() }, rawQuery);

--- a/desktop/src/main/embeds/web-contents-view.ts
+++ b/desktop/src/main/embeds/web-contents-view.ts
@@ -1,6 +1,6 @@
 // Electron WebContentsView adapter implementing EmbedViewLike. Each embed runs
 // in its own isolated partition. Hosted-shell views have no preload/IPC
-// exposure; app views may receive the narrow database-only preload. Navigation
+// exposure; app views may receive the narrow app-scoped preload. Navigation
 // is gated by an origin allowlist; external links open in the system browser.
 import { WebContentsView, shell, type BaseWindow, type NativeImage } from "electron";
 import { isNavigationAllowed } from "./origin-policy";

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -10,7 +10,11 @@ import {
   installSupportMessageAnalytics,
 } from "./auth/header-injection";
 import { EmbedService } from "./embeds/embed-service";
-import { NativeAppBridge, createNativeAppQueryRequester } from "./embeds/native-app-bridge";
+import {
+  NativeAppBridge,
+  createNativeAppQueryRequester,
+  createNativeAppGatewayRequester,
+} from "./embeds/native-app-bridge";
 import {
   abortCodingAgentThread,
   createCodingAgentSourcePullRequest,
@@ -243,6 +247,10 @@ if (!gotLock) {
       );
 
       const nativeAppBridge = new NativeAppBridge({
+        gatewayRequest: createNativeAppGatewayRequester({
+          getGatewayOrigin: () => auth.getGatewayOrigin(),
+          getToken: () => auth.getToken(),
+        }),
         gatewayOrigin: () => auth.getGatewayOrigin(),
         request: createNativeAppQueryRequester({
           getGatewayOrigin: () => auth.getGatewayOrigin(),

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -13,6 +13,10 @@ import {
   createNativeAppDatabase,
   type NativeAppQuery,
 } from "../shared/native-app-bridge";
+import {
+  NATIVE_APP_GATEWAY_CHANNEL,
+  createNativeAppGatewayFetch,
+} from "../shared/native-app-gateway";
 
 const NATIVE_APP_BRIDGE_ARG = "--matrix-app-bridge";
 
@@ -44,7 +48,10 @@ export type OperatorBridge = typeof api;
 if (process.argv.includes(NATIVE_APP_BRIDGE_ARG)) {
   const database = createNativeAppDatabase((query: NativeAppQuery) =>
     ipcRenderer.invoke(NATIVE_APP_QUERY_CHANNEL, query));
-  contextBridge.exposeInMainWorld("MatrixOS", Object.freeze({ db: database }));
+  contextBridge.exposeInMainWorld("MatrixOS", Object.freeze({
+    db: database,
+    gatewayFetch: createNativeAppGatewayFetch((request) => ipcRenderer.invoke(NATIVE_APP_GATEWAY_CHANNEL, request)),
+  }));
 } else {
   contextBridge.exposeInMainWorld("operator", api);
 }

--- a/desktop/src/shared/native-app-gateway.ts
+++ b/desktop/src/shared/native-app-gateway.ts
@@ -1,0 +1,52 @@
+import { z } from "zod/v4";
+
+export const NATIVE_APP_GATEWAY_CHANNEL = "native-app:gateway-fetch";
+export const NATIVE_APP_GATEWAY_TIMEOUT_MS = 10_000;
+
+const ActivityQuerySchema = z.strictObject({
+  processLimit: z.string().regex(/^(?:[1-9][0-9]?|100)$/).optional(),
+  includeSuggestions: z.enum(["true", "false"]).optional(),
+});
+
+// This compatibility method intentionally grants only Resource Manager's read.
+// Do not turn it into arbitrary authenticated gateway access for installed apps.
+export const NativeAppGatewayRequestSchema = z.strictObject({
+  url: z.string().max(256).refine((url) => {
+    if (!/^\/api\/system\/activity(?:\?[^#]*)?$/.test(url)) return false;
+    const params = new URLSearchParams(url.split("?")[1]);
+    const values = Object.fromEntries(params);
+    return Object.keys(values).length === [...params].length
+      && ActivityQuerySchema.safeParse(values).success;
+  }),
+  init: z.strictObject({ method: z.literal("GET").optional() }).optional(),
+});
+
+export type NativeAppGatewayRequest = z.infer<typeof NativeAppGatewayRequestSchema>;
+
+export function createNativeAppGatewayFetch(
+  invoke: (request: NativeAppGatewayRequest) => Promise<unknown>,
+) {
+  return async <T>(url: string, init?: RequestInit, timeoutMs = NATIVE_APP_GATEWAY_TIMEOUT_MS): Promise<T> => {
+    const parsed = NativeAppGatewayRequestSchema.safeParse({ url, ...(init ? { init } : {}) });
+    if (!parsed.success) throw new Error("invalid app gateway request");
+    const timeout = Number.isFinite(timeoutMs)
+      ? Math.max(1, Math.min(timeoutMs, NATIVE_APP_GATEWAY_TIMEOUT_MS))
+      : NATIVE_APP_GATEWAY_TIMEOUT_MS;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        invoke(parsed.data),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error("app gateway request timed out")), timeout);
+        }),
+      ]) as T;
+    } catch (error: unknown) {
+      console.warn("[native-app-bridge] gateway read failed:",
+        error instanceof Error ? error.name : typeof error);
+      // Main logs the underlying error; apps only receive a fixed safe message.
+      throw new Error("app gateway request failed");
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/tests/default-apps/resource-manager-native-bridge.test.ts
+++ b/tests/default-apps/resource-manager-native-bridge.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { NativeAppBridge, createNativeAppGatewayRequester } from "@desktop/main/embeds/native-app-bridge";
+import App from "../../home/apps/resource-manager/src/App.js";
+
+const electron = vi.hoisted(() => ({
+  contextBridge: { exposeInMainWorld: vi.fn() },
+  ipcRenderer: { invoke: vi.fn() },
+}));
+vi.mock("electron", () => electron);
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(window, "MatrixOS");
+});
+
+it("loads Resource Manager through the actual native app preload", async () => {
+  vi.spyOn(process, "argv", "get").mockReturnValue(["electron", "--matrix-app-bridge"]);
+  electron.contextBridge.exposeInMainWorld.mockImplementation((name, value) => {
+    Object.assign(window, { [name]: value });
+  });
+  const snapshot = {
+    machine: { handle: "review", hostname: "review", status: "healthy", uptimeSeconds: 60 },
+    resources: {
+      cpu: { cores: 4, load1: 1 },
+      memory: { totalBytes: 1024, usedBytes: 512, availableBytes: 512 },
+      swap: { totalBytes: 0, usedBytes: 0 }, disk: [],
+    },
+    services: [], processes: [], cleanupSuggestions: [], collectionWarnings: [],
+  };
+  const fetchFn = vi.fn(async () => new Response(JSON.stringify(snapshot)));
+  const bridge = new NativeAppBridge({
+    request: vi.fn(),
+    gatewayOrigin: () => "https://gateway.test",
+    gatewayRequest: createNativeAppGatewayRequester({
+      getGatewayOrigin: () => "https://gateway.test", getToken: () => "desktop-token", fetchFn,
+    }),
+  });
+  bridge.register(42, "resource-manager");
+  const mainFrame = {};
+  const handle = vi.fn();
+  bridge.registerIpc({ handle });
+  electron.ipcRenderer.invoke.mockImplementation((channel, request) => {
+    const handler = handle.mock.calls.find(([name]) => name === channel)?.[1];
+    return handler({ senderFrame: mainFrame, sender: {
+      id: 42, mainFrame, getURL: () => "https://gateway.test/apps/resource-manager/",
+    } }, request);
+  });
+  await import("../../desktop/src/preload/index.js");
+  render(React.createElement(App));
+  await waitFor(() => expect(screen.getByText("4 cores")).toBeTruthy());
+  expect(screen.queryByText("Resource data is unavailable.")).toBeNull();
+  expect(fetchFn).toHaveBeenCalledOnce();
+  fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+  await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(2));
+  expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith("native-app:gateway-fetch", {
+    url: "/api/system/activity?processLimit=25&includeSuggestions=true", init: { method: "GET" },
+  });
+});

--- a/tests/desktop/native-app-bridge.test.ts
+++ b/tests/desktop/native-app-bridge.test.ts
@@ -54,7 +54,7 @@ describe("native app database bridge", () => {
 
   it("binds each sender to its registered app slug and current app URL", async () => {
     const request = vi.fn(async (_slug: string, _query: unknown) => ({ id: "db-note" }));
-    const bridge = new NativeAppBridge({
+    const bridge = new NativeAppBridge({ gatewayRequest: vi.fn(),
       request,
       gatewayOrigin: () => "https://gateway.test",
     });
@@ -82,7 +82,7 @@ describe("native app database bridge", () => {
   });
 
   it("evicts sender registrations when views close and caps retained identities", async () => {
-    const bridge = new NativeAppBridge({
+    const bridge = new NativeAppBridge({ gatewayRequest: vi.fn(),
       request: vi.fn(async () => []),
       gatewayOrigin: () => "https://gateway.test",
       maxSenders: 2,
@@ -144,7 +144,7 @@ describe("native app database bridge", () => {
       }),
     );
 
-    const bridge = new NativeAppBridge({ request, gatewayOrigin: () => "https://gateway.test" });
+    const bridge = new NativeAppBridge({ gatewayRequest: vi.fn(), request, gatewayOrigin: () => "https://gateway.test" });
     bridge.register(77, "games/2048", "2048");
     await expect(bridge.query(
       { id: 77, url: "https://gateway.test/apps/2048/" },

--- a/tests/desktop/native-app-gateway-preload.test.ts
+++ b/tests/desktop/native-app-gateway-preload.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { createNativeAppGatewayFetch } from "@desktop/shared/native-app-gateway";
+
+afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
+
+it("supports default GET options and closes the preload timer after success", async () => {
+  vi.useFakeTimers();
+  const invoke = vi.fn(async () => ({ resources: {} }));
+  const gatewayFetch = createNativeAppGatewayFetch(invoke);
+  await expect(gatewayFetch("/api/system/activity")).resolves.toEqual({ resources: {} });
+  expect(invoke).toHaveBeenCalledWith({ url: "/api/system/activity" });
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("rejects invalid preload input before IPC", async () => {
+  const invoke = vi.fn();
+  const gatewayFetch = createNativeAppGatewayFetch(invoke);
+  await expect(gatewayFetch("/api/system/update")).rejects.toThrow("invalid app gateway request");
+  await expect(gatewayFetch("/api/system/activity", { method: "POST" }))
+    .rejects.toThrow("invalid app gateway request");
+  expect(invoke).not.toHaveBeenCalled();
+});
+
+it.each([undefined, Infinity, 60_000])("bounds a hung IPC request to ten seconds (%s)", async (timeout) => {
+  vi.useFakeTimers();
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const gatewayFetch = createNativeAppGatewayFetch(() => new Promise(() => undefined));
+  const result = expect(gatewayFetch("/api/system/activity", undefined, timeout))
+    .rejects.toThrow(/^app gateway request failed$/);
+  await vi.advanceTimersByTimeAsync(10_000);
+  await result;
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/tests/desktop/native-app-gateway.test.ts
+++ b/tests/desktop/native-app-gateway.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { NativeAppBridge, createNativeAppGatewayRequester } from "@desktop/main/embeds/native-app-bridge";
+
+const url = "/api/system/activity?processLimit=25&includeSuggestions=true";
+const sender = { id: 42, url: "https://gateway.test/apps/resource-manager/" };
+function setup() {
+  const fetchFn = vi.fn(async () => new Response(JSON.stringify({ generatedAt: "now" })));
+  const gatewayRequest = createNativeAppGatewayRequester({
+    getGatewayOrigin: () => "https://gateway.test", getToken: () => "desktop-token", fetchFn,
+  });
+  const bridge = new NativeAppBridge({
+    request: vi.fn(), gatewayRequest, gatewayOrigin: () => "https://gateway.test",
+  });
+  bridge.register(42, "resource-manager");
+  return { bridge, fetchFn, gatewayRequest };
+}
+
+describe("native Resource Manager gateway bridge", () => {
+  it("uses main-process credentials for the registered app's activity GET", async () => {
+    const { bridge, fetchFn } = setup();
+    await expect(bridge.gatewayFetch(sender, { url, init: { method: "GET" } }))
+      .resolves.toEqual({ generatedAt: "now" });
+    expect(fetchFn).toHaveBeenCalledWith(`https://gateway.test${url}`, expect.objectContaining({
+      method: "GET", redirect: "error", headers: { authorization: "Bearer desktop-token" },
+      signal: expect.any(AbortSignal),
+    }));
+  });
+
+  it.each([
+    { url: "/api/system/update" }, { url: "/api/system/activity/actions" },
+    { url: "https://attacker.test/api/system/activity" }, { url: "//attacker.test" },
+    { url: "/api/system/activity/../update" }, { url: "/api/system/activity#fragment" },
+    { url: "/api/system/activity?processLimit=999" },
+    { url: "/api/system/activity?unknown=true" },
+    { url: "/api/system/activity?processLimit=1&processLimit=2" },
+    { url, init: { method: "POST" } }, { url, init: { headers: { authorization: "spoof" } } },
+    { url, init: { body: "payload" } }, { url, app: "resource-manager" },
+  ])("rejects disallowed requests before fetching: %j", async (payload) => {
+    const { bridge, fetchFn } = setup();
+    await expect(bridge.gatewayFetch(sender, payload)).rejects.toThrow();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects other apps, unregistered views and navigation away from the registered route", async () => {
+    const { bridge, fetchFn } = setup();
+    bridge.register(43, "notes");
+    bridge.register(44, "custom/resource-manager", "resource-manager");
+    for (const source of [
+      { ...sender, id: 99 }, { id: 43, url: "https://gateway.test/apps/notes/" },
+      { ...sender, id: 44 }, { ...sender, url: "https://attacker.test/apps/resource-manager/" },
+      { ...sender, url: "https://gateway.test/apps/notes/" },
+    ]) await expect(bridge.gatewayFetch(source, { url })).rejects.toThrow();
+    bridge.unregister(42);
+    await expect(bridge.gatewayFetch(sender, { url })).rejects.toThrow();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("requires authentication and rejects failed or oversized gateway responses", async () => {
+    const { gatewayRequest, fetchFn } = setup();
+    fetchFn.mockResolvedValueOnce(new Response("unavailable", { status: 503 }));
+    await expect(gatewayRequest("resource-manager", { url })).rejects.toThrow();
+    fetchFn.mockResolvedValueOnce(new Response("{}", { headers: { "content-length": "9000000" } }));
+    await expect(gatewayRequest("resource-manager", { url })).rejects.toThrow();
+    const unauthenticated = createNativeAppGatewayRequester({
+      getGatewayOrigin: () => "https://gateway.test", getToken: () => null, fetchFn,
+    });
+    await expect(unauthenticated("resource-manager", { url })).rejects.toThrow();
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("native gateway IPC boundary", () => {
+  it("rejects subframes and hides internal failure details", async () => {
+    const { bridge, fetchFn } = setup();
+    const handle = vi.fn();
+    bridge.registerIpc({ handle });
+    const handler = handle.mock.calls.find(([name]) => name === "native-app:gateway-fetch")![1];
+    const mainFrame = {};
+    const event = { senderFrame: mainFrame, sender: {
+      id: sender.id, mainFrame, getURL: () => sender.url,
+    } };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      await expect(handler({ ...event, senderFrame: {} }, { url }))
+        .rejects.toThrow(/^app gateway request failed$/);
+      expect(fetchFn).not.toHaveBeenCalled();
+      fetchFn.mockRejectedValueOnce(new Error("private upstream detail"));
+      await expect(handler(event, { url })).rejects.toThrow(/^app gateway request failed$/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Resource Manager displays `Resource data is unavailable.` in Electron Desktop because the native app preload exposes `MatrixOS.db` but omits the `gatewayFetch` method used to read system activity. The request fails before reaching the gateway.

Add a native read channel for the registered Resource Manager view. Validate requests in preload and main, reject other apps/subframes and non-GET or non-activity requests, retain credentials in main, and bound request duration and response size. Existing web bridge behavior is preserved.

Fixes https://linear.app/matrix-os/issue/MAT-521

## Validation

- Regression first reproduced `matrix_bridge_unavailable` using the real native preload and Resource Manager component.
- 118 focused tests pass, including preload → IPC handler → authenticated request → rendering and Refresh, navigation/app-identity rejection, URL/method validation, IPC timeout, and response limits.
- Full repository typecheck passes; pattern scan reports 0 violations (5 existing warnings).
- Electron production build passes. Live Electron Desktop connected to an authenticated runtime displays CPU/memory/disk, four running services, and processes; Refresh updates the CPU load. Screenshot retained in the private task to avoid publishing owner/runtime identity.
- Full repository unit run was stopped after reproducible failures in unchanged Linux host-script tests on macOS (`stat -c` and `add-apt-repository`; isolated rerun: 8 failed / 26 passed). No complete-green-suite claim.
- Greptile: 5/5 at `44a4c5e47355b0467648547642589575ee5dfc44`, with no findings or review threads.
- Final real-device validation after Greptile: the exact-head Electron build renders resource data and Refresh updates CPU load from 10.15 to 0.10, health, memory, and processes. Native accessibility evidence and a window capture are retained privately; the capture service retained an older rendered frame, so the fresh accessibility snapshot records the updated values.
- The independent GitHub Claude review job repeatedly fails before producing feedback (`is_error: true`, zero model usage), including a debug retry; the same startup failure also affects another PR. It is separate from the repository's required `CI Results` aggregate. No workflow or gate was disabled.
- GitHub CI Results passes at the exact head: all four unit shards (14,675 passed / 36 skipped), E2E including required Electron regressions, production builds, typecheck, parity, and remaining aggregate checks. The initial terminal clipboard E2E missed the first selected character; rerunning the failed E2E on unchanged code passed every regression.
- Human Review passed; the owner authorized merge after exact-head Greptile 5/5 and green CI.

## Surface matrix

| Surface | UI | Behavior | State/recovery | Automated tests | Real evidence |
| --- | --- | --- | --- | --- | --- |
| Web Canvas | unchanged | unchanged | unchanged | existing web bridge tests pass | no new capture |
| Web Desktop | unchanged | unchanged | unchanged | existing web bridge tests pass | no new capture |
| Electron Desktop | existing UI restored | activity reads pass | Refresh passes | pass | live native window and screenshot |
| Web Mobile | unchanged | unchanged | unchanged | no mobile code changed | no new capture |
| Native Mobile | unchanged | unchanged | unchanged | no mobile code changed | no new capture |

## Invariants

- Source of truth: the selected gateway's existing `/api/system/activity` snapshot.
- Lock/transaction scope: read-only; no database or file writes added.
- Acceptable orphan states: no durable state; failed reads return a generic error, preload timers clear, native fetches time out, and sender registrations retain existing close/shutdown cleanup.
- Auth source of truth: main-process credentials and registered app/view identity, never renderer-provided app names or headers. Only the registered Resource Manager main frame can read activity.
- Deferred scope: general native app gateway access, other bridge APIs, cleanup mutations, and visual redesign.
