### PR TITLE
fix(platform): preserve stable bundle bootstrap compatibility

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -672,10 +672,10 @@ runcmd:
       chown root:matrix /opt/matrix/release.json
       chmod 0644 /opt/matrix/release.json
     fi
-    for required_bin in matrixctl matrix-r2-broker.mjs matrix-db-backup.sh matrix-restore.sh matrix-owner-env matrix-gateway matrix-register-vps matrix-shell matrix-code matrix-sync-agent matrix-symphony matrix-symphony-control matrix-install-hermes; do
+    for required_bin in matrixctl matrix-r2-broker.mjs matrix-db-backup.sh matrix-restore.sh matrix-owner-env matrix-gateway matrix-shell matrix-code matrix-sync-agent matrix-symphony matrix-symphony-control matrix-install-hermes; do
       chmod 0750 "/opt/matrix/bin/${required_bin}"
     done
-    for optional_bin in matrix-integrations matrix-integrations-mcp matrix-register-integrations-mcp matrix-hermes-dashboard matrix-install-openclaw matrix-openclaw-gateway matrix-agent-runtime-control matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do
+    for optional_bin in matrix-register-vps matrix-integrations matrix-integrations-mcp matrix-register-integrations-mcp matrix-hermes-dashboard matrix-install-openclaw matrix-openclaw-gateway matrix-agent-runtime-control matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do
       if [ -e "/opt/matrix/bin/${optional_bin}" ]; then
         chmod 0750 "/opt/matrix/bin/${optional_bin}"
       fi
@@ -716,11 +716,17 @@ runcmd:
     matrix_uid="$(id -u matrix)"
     runuser -u matrix -- env HOME=/home/matrix/home XDG_RUNTIME_DIR="/run/user/${matrix_uid}" DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${matrix_uid}/bus" systemctl --user daemon-reload
     systemctl disable matrix-openclaw-gateway.service || true
-    systemctl enable matrix-restore.service matrix-terminal-runtime.service matrix-gateway.service matrix-vps-registration.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx
+    systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx
     if [ -f /etc/systemd/system/matrix-integrations-agents.service ] && [ -x /opt/matrix/bin/matrix-register-integrations-mcp ]; then
       systemctl enable matrix-integrations-agents.service
     fi
-    systemctl start matrix-restore.service matrix-terminal-runtime.service matrix-gateway.service matrix-vps-registration.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service
+    if [ -f /etc/systemd/system/matrix-terminal-runtime.service ]; then
+      systemctl enable --now matrix-terminal-runtime.service
+    fi
+    systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service
+    if [ -f /etc/systemd/system/matrix-vps-registration.service ]; then
+      systemctl enable --now matrix-vps-registration.service
+    fi
     log_bootstrap_phase core_services_started
     systemctl start --no-block matrix-code-server.service || echo "matrix-host: code-server runtime install will retry via systemd" >&2
     systemctl start --no-block matrix-code.service || echo "matrix-host: code editor will retry via systemd" >&2

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -53,8 +53,10 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(cloudInit).toContain("PLATFORM_INTERNAL_URL={{platformInternalUrl}}");
     expect(cloudInit).toContain("UPGRADE_TOKEN={{platformVerificationToken}}");
     expect(cloudInit).toContain("Environment=SYMPHONY_PORT=4766");
-    expect(cloudInit).toContain("systemctl enable matrix-restore.service matrix-terminal-runtime.service matrix-gateway.service matrix-vps-registration.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service");
-    expect(cloudInit).toContain("systemctl start matrix-restore.service matrix-terminal-runtime.service matrix-gateway.service matrix-vps-registration.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service");
+    expect(cloudInit).toContain("systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service");
+    expect(cloudInit).toContain("systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service");
+    expect(cloudInit).toContain("systemctl enable --now matrix-terminal-runtime.service");
+    expect(cloudInit).toContain("systemctl enable --now matrix-vps-registration.service");
     expect(cloudInit).toContain("systemctl start --no-block matrix-code-server.service");
     expect(cloudInit).toContain("systemctl start --no-block matrix-code.service");
   });

