### PR TITLE
fix(chat): preserve complete streamed responses

### DIFF
--- a/desktop/src/renderer/src/components/conversation/presentation.ts
+++ b/desktop/src/renderer/src/components/conversation/presentation.ts
@@ -19,6 +19,8 @@ export interface ConversationMessagePresentation {
   markdown: string;
   copyText: string;
   timestamp: number;
+  /** The live event stream already delivered content for this message. */
+  wasStreamed?: boolean;
   content?: ConversationMessageContentPresentation[];
   /** @deprecated Use references for new provider-neutral projections. */
   attachments?: ConversationAttachmentPresentation[];

--- a/desktop/src/renderer/src/components/conversation/transcript.tsx
+++ b/desktop/src/renderer/src/components/conversation/transcript.tsx
@@ -383,6 +383,7 @@ function ConversationTurn({
   initialFinalIds: ReadonlySet<string>;
 }) {
   const [expanded, setExpanded] = useState(turn.expandedByDefault ?? false);
+  const renderedLiveOutput = useRef(false);
   const showWork = turn.active || expanded;
   const hasWork = turn.work.length > 0;
   const terminalPartial = !turn.active
@@ -395,6 +396,12 @@ function ConversationTurn({
   const visibleTimeline = timeline?.filter((entry) => (
     entry.kind === "user-followup" || showWork || (terminalPartial !== undefined && entry.item.id === terminalPartial.id)
   ));
+  useEffect(() => {
+    if (turn.active && (
+      turn.final?.kind === "message"
+      || turn.work.some((item) => item.kind === "message")
+    )) renderedLiveOutput.current = true;
+  }, [turn.active, turn.final, turn.work]);
   return (
     <>
       {turn.user ? <UserMessage message={turn.user} callbacks={callbacks} /> : null}
@@ -432,7 +439,7 @@ function ConversationTurn({
           callbacks={callbacks}
           showMetadata={!turn.active}
           streaming={turn.active}
-          animateOnMount={!initialFinalIds.has(turn.final.id)}
+          animateOnMount={!initialFinalIds.has(turn.final.id) && !renderedLiveOutput.current}
         />
       ) : null}
     </>

--- a/desktop/src/renderer/src/components/conversation/transcript.tsx
+++ b/desktop/src/renderer/src/components/conversation/transcript.tsx
@@ -383,7 +383,6 @@ function ConversationTurn({
   initialFinalIds: ReadonlySet<string>;
 }) {
   const [expanded, setExpanded] = useState(turn.expandedByDefault ?? false);
-  const renderedLiveOutput = useRef(false);
   const showWork = turn.active || expanded;
   const hasWork = turn.work.length > 0;
   const terminalPartial = !turn.active
@@ -396,12 +395,6 @@ function ConversationTurn({
   const visibleTimeline = timeline?.filter((entry) => (
     entry.kind === "user-followup" || showWork || (terminalPartial !== undefined && entry.item.id === terminalPartial.id)
   ));
-  useEffect(() => {
-    if (turn.active && (
-      turn.final?.kind === "message"
-      || turn.work.some((item) => item.kind === "message")
-    )) renderedLiveOutput.current = true;
-  }, [turn.active, turn.final, turn.work]);
   return (
     <>
       {turn.user ? <UserMessage message={turn.user} callbacks={callbacks} /> : null}
@@ -439,7 +432,10 @@ function ConversationTurn({
           callbacks={callbacks}
           showMetadata={!turn.active}
           streaming={turn.active}
-          animateOnMount={!initialFinalIds.has(turn.final.id) && !renderedLiveOutput.current}
+          animateOnMount={
+            !initialFinalIds.has(turn.final.id)
+            && !(turn.final.kind === "message" && turn.final.wasStreamed)
+          }
         />
       ) : null}
     </>

--- a/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
+++ b/desktop/src/renderer/src/features/chat/CanonicalChatWorkspace.tsx
@@ -270,7 +270,10 @@ export function CanonicalChatWorkspace({
   const composerHasInput = Boolean(
     draft.trim() || referenceTokens.length > 0 || attachments.items.length > 0,
   );
-  const transcript = controller.detail ? canonicalChatPresentation(controller.detail) : [];
+  const transcript = controller.detail ? canonicalChatPresentation({
+    ...controller.detail,
+    streamedMessageIds: controller.streamedMessageIds,
+  }) : [];
 
   useEffect(() => {
     if (!editingQueuedTurn || !controller.detail) return;

--- a/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
+++ b/desktop/src/renderer/src/features/chat/canonical-chat-presentation.ts
@@ -19,6 +19,7 @@ import type {
 
 const MAX_MESSAGE_PART_PROJECTIONS = 64;
 const MAX_RUN_ACTIVITY_PROJECTIONS = 500;
+const MAX_STREAMED_MESSAGE_PROJECTIONS = 200;
 
 function setBounded<K, V>(map: Map<K, V>, key: K, value: V, limit: number): boolean {
   if (!map.has(key) && map.size >= limit) return false;
@@ -560,7 +561,11 @@ export function canonicalChatPresentation(input: {
   turns: CanonicalChatTurn[];
   runs: CanonicalChatRun[];
   activities: CanonicalChatRunActivity[];
+  streamedMessageIds?: readonly string[];
 }): ConversationTurnPresentation[] {
+  const streamedMessageIds = new Set(
+    input.streamedMessageIds?.slice(-MAX_STREAMED_MESSAGE_PROJECTIONS) ?? [],
+  ); // Per-detail projection, explicitly capped with the message window.
   const approvalViews = canonicalChatApprovals(input);
   const latestTurnId = input.turns.reduce<CanonicalChatTurn | undefined>((latest, turn) => (
     latest === undefined
@@ -671,7 +676,12 @@ export function canonicalChatPresentation(input: {
       ...(timeline.length > 0 ? { timeline } : {}),
       ...(userFollowups.length > 0 ? { expandedByDefault: true } : {}),
       ...(finalMessage && messageText(finalMessage)
-        ? { final: messagePresentation(finalMessage, "final") }
+        ? {
+            final: {
+              ...messagePresentation(finalMessage, "final"),
+              ...(streamedMessageIds.has(finalMessage.id) ? { wasStreamed: true } : {}),
+            },
+          }
         : live.streamingFinal
           ? { final: live.streamingFinal }
           : live.failure ? { final: live.failure } : {}),

--- a/desktop/src/renderer/src/features/chat/use-canonical-chat-route-controller.ts
+++ b/desktop/src/renderer/src/features/chat/use-canonical-chat-route-controller.ts
@@ -24,6 +24,7 @@ const INITIAL_DETAIL_MAX_RETRY_MS = 2_000;
 const ACTIVE_RUN_FALLBACK_POLL_MS = 2_000;
 const ACTIVE_RUN_FALLBACK_MAX_RETRY_MS = 10_000;
 const STREAM_MESSAGE_REFRESH_COALESCE_MS = 200;
+const MAX_STREAMED_MESSAGE_IDS = 200;
 
 function detailWithRecord(
   detail: CanonicalChatDetailResponse,
@@ -74,6 +75,10 @@ export function useCanonicalChatRouteController({
   const [error, setError] = useState<string | null>(null);
   const activeChatIdRef = useRef<string | null>(initialChatId);
   const detailRef = useRef<CanonicalChatDetailResponse | null>(null);
+  const streamedMessagesRef = useRef<{ chatId: string | null; ids: string[] }>({
+    chatId: initialChatId,
+    ids: [],
+  });
   const routeScopeRef = useRef<{ active: boolean; client: CanonicalChatClient; projectId: string | null } | null>(null);
   const listRequestSequence = useRef(0);
   const detailRequestSequence = useRef(0);
@@ -206,6 +211,17 @@ export function useCanonicalChatRouteController({
         setItems((current) => current.map((item) => item.chat.id === record.chat.id
           && item.chat.revision < record.chat.revision ? record : item));
         if (event.chatId === activeChatIdRef.current) {
+          const streamedMessageId = event.content.content.messageDelta?.message.id;
+          if (streamedMessageId) {
+            const currentStream = streamedMessagesRef.current;
+            const ids = currentStream.chatId === event.chatId
+              ? currentStream.ids.filter((id) => id !== streamedMessageId)
+              : [];
+            streamedMessagesRef.current = {
+              chatId: event.chatId,
+              ids: [...ids, streamedMessageId].slice(-MAX_STREAMED_MESSAGE_IDS),
+            };
+          }
           const current = detailRef.current;
           const next = current ? applyCanonicalChatContent(current, event.content) : null;
           if (next) {
@@ -823,6 +839,9 @@ export function useCanonicalChatRouteController({
     items,
     activeChatId,
     detail,
+    streamedMessageIds: streamedMessagesRef.current.chatId === activeChatId
+      ? streamedMessagesRef.current.ids
+      : [],
     status,
     error,
     selectChat,

--- a/tests/desktop/canonical-chat-presentation.test.ts
+++ b/tests/desktop/canonical-chat-presentation.test.ts
@@ -595,6 +595,45 @@ describe("canonical Chat presentation adapter", () => {
     expect(presented?.final).toBeUndefined();
   });
 
+  it("marks a completed final message when its content arrived through assistant deltas", () => {
+    const { snapshot } = createCanonicalChatFixture("completed");
+    const run = snapshot.runs[0]!;
+    const finalMessage = {
+      id: "msg_streamed_result",
+      chatId: snapshot.chat.id,
+      seq: 2,
+      role: "assistant" as const,
+      state: "committed" as const,
+      turnId: snapshot.turns[0]!.id,
+      runId: run.id,
+      parts: [{ type: "text" as const, text: "The streamed result is complete." }],
+      createdAt: "2026-08-26T00:00:02.000Z",
+    };
+
+    const [presented] = canonicalChatPresentation({
+      messages: [...snapshot.messages, finalMessage],
+      turns: snapshot.turns,
+      runs: snapshot.runs,
+      streamedMessageIds: [finalMessage.id],
+      activities: [{
+        id: "activity_streamed_result",
+        chatId: snapshot.chat.id,
+        runId: run.id,
+        sequence: 1,
+        type: "assistant.delta",
+        messageId: finalMessage.id,
+        delta: "The streamed result is complete.",
+        occurredAt: finalMessage.createdAt,
+      }],
+    });
+
+    expect(presented?.final).toMatchObject({
+      id: finalMessage.id,
+      markdown: "The streamed result is complete.",
+      wasStreamed: true,
+    });
+  });
+
   it("shows the model first and removes generic Thinking when visible work arrives", () => {
     const { snapshot } = createCanonicalChatFixture("accepted");
     const run = snapshot.runs[0]!;

--- a/tests/desktop/canonical-chat-refresh-recovery.test.tsx
+++ b/tests/desktop/canonical-chat-refresh-recovery.test.tsx
@@ -79,6 +79,7 @@ describe("Desktop event refresh recovery", () => {
       await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
       expect(hook.result.current.detail?.messages[0]?.parts).toEqual([{ type: "text", text: "hello" }]);
       expect(hook.result.current.detail?.record.activeRun).toBeUndefined();
+      expect(hook.result.current.streamedMessageIds).toEqual([message.id]);
       expect(getDetail).toHaveBeenCalledOnce();
     } finally { hook.unmount(); vi.useRealTimers(); }
   });

--- a/tests/desktop/chat-claude-steer-transcript.test.tsx
+++ b/tests/desktop/chat-claude-steer-transcript.test.tsx
@@ -7,8 +7,14 @@ import { useBoard } from "@desktop/renderer/src/stores/board";
 import { useConnection } from "@desktop/renderer/src/stores/connection";
 import { createCanonicalChatEventSource } from "../../packages/ui/src/canonical-chat-event-source";
 import { createCanonicalChatWorkspaceClient } from "./canonical-chat-workspace-test-utils";
-import { AFTER_STEER, BEFORE_STEER, FINAL_TEXT, STEER_REQUEST,
-  createClaudeSteerStreamHarness } from "../helpers/claude-steer-stream-harness";
+import {
+  AFTER_STEER,
+  BEFORE_STEER,
+  FINAL_TEXT,
+  STEER_REQUEST,
+  contentFrames,
+  createClaudeSteerStreamHarness,
+} from "../helpers/claude-steer-stream-harness";
 
 beforeEach(() => {
   vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
@@ -72,6 +78,13 @@ it("renders real Claude post-Steer HTTP events in the Electron transcript before
     // Completed intermediate work is intentionally collapsed into its receipt.
     await waitFor(() => expect(screen.getByRole("log").textContent).toContain(FINAL_TEXT));
     expect(screen.getByRole("log").textContent!.split(FINAL_TEXT)).toHaveLength(2);
+    const persisted = await h.getDetail();
+    expect(persisted.messages.flatMap((message) => message.parts)
+      .some((part) => part.type === "text" && part.text === FINAL_TEXT)).toBe(true);
+    expect(contentFrames(h.frames).some((frame) => (
+      frame.content.messages?.some((message) => message.parts
+        .some((part) => part.type === "text" && part.text === FINAL_TEXT))
+    ))).toBe(true);
     expect(client.getDetail).toHaveBeenCalledTimes(1);
   } finally {
     cleanup(); source.dispose(); await h.close();

--- a/tests/desktop/conversation-transcript-neutral.test.tsx
+++ b/tests/desktop/conversation-transcript-neutral.test.tsx
@@ -596,6 +596,57 @@ describe("provider-neutral conversation transcript", () => {
     }
   });
 
+  it("shows a streamed work message immediately when completion promotes it to the final response", () => {
+    vi.useFakeTimers();
+    const text = `${"promoted_stream_output_".repeat(100)}done`;
+    const streamedMessage = {
+      kind: "message" as const,
+      id: "message-streamed-work",
+      role: "assistant" as const,
+      phase: "commentary" as const,
+      markdown: "Earlier streamed work",
+      copyText: "Earlier streamed work",
+      timestamp: 1_000,
+    };
+    const activeTurn: ConversationTurnPresentation = {
+      id: "turn-promoted-stream",
+      startedAt: 1_000,
+      endedAt: 1_000,
+      active: true,
+      work: [streamedMessage],
+    };
+
+    try {
+      const { container, rerender } = render(
+        <ConversationTranscript turns={[activeTurn]} callbacks={{ copyText: vi.fn() }} />,
+      );
+      expect(container.querySelector('[data-selectable]')?.textContent).toBe("Earlier streamed work");
+
+      rerender(
+        <ConversationTranscript
+          turns={[{
+            ...activeTurn,
+            active: false,
+            endedAt: 2_000,
+            work: [],
+            final: {
+              ...streamedMessage,
+              id: "message-promoted-final",
+              phase: "final",
+              markdown: text,
+              copyText: text,
+            },
+          }]}
+          callbacks={{ copyText: vi.fn() }}
+        />,
+      );
+
+      expect(container.querySelector('[data-selectable]')?.textContent).toBe(text);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps durable partial output visible beside an aborted terminal notice", () => {
     vi.useFakeTimers();
     const partial = "Durable partial output that must remain visible after cancellation.";

--- a/tests/desktop/conversation-transcript-neutral.test.tsx
+++ b/tests/desktop/conversation-transcript-neutral.test.tsx
@@ -604,8 +604,8 @@ describe("provider-neutral conversation transcript", () => {
       id: "message-streamed-work",
       role: "assistant" as const,
       phase: "commentary" as const,
-      markdown: "Earlier streamed work",
-      copyText: "Earlier streamed work",
+      markdown: text,
+      copyText: text,
       timestamp: 1_000,
     };
     const activeTurn: ConversationTurnPresentation = {
@@ -620,7 +620,7 @@ describe("provider-neutral conversation transcript", () => {
       const { container, rerender } = render(
         <ConversationTranscript turns={[activeTurn]} callbacks={{ copyText: vi.fn() }} />,
       );
-      expect(container.querySelector('[data-selectable]')?.textContent).toBe("Earlier streamed work");
+      expect(container.querySelector('[data-selectable]')?.textContent).toBe(text);
 
       rerender(
         <ConversationTranscript
@@ -635,6 +635,7 @@ describe("provider-neutral conversation transcript", () => {
               phase: "final",
               markdown: text,
               copyText: text,
+              wasStreamed: true,
             },
           }]}
           callbacks={{ copyText: vi.fn() }}
@@ -642,6 +643,57 @@ describe("provider-neutral conversation transcript", () => {
       );
 
       expect(container.querySelector('[data-selectable]')?.textContent).toBe(text);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves mount animation for a distinct final after streamed commentary", () => {
+    vi.useFakeTimers();
+    const finalText = `${"distinct_final_output_".repeat(100)}done`;
+    const activeTurn: ConversationTurnPresentation = {
+      id: "turn-distinct-final",
+      startedAt: 1_000,
+      endedAt: 1_000,
+      active: true,
+      work: [{
+        kind: "message",
+        id: "message-streamed-commentary",
+        role: "assistant",
+        phase: "commentary",
+        markdown: "Earlier streamed commentary",
+        copyText: "Earlier streamed commentary",
+        timestamp: 1_000,
+      }],
+    };
+
+    try {
+      const { container, rerender } = render(
+        <ConversationTranscript turns={[activeTurn]} callbacks={{ copyText: vi.fn() }} />,
+      );
+
+      rerender(
+        <ConversationTranscript
+          turns={[{
+            ...activeTurn,
+            active: false,
+            endedAt: 2_000,
+            work: [],
+            final: {
+              kind: "message",
+              id: "message-distinct-final",
+              role: "assistant",
+              phase: "final",
+              markdown: finalText,
+              copyText: finalText,
+              timestamp: 2_000,
+            },
+          }]}
+          callbacks={{ copyText: vi.fn() }}
+        />,
+      );
+
+      expect(container.querySelector('[data-selectable]')?.textContent).not.toBe(finalText);
     } finally {
       vi.useRealTimers();
     }

--- a/tests/plugins/matrix-marketplace.test.ts
+++ b/tests/plugins/matrix-marketplace.test.ts
@@ -107,13 +107,16 @@ describe("Matrix OS Codex marketplace plugin", () => {
     expect(combined).toMatch(/claude auth status/);
     expect(readSkill("matrix-github-project")).toMatch(/gh auth status/);
     expect(combined).toMatch(/auth-codex-<suffix>/);
-    expect(combined).toMatch(/auth-github-<suffix>/);
+    expect(combined).not.toMatch(/auth-github-<suffix>/);
+    expect(readSkill("matrix-github-project")).toMatch(
+      /gh auth login --hostname github\.com --git-protocol ssh --web/,
+    );
     expect(combined).toMatch(/browser\/device/i);
     expect(combined).toMatch(/Never (?:scan|read|upload)[^\n]*credential files/i);
     expect(combined).toMatch(/ask before installing/i);
   });
 
-  it("requires observable sessions, scopes tabs by transport, and sandboxes coding agents", () => {
+  it("requires project-scoped workspaces with observable tabs and sandboxes coding agents", () => {
     const skill = readSkill("matrix-cloud-run");
     const hostedWorkflows = [
       readSkill("matrix-onboarding"),
@@ -128,16 +131,17 @@ describe("Matrix OS Codex marketplace plugin", () => {
     expect(skill).toMatch(/mkdir[^\n]*apps\/<slug>/);
     expect(skill).toMatch(/-C[^\n]*existing directory/i);
     for (const workflow of workflows) {
-      expect(workflow).toMatch(/matrix run -it --session/);
+      expect(workflow).toMatch(/matrix run -it --project <project>/);
+      expect(workflow).not.toMatch(/matrix run -it --session/);
       expect(workflow).not.toMatch(/matrix run --json/);
-      expect(workflow).toMatch(/separate[^\n]*session/i);
-      expect(workflow).toMatch(/matrix shell connect/);
+      expect(workflow).toMatch(/(?:another|separate)[^\n]*tab/i);
+      expect(workflow).toMatch(/matrix shell connect --project <project> --tab <tab-id>/);
     }
     for (const workflow of hostedWorkflows) {
       expect(workflow).toMatch(/create_terminal_tab/);
-      expect(workflow).toMatch(/CLI workflow does not address tabs directly/i);
     }
-    expect(standaloneWorkflow).toMatch(/never (?:create or use|use)[^\n]*tabs/i);
+    expect(standaloneWorkflow).toMatch(/one Zellij workspace/i);
+    expect(standaloneWorkflow).toMatch(/separate Matrix tab/i);
     expect(skill).toMatch(/prompt[^\n]*argument/i);
     expect(skill).toMatch(/--sandbox workspace-write/);
     expect(skill).toMatch(/--sandbox read-only/);
@@ -173,7 +177,9 @@ describe("Matrix OS Codex marketplace plugin", () => {
 
     expect(standalone).toContain("# Matrix OS");
     expect(standalone).toMatch(/^author: Matrix OS$/m);
-    expect(standalone).toMatch(/matrix run -it --session/);
+    expect(standalone).toMatch(/matrix run -it --project <project>/);
+    expect(standalone).toMatch(/matrix shell connect --project <project> --tab <tab-id>/);
+    expect(standalone).not.toMatch(/matrix run -it --session/);
     expect(standalone).toMatch(/gh repo clone/);
     expect(standalone).toMatch(/--sandbox workspace-write/);
     expect(standalone).toMatch(/claude[^\n]*--permission-mode auto/i);


### PR DESCRIPTION
## Summary

- prevent a completed streamed response from replaying its reveal animation when live assistant output is promoted to the final message
- carry a bounded, active-chat list of message IDs observed in live content frames so only genuinely streamed finals bypass the completion remount animation
- prove the exact Claude final text reaches persistence, SSE projection, and the Electron transcript without weakening the existing assertion
- retain the canonical marketplace contract assertions merged independently in #1622 while synchronizing this branch with current `main`

## Tests

- `pnpm test tests/plugins/matrix-marketplace.test.ts`
- `pnpm exec vitest run tests/desktop/conversation-transcript-neutral.test.tsx`
- five consecutive runs of `pnpm exec vitest run tests/desktop/chat-claude-steer-transcript.test.tsx --reporter=verbose`
- `pnpm exec vitest run tests/gateway/chat-claude-steer-live-stream.test.ts tests/gateway/chat-claude-steer-reasoning.test.ts tests/gateway/chat-claude-quota-stream.test.ts tests/desktop/chat-claude-steer-transcript.test.tsx tests/desktop/chat-steer-http-stream.test.tsx tests/gateway/chat-content-stream.test.ts tests/gateway/chat-content-outbox.test.ts tests/gateway/chat-event-stream.test.ts`
- `pnpm exec vitest run tests/desktop/conversation-transcript-neutral.test.tsx tests/ui/canonical-chat-content.test.ts tests/ui/canonical-chat-event-source.test.ts tests/desktop/canonical-chat-event-source.test.ts tests/shell/canonical-chat-content.test.tsx tests/desktop/chat-hermes-startup-transcript.test.tsx tests/gateway/chat-hermes-startup-stream.test.ts tests/gateway/chat-hermes-startup-retry.test.ts`
- `pnpm exec vitest run tests/gateway/codex-startup-stream.test.ts tests/desktop/codex-startup-transcript.test.tsx --reporter=dot`
- 127-test combined marketplace, Claude, Hermes, canonical projection/content, route-controller, and Codex startup regression run
- full typecheck command underlying `bun run typecheck` (pass; Bun is unavailable on this host)
- `pnpm check:patterns` (pass; zero violations)
- `npx react-doctor@latest --verbose --scope changed desktop` (the introduced lookup warning was resolved; remaining findings are pre-existing component complexity/state-organization warnings)
- CI-layout unit shards 1/4, 2/4, and 4/4 passed locally: 11,143 tests passed and 32 skipped across those shards
- shard 3/4 reached 3,396 passing tests and then hit local worker exits plus one PGlite hook timeout under exhausted swap; the same shard passes on current-main CI, and the isolated test had no assertion failure

## Review / Monitoring

- latest failing `main` CI at SHA `4ae7721d3eeacd4447761ed9b47d18efeeab05a0` was inspected; its only test failures were the three stale marketplace assertions
- current base SHA `70f0603222fa7630fb0553e213d9a1e719541424` independently resolves those assertions in #1622; the synced marketplace test passes here and this PR supplies the remaining streaming reliability fix
- no timeout increases, skipped tests, weakened expectations, or arbitrary sleeps
- Greptile's distinct-final animation finding was reproduced first and fixed by replacing the broad turn-level heuristic with exact bounded transport provenance
- no preview VPS; this is a non-layout transcript reliability repair with exact DOM/event/persistence regression coverage
- keep this PR at a stable head while CI and Greptile review run; address every actionable thread before merge

## Invariants

- **Source of truth:** persisted canonical chat messages remain authoritative for content; the active route controller records bounded transport provenance only to decide whether a final was already streamed. The marketplace assertions inherited from current `main` keep the production CLI project-scoped and do not regain `--session` support.
- **Lock/transaction scope:** no database writes, locks, transactions, or network-call boundaries change.
- **Acceptable orphan states:** none introduced; no persistence lifecycle or multi-step mutation changes.
- **Auth source of truth:** unchanged. Existing CLI, gateway, and GitHub authentication mechanisms remain authoritative.
- **Deferred scope:** no skill/CLI behavior changes, no session compatibility layer, no timeout tuning, and no deployment or preview environment.
