### PR TITLE
test(desktop): stabilize terminal clipboard regression

### DIFF
--- a/tests/e2e/desktop/fixtures/stub-gateway.ts
+++ b/tests/e2e/desktop/fixtures/stub-gateway.ts
@@ -640,6 +640,7 @@ export async function startStubGateway(options: StubGatewayOptions = {}): Promis
   };
   let currentToken = TOKEN;
   const activeTerminalOutputs: Partial<Record<string, (data: string) => void>> = {};
+  const terminalOutputSequences: Record<string, number> = {};
   let createdHermesConversation = false;
   const hermesConversationContexts = new Map<string, Map<string, string>>([
     [TOKEN, new Map()],
@@ -1303,7 +1304,7 @@ export async function startStubGateway(options: StubGatewayOptions = {}): Promis
   });
 
   function runTerminalTab(ws: WebSocket, workspaceId: string, tabId: string): void {
-    let seq = 0;
+    let seq = terminalOutputSequences[tabId] ?? 0;
     const terminalRef = { workspaceId, tabId };
     const tab = terminalTabs.find((candidate) => candidate.id === tabId);
     if (workspaceId !== TERMINAL_WORKSPACE_ID || !tab) {
@@ -1322,6 +1323,7 @@ export async function startStubGateway(options: StubGatewayOptions = {}): Promis
     }));
     const sendOutput = (data: string) => {
       seq += 1;
+      terminalOutputSequences[tabId] = seq;
       ws.send(JSON.stringify({ type: "output", terminalRef, revision, seq, data }));
     };
     activeTerminalOutputs[session] = sendOutput;

--- a/tests/e2e/desktop/terminal-clipboard.e2e.test.ts
+++ b/tests/e2e/desktop/terminal-clipboard.e2e.test.ts
@@ -47,7 +47,11 @@ suite("packaged Electron terminal clipboard", () => {
     await app.evaluate(({ clipboard }, value) => clipboard.writeText(value), text);
   }
 
-  async function terminalPoint(text: string, characterIndex: number): Promise<CellPoint> {
+  async function terminalPoint(
+    text: string,
+    characterIndex: number,
+    cellOffset = 0.5,
+  ): Promise<CellPoint> {
     const surface = terminalSurface();
     const row = surface.locator('.xterm-accessibility-tree [role="listitem"]', { hasText: text }).last();
     await row.waitFor({ timeout: 10_000 });
@@ -71,7 +75,7 @@ suite("packaged Electron terminal clipboard", () => {
     if (!resize) throw new Error("terminal column count is unavailable");
     const cellWidth = screenBox.width / resize.cols;
     return {
-      x: screenBox.x + (start + characterIndex + 0.5) * cellWidth,
+      x: screenBox.x + (start + characterIndex + cellOffset) * cellWidth,
       y: rowBox.y + rowBox.height / 2,
     };
   }
@@ -82,8 +86,12 @@ suite("packaged Electron terminal clipboard", () => {
     endText: string,
     endIndexExclusive: number,
   ): Promise<void> {
-    const start = await terminalPoint(startText, startIndex);
-    const end = await terminalPoint(endText, Math.max(0, endIndexExclusive - 0.5));
+    // xterm shifts selection coordinates by half a cell before rounding. A
+    // synthetic pointer exactly at the midpoint can therefore land on either
+    // side when Chromium and xterm use slightly different fractional widths.
+    // Keep both anchors safely inside the intended selection halves.
+    const start = await terminalPoint(startText, startIndex, 0.25);
+    const end = await terminalPoint(endText, Math.max(0, endIndexExclusive - 1), 0.75);
     await page.mouse.move(start.x, start.y);
     await page.mouse.down();
     await page.mouse.move(end.x, end.y, { steps: 6 });


### PR DESCRIPTION
## Summary

- keep synthetic xterm selection anchors away from the half-cell rounding boundary that intermittently omitted the first character
- preserve terminal output sequence numbers across stub-gateway reconnects so resumed clients do not discard fresh test output as stale
- stabilize both the exact clipboard-selection regression and the reload/edge-scroll regression in the required Electron CI suite

## Tests

- frozen `pnpm install`
- Desktop production build
- exact required Electron clipboard suite: 3 consecutive passes, 21/21 tests
- repository typecheck via the equivalent pinned `pnpm` commands (the local shell does not expose `bun`)
- pattern scan: 0 violations
- diff hygiene
- full unsharded unit suite was stopped after two unrelated deterministic billing-screenshot tests timed out locally (`billing-section.test.tsx`); GitHub's required sharded CI remains authoritative

## Review/Monitoring

- Follow-up to the Main CI failure on merge SHA `ebe830c800086074408cec38bf299d6735f11816`
- CI and Greptile will be monitored on this frozen commit; no further pushes while review is running

## Invariants

- **Source of truth:** production xterm behavior is unchanged; only packaged-Electron test coordinates and the bounded stub gateway are changed.
- **Lock/transaction scope:** no database writes, locks, or transactions are involved.
- **Acceptable orphan states:** the stub sequence counters live only for one test-gateway process and disappear at teardown.
- **Auth source of truth:** the existing stub bearer-token contract remains unchanged.
- **Deferred scope:** this PR does not change customer runtime, terminal migration, deployment, or clipboard product behavior.