--- a/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
+++ b/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
@@ -131,6 +131,7 @@ describe("customer VPS user-systemd terminal runtime", () => {
     expect(build).toContain("matrix-terminal-runtime");
     expect(service).toContain("User=matrix");
     expect(service).toContain("RuntimeDirectory=matrix");
+    expect(service).toContain("ConditionPathExists=/opt/matrix/bin/matrix-terminal-runtime");
     expect(service).toContain("ExecStart=/opt/matrix/bin/matrix-terminal-runtime");
     expect(service).toContain("KillMode=control-group");
   });

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -326,10 +326,10 @@ exit 99
     expect(codeServerBlock).not.toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
     expect(cloudInit).toContain('TimeoutStartSec=1800');
     expect(cloudInit).toContain(
-      'systemctl enable matrix-restore.service matrix-terminal-runtime.service matrix-gateway.service matrix-vps-registration.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx',
+      'systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer nginx',
     );
     expect(cloudInit).toContain(
-      'systemctl start matrix-restore.service matrix-terminal-runtime.service matrix-gateway.service matrix-vps-registration.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service',
+      'systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-sync-agent.service matrix-symphony.service',
     );
     expect(cloudInit).not.toContain(
       'systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service',
@@ -338,7 +338,7 @@ exit 99
     expect(cloudInit).toContain('systemctl start --no-block matrix-code.service || echo "matrix-host: code editor will retry via systemd" >&2');
     expect(cloudInit).toContain('systemctl start --no-block matrix-hermes.service || echo "matrix-host: optional Hermes install will retry via systemd" >&2');
     expect(cloudInit).toContain('systemctl start --no-block matrix-hermes-dashboard.service || echo "matrix-host: optional Hermes dashboard will retry via systemd" >&2');
-    expect(cloudInit.indexOf('systemctl start matrix-restore.service matrix-terminal-runtime.service matrix-gateway.service')).toBeLessThan(
+    expect(cloudInit.indexOf('systemctl start matrix-restore.service matrix-gateway.service')).toBeLessThan(
       cloudInit.indexOf('systemctl start --no-block matrix-hermes.service'),
     );
     expect(cloudInit.indexOf('systemctl start --no-block matrix-hermes.service')).toBeLessThan(
@@ -387,13 +387,13 @@ exit 99
     const cloudInit = await loadCustomerVpsCloudInitTemplate();
 
     expect(cloudInit).toContain('runcmd:');
-    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-terminal-runtime.service matrix-gateway.service matrix-vps-registration.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer');
+    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer');
     expect(cloudInit).toContain('install -o root -g root -m 0644 /opt/matrix/systemd/*.service /etc/systemd/system/');
     expect(cloudInit).toContain('/opt/matrix/messaging /opt/matrix/messaging/bin');
     expect(cloudInit).toContain('if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then');
     expect(cloudInit).toContain('systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service');
     expect(cloudInit).toContain('messaging runtimes not installed; units installed but not enabled');
-    expect(cloudInit).toContain('for optional_bin in matrix-integrations matrix-integrations-mcp matrix-register-integrations-mcp matrix-hermes-dashboard matrix-install-openclaw matrix-openclaw-gateway matrix-agent-runtime-control matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do');
+    expect(cloudInit).toContain('for optional_bin in matrix-register-vps matrix-integrations matrix-integrations-mcp matrix-register-integrations-mcp matrix-hermes-dashboard matrix-install-openclaw matrix-openclaw-gateway matrix-agent-runtime-control matrix-install-linux-tools matrix-install-developer-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do');
     expect(cloudInit).toContain('MATRIX_HOST_BUNDLE_URL={{hostBundleUrl}}');
     expect(cloudInit).toContain('MATRIX_IMAGE_VERSION={{imageVersion}}');
     expect(cloudInit).toContain('MATRIX_UPDATE_CHANNEL={{updateChannel}}');
@@ -765,12 +765,35 @@ exit 99
     expect(gateway).not.toContain('MATRIX_REGISTER_CLIENT');
     expect(registration).toContain('After=network-online.target matrix-gateway.service');
     expect(registration).not.toContain('Requires=matrix-gateway.service');
+    expect(registration).toContain('ConditionPathExists=/opt/matrix/bin/matrix-register-vps');
     expect(registration).toContain('ExecStart=/opt/matrix/bin/matrix-register-vps');
     expect(registration).toContain('Restart=on-failure');
     expect(registration).toContain('SuccessExitStatus=64');
     expect(registration).toContain('StartLimitIntervalSec=0');
     expect(registration).not.toContain('StartLimitBurst=');
     expect(cloudInit).toContain('matrix-vps-registration.service');
+  });
+
+  it('keeps bootstrap compatible with bundles that predate dedicated lifecycle services', () => {
+    const root = process.cwd();
+    const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
+    const requiredBins = cloudInit.match(/for required_bin in ([^;]+); do/)?.[1]?.split(' ') ?? [];
+    const optionalBins = cloudInit.match(/for optional_bin in ([^;]+); do/)?.[1]?.split(' ') ?? [];
+
+    expect(requiredBins).not.toContain('matrix-register-vps');
+    expect(optionalBins).toContain('matrix-register-vps');
+    expect(cloudInit).toContain(
+      'if [ -f /etc/systemd/system/matrix-terminal-runtime.service ]; then',
+    );
+    expect(cloudInit).toContain('systemctl enable --now matrix-terminal-runtime.service');
+    expect(cloudInit).toContain(
+      'if [ -f /etc/systemd/system/matrix-vps-registration.service ]; then',
+    );
+    expect(cloudInit).toContain('systemctl enable --now matrix-vps-registration.service');
+    expect(cloudInit).not.toMatch(/systemctl enable[^\n]+matrix-restore\.service[^\n]+matrix-terminal-runtime\.service/);
+    expect(cloudInit).not.toMatch(/systemctl start[^\n]+matrix-restore\.service[^\n]+matrix-terminal-runtime\.service/);
+    expect(cloudInit).not.toMatch(/systemctl enable[^\n]+matrix-gateway\.service[^\n]+matrix-vps-registration\.service/);
+    expect(cloudInit).not.toMatch(/systemctl start[^\n]+matrix-gateway\.service[^\n]+matrix-vps-registration\.service/);
   });
 
   it('uploads DB snapshots before updating latest without calling deferred pruning', () => {
@@ -889,13 +912,13 @@ exit 99
     for (const bin of ['matrixctl', 'matrix-r2-broker.mjs', 'matrix-db-backup.sh', 'matrix-restore.sh']) {
       expect(existsSync(join(root, 'distro/customer-vps/host-bin', bin))).toBe(true);
     }
-    expect(cloudInit).toMatch(/for required_bin in matrixctl matrix-r2-broker\.mjs matrix-db-backup\.sh matrix-restore\.sh matrix-owner-env matrix-gateway matrix-register-vps /);
+    expect(cloudInit).toMatch(/for required_bin in matrixctl matrix-r2-broker\.mjs matrix-db-backup\.sh matrix-restore\.sh matrix-owner-env matrix-gateway matrix-shell /);
     expect(cloudInit).toContain('path: /etc/systemd/system/matrix-db-backup.timer');
     expect(cloudInit).toContain('docker.io elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools file git postgresql-client procps nginx openssl socat sudo unzip zsh');
     expect(cloudInit).toContain('https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip');
     expect(cloudInit).toContain('/tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli');
     expect(cloudInit).toContain('docker run -d');
-    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-terminal-runtime.service matrix-gateway.service matrix-vps-registration.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer');
+    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code-server.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-hermes-dashboard.service matrix-linux-tools.service matrix-developer-tools.service matrix-db-backup.timer');
   });
 
   it('includes a bounded matrixctl recovery wrapper', () => {


### PR DESCRIPTION
## Summary

- Keep latest platform cloud-init compatible with the promoted stable bundle, which predates the dedicated terminal-runtime and VPS-registration services.
- Treat the new registration helper as optional during bootstrap.
- Enable the terminal-runtime and registration units only when the installed bundle provides them, while preserving legacy gateway registration for older bundles.
- Retain current-bundle service ordering and Hetzner user-data headroom.

## Tests

- `pnpm install --frozen-lockfile`
- 152 focused host-bootstrap, terminal-runtime, registration-client, and host-bundle tests
- Full TypeScript gate (all packages from the repository typecheck script)
- `pnpm run check:patterns` — 0 violations
- `git diff --check`
- Full `pnpm run test` attempted; the monolithic local run hit unrelated pre-existing timeout flakes in `tests/platform/proxy-routing.test.ts` and `tests/shell/billing-section.test.tsx` after the changed-area suites passed. CI shards are the authoritative full-suite result.

## Review/Monitoring

- Review range frozen at `be1367e4f..5e1f60ea2`.
- CI and Greptile monitoring pending.

## Invariants

### Source of truth

- The installed host bundle is authoritative for which lifecycle services exist.
- A service is activated only when its installed unit exists; each unit separately guards its required executable with `ConditionPathExists`.

### Lock/transaction scope

- No database writes, locks, or network calls are added.
- Bootstrap service activation remains within the existing single cloud-init execution.

### Acceptable orphan states

- Older bundles without either new unit skip that service and continue booting; their gateway retains the legacy registration client.
- Current bundles include both units and helpers, so the dedicated terminal and registration services are enabled and started.
- A unit without its helper is safely skipped by systemd condition handling instead of aborting bootstrap.

### Auth source of truth

- VPS registration remains authenticated by the per-machine registration token in `registration.env`; this change does not alter token validation or platform auth.

### Deferred scope

- This PR does not promote channels, redeploy the platform, or mutate customer machines.
- A disposable stable-to-dev VPS upgrade remains the post-deploy validation step.
