### PR TITLE
fix(updates): recover interrupted stable upgrades

### DIFF
--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -396,6 +396,69 @@ jobs:
               jq -e 'select(.exitCode==0 and .timedOut==false and .truncated==false and .signal==null)' \
                 "$response" >/dev/null
           }
+          collect_preview_diagnostics() {
+            local body response=/tmp/preview-update-diagnostics.json state_script
+            if ! printf '%s' "$address" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+              echo "Preview diagnostics unavailable because the runtime address is invalid." >&2
+              return 1
+            fi
+
+            read -r -d '' state_script <<'PYTHON' || true
+          import json
+          import os
+          import re
+          import stat
+
+          def read_regular(path, limit):
+              fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+              try:
+                  metadata = os.fstat(fd)
+                  if not stat.S_ISREG(metadata.st_mode) or metadata.st_size < 1 or metadata.st_size > limit:
+                      raise ValueError("invalid file")
+                  value = os.read(fd, limit + 1)
+                  if len(value) > limit:
+                      raise ValueError("oversized file")
+                  return value.decode("utf-8")
+              finally:
+                  os.close(fd)
+
+          state = {}
+          try:
+              value = read_regular("/opt/matrix/app/BUNDLE_VERSION", 256).strip()
+              state["appVersion"] = value if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", value) else "invalid"
+          except (OSError, UnicodeError, ValueError):
+              state["appVersion"] = "unavailable"
+          try:
+              payload = json.loads(read_regular("/opt/matrix/release.json", 65536))
+              value = payload.get("version")
+              state["releaseVersion"] = value if isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", value) else "invalid"
+          except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+              state["releaseVersion"] = "unavailable"
+          try:
+              payload = json.loads(read_regular("/opt/matrix/app/.update-error.json", 65536))
+              code = payload.get("code")
+              version = payload.get("version")
+              state["updateError"] = code if isinstance(code, str) and re.fullmatch(r"[a-z][a-z0-9_]{0,63}", code) else "invalid"
+              state["updateVersion"] = version if isinstance(version, str) and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", version) else "invalid"
+          except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+              state["updateError"] = "none"
+          try:
+              value = read_regular("/opt/matrix/staging/update-phase", 64).strip()
+              state["updatePhase"] = value if re.fullmatch(r"[a-z][a-z-]{0,31}", value) else "invalid"
+          except (OSError, UnicodeError, ValueError):
+              state["updatePhase"] = "idle"
+          print(json.dumps(state, sort_keys=True))
+          PYTHON
+            body="$(jq -cn --arg script "$state_script" \
+              '{command:["/usr/bin/python3","-c",$script],timeoutMs:10000}')"
+            echo "::group::Sanitized preview updater state"
+            if send_runtime_command "$body" "$response"; then
+              jq -r '.stdout // ""' "$response"
+            else
+              echo "Bounded updater-state collection failed." >&2
+            fi
+            echo "::endgroup::"
+          }
           probe_active_bundle_version() {
             local body response=/tmp/preview-active-bundle-version.json probe_script
             read -r -d '' probe_script <<'PYTHON' || true
@@ -535,6 +598,7 @@ jobs:
               exit 1
             fi
             if [ "$SECONDS" -ge "$deadline" ]; then
+              collect_preview_diagnostics || true
               echo "Timed out waiting for ${HANDLE} to install ${VERSION} (last: status=${status}, healthy=${healthy}, version=${runtime_version})." >&2
               exit 1
             fi

--- a/distro/customer-vps/host-bin/matrix-gateway
+++ b/distro/customer-vps/host-bin/matrix-gateway
@@ -80,7 +80,7 @@ if [ -f "$APP_DIR/packages/gateway/dist/shell/register-agent-bridges-cli.js" ]; 
 fi
 cd "$APP_DIR"
 if [ -f "$APP_DIR/packages/gateway/dist/main.js" ]; then
-  "$NODE_BIN" "$APP_DIR/packages/gateway/dist/main.js" &
+  "$NODE_BIN" --import=tsx "$APP_DIR/packages/gateway/dist/main.js" &
 else
   "$NODE_BIN" --import=tsx "$APP_DIR/packages/gateway/src/main.ts" &
 fi

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -149,12 +149,14 @@ restore_rollback_release_metadata() {
   sudo mv -Tf "$RELEASE_ROLLBACK_FILE" "$RELEASE_FILE" || return 1
 }
 
-rollback_release_metadata_is_ready() {
-  local rollback_app="$1" expected_version actual_version
-  [ -d "$rollback_app" ] && [ ! -L "$rollback_app" ] || return 1
-  [ -f "$rollback_app/BUNDLE_VERSION" ] && [ ! -L "$rollback_app/BUNDLE_VERSION" ] || return 1
-  IFS= read -r expected_version <"$rollback_app/BUNDLE_VERSION" || return 1
-  actual_version="$(python3 - "$RELEASE_ROLLBACK_FILE" <<'PY'
+release_metadata_matches_app() {
+  local app_dir="$1" release_file="$2" expected_version actual_version
+  [ -d "$app_dir" ] && [ ! -L "$app_dir" ] || return 1
+  [ -f "$app_dir/BUNDLE_VERSION" ] && [ ! -L "$app_dir/BUNDLE_VERSION" ] || return 1
+  [ -f "$release_file" ] && [ ! -L "$release_file" ] || return 1
+  IFS= read -r expected_version <"$app_dir/BUNDLE_VERSION" || return 1
+  [[ "$expected_version" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || return 1
+  actual_version="$(python3 - "$release_file" <<'PY'
 import json
 import os
 import stat
@@ -177,6 +179,10 @@ finally:
 PY
   )" || return 1
   [ "$actual_version" = "$expected_version" ]
+}
+
+rollback_release_metadata_is_ready() {
+  release_metadata_matches_app "$1" "$RELEASE_ROLLBACK_FILE"
 }
 
 # Echo the lines of an existing symphony.env that this agent does not manage so
@@ -849,6 +855,11 @@ consume_update_trigger() {
 recover_interrupted_update() {
   local phase version="" transaction_state=""
   [ -f "$UPDATE_PHASE_MARKER" ] && [ ! -L "$UPDATE_PHASE_MARKER" ] || return 0
+  phase="$(cat "$UPDATE_PHASE_MARKER" 2>/dev/null || true)"
+  case "$phase" in
+    prepare|download|verify|extract|terminal-runtime|app-install|host-bin|health) ;;
+    *) phase=unknown ;;
+  esac
   if [ -f "$UPDATE_TRANSACTION_STATE" ] && [ ! -L "$UPDATE_TRANSACTION_STATE" ]; then
     transaction_state="$(cat "$UPDATE_TRANSACTION_STATE" 2>/dev/null || true)"
     case "$transaction_state" in
@@ -879,15 +890,30 @@ recover_interrupted_update() {
     esac
   fi
   [ -f "$UPDATE_MARKER" ] && [ ! -L "$UPDATE_MARKER" ] || {
+    case "$phase" in
+      host-bin|health)
+        version="$(current_version)"
+        [[ "$version" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || version=""
+        if [ -d "$APP_DIR.rollback" ] && [ ! -L "$APP_DIR.rollback" ]; then
+          if release_metadata_matches_app "$APP_DIR.rollback" "$RELEASE_FILE"; then
+            log "Recovering update interrupted after a legacy updater replaced the app"
+            if do_rollback false; then
+              write_update_error "apply_interrupted" "The interrupted update was rolled back to the previous runtime." "$version"
+            else
+              write_update_error "post_install_rollback_failed" "The interrupted update could not be rolled back completely." "$version"
+            fi
+          else
+            log "ERROR: interrupted legacy update metadata does not identify the rollback app"
+            write_update_error "post_install_rollback_failed" "The interrupted update could not be rolled back completely." "$version"
+          fi
+          return 0
+        fi
+        ;;
+    esac
     rm -f -- "$UPDATE_PHASE_MARKER"
     return 0
   }
   [ ! -e "$UPDATE_ERROR_MARKER" ] && [ ! -L "$UPDATE_ERROR_MARKER" ] || return 0
-  phase="$(cat "$UPDATE_PHASE_MARKER" 2>/dev/null || true)"
-  case "$phase" in
-    prepare|download|verify|extract|terminal-runtime|app-install|host-bin|health) ;;
-    *) phase=unknown ;;
-  esac
   version="$(json_field "$(cat "$UPDATE_MARKER")" version 2>/dev/null || true)"
   log "ERROR: interrupted update recovered at bounded phase $phase"
   write_update_error "apply_interrupted" "The update process was interrupted before completion." "$version"
@@ -1441,10 +1467,21 @@ do_rollback() {
   elif [ ! -f "$UPDATE_TRANSACTION_STATE" ] || [ -L "$UPDATE_TRANSACTION_STATE" ]; then
     log "ERROR: no rollback app or update transaction is available"; return 1
   fi
-  if [ "$restore_release_metadata" = true ] && [ "$has_app_rollback" = true ] \
-    && ! rollback_release_metadata_is_ready "$APP_DIR.rollback"; then
-    log "ERROR: rollback release metadata is unavailable or inconsistent"
-    return 1
+  if [ "$has_app_rollback" = true ]; then
+    if [ "$restore_release_metadata" = true ]; then
+      if rollback_release_metadata_is_ready "$APP_DIR.rollback"; then
+        :
+      elif release_metadata_matches_app "$APP_DIR.rollback" "$RELEASE_FILE"; then
+        log "Installed release metadata already identifies the rollback app"
+        restore_release_metadata=false
+      else
+        log "ERROR: rollback release metadata is unavailable or inconsistent"
+        return 1
+      fi
+    elif ! release_metadata_matches_app "$APP_DIR.rollback" "$RELEASE_FILE"; then
+      log "ERROR: installed release metadata does not identify the rollback app"
+      return 1
+    fi
   fi
   log "Rolling back..."
   if ! stop_runtime_services; then

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -149,42 +149,6 @@ restore_rollback_release_metadata() {
   sudo mv -Tf "$RELEASE_ROLLBACK_FILE" "$RELEASE_FILE" || return 1
 }
 
-release_metadata_matches_app() {
-  local app_dir="$1" release_file="$2" expected_version actual_version
-  [ -d "$app_dir" ] && [ ! -L "$app_dir" ] || return 1
-  [ -f "$app_dir/BUNDLE_VERSION" ] && [ ! -L "$app_dir/BUNDLE_VERSION" ] || return 1
-  [ -f "$release_file" ] && [ ! -L "$release_file" ] || return 1
-  IFS= read -r expected_version <"$app_dir/BUNDLE_VERSION" || return 1
-  [[ "$expected_version" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || return 1
-  actual_version="$(python3 - "$release_file" <<'PY'
-import json
-import os
-import stat
-import sys
-
-fd = os.open(sys.argv[1], os.O_RDONLY | os.O_NOFOLLOW)
-try:
-    metadata = os.fstat(fd)
-    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size < 2 or metadata.st_size > 65536:
-        raise ValueError("invalid rollback release metadata")
-    payload = os.read(fd, 65537)
-    if len(payload) > 65536:
-        raise ValueError("oversized rollback release metadata")
-    version = json.loads(payload).get("version")
-    if not isinstance(version, str):
-        raise ValueError("missing rollback release version")
-    print(version)
-finally:
-    os.close(fd)
-PY
-  )" || return 1
-  [ "$actual_version" = "$expected_version" ]
-}
-
-rollback_release_metadata_is_ready() {
-  release_metadata_matches_app "$1" "$RELEASE_ROLLBACK_FILE"
-}
-
 # Echo the lines of an existing symphony.env that this agent does not manage so
 # operator-set configuration survives a host bundle update. Blank and comment
 # lines are kept; managed KEY= lines are dropped (re-emitted with fresh values
@@ -852,73 +816,6 @@ consume_update_trigger() {
   sudo rm -f -- "$UPDATE_TRIGGER"
 }
 
-recover_interrupted_update() {
-  local phase version="" transaction_state=""
-  [ -f "$UPDATE_PHASE_MARKER" ] && [ ! -L "$UPDATE_PHASE_MARKER" ] || return 0
-  phase="$(cat "$UPDATE_PHASE_MARKER" 2>/dev/null || true)"
-  case "$phase" in
-    prepare|download|verify|extract|terminal-runtime|app-install|host-bin|health) ;;
-    *) phase=unknown ;;
-  esac
-  if [ -f "$UPDATE_TRANSACTION_STATE" ] && [ ! -L "$UPDATE_TRANSACTION_STATE" ]; then
-    transaction_state="$(cat "$UPDATE_TRANSACTION_STATE" 2>/dev/null || true)"
-    case "$transaction_state" in
-      prepared|mutating)
-        log "Recovering interrupted update transaction"
-        if [ -f "$UPDATE_TRANSACTION_DIR/candidate-version" ] && [ ! -L "$UPDATE_TRANSACTION_DIR/candidate-version" ]; then
-          IFS= read -r version <"$UPDATE_TRANSACTION_DIR/candidate-version" || version=""
-          [[ "$version" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || version=""
-        fi
-        if transaction_candidate_is_committed "$version"; then
-          log "Interrupted update had already committed; finalizing transaction"
-          clear_consumed_update_markers
-          cleanup_update_transaction
-          rm -f -- "$UPDATE_PHASE_MARKER"
-          return 0
-        fi
-        if do_rollback false; then
-          write_update_error "apply_interrupted" "The interrupted update was rolled back to the previous runtime." "$version"
-        else
-          write_update_error "post_install_rollback_failed" "The interrupted update could not be rolled back completely." "$version"
-        fi
-        return 0
-        ;;
-      *)
-        log "ERROR: update transaction state is invalid"
-        return 1
-        ;;
-    esac
-  fi
-  [ -f "$UPDATE_MARKER" ] && [ ! -L "$UPDATE_MARKER" ] || {
-    case "$phase" in
-      host-bin|health)
-        version="$(current_version)"
-        [[ "$version" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || version=""
-        if [ -d "$APP_DIR.rollback" ] && [ ! -L "$APP_DIR.rollback" ]; then
-          if release_metadata_matches_app "$APP_DIR.rollback" "$RELEASE_FILE"; then
-            log "Recovering update interrupted after a legacy updater replaced the app"
-            if do_rollback false; then
-              write_update_error "apply_interrupted" "The interrupted update was rolled back to the previous runtime." "$version"
-            else
-              write_update_error "post_install_rollback_failed" "The interrupted update could not be rolled back completely." "$version"
-            fi
-          else
-            log "ERROR: interrupted legacy update metadata does not identify the rollback app"
-            write_update_error "post_install_rollback_failed" "The interrupted update could not be rolled back completely." "$version"
-          fi
-          return 0
-        fi
-        ;;
-    esac
-    rm -f -- "$UPDATE_PHASE_MARKER"
-    return 0
-  }
-  [ ! -e "$UPDATE_ERROR_MARKER" ] && [ ! -L "$UPDATE_ERROR_MARKER" ] || return 0
-  version="$(json_field "$(cat "$UPDATE_MARKER")" version 2>/dev/null || true)"
-  log "ERROR: interrupted update recovered at bounded phase $phase"
-  write_update_error "apply_interrupted" "The update process was interrupted before completion." "$version"
-}
-
 fetch_manifest() {
   local url="$1" manifest
   if ! manifest="$(curl --fail --silent --show-error --max-time 15 "$url" 2>&1)"; then
@@ -1459,85 +1356,15 @@ run_apply_update() {
   return "$status"
 }
 
-# ── Rollback ─────────────────────────────────────────────────────────
-do_rollback() {
-  local restore_release_metadata="${1:-true}" has_app_rollback=false
-  if [ -d "$APP_DIR.rollback" ] && [ ! -L "$APP_DIR.rollback" ]; then
-    has_app_rollback=true
-  elif [ ! -f "$UPDATE_TRANSACTION_STATE" ] || [ -L "$UPDATE_TRANSACTION_STATE" ]; then
-    log "ERROR: no rollback app or update transaction is available"; return 1
-  fi
-  if [ "$has_app_rollback" = true ]; then
-    if [ "$restore_release_metadata" = true ]; then
-      if rollback_release_metadata_is_ready "$APP_DIR.rollback"; then
-        :
-      elif release_metadata_matches_app "$APP_DIR.rollback" "$RELEASE_FILE"; then
-        log "Installed release metadata already identifies the rollback app"
-        restore_release_metadata=false
-      else
-        log "ERROR: rollback release metadata is unavailable or inconsistent"
-        return 1
-      fi
-    elif ! release_metadata_matches_app "$APP_DIR.rollback" "$RELEASE_FILE"; then
-      log "ERROR: installed release metadata does not identify the rollback app"
-      return 1
-    fi
-  fi
-  log "Rolling back..."
-  if ! stop_runtime_services; then
-    log "ERROR: rollback could not stop the runtime services safely"
-    return 1
-  fi
-  if [ "$has_app_rollback" = true ] \
-    && [ -f "$APP_DIR/$TERMINAL_RUNTIME_GENERATION_FILE" ] \
-    && [ ! -f "$APP_DIR.rollback/$TERMINAL_RUNTIME_GENERATION_FILE" ] \
-    && [ -f "/home/matrix/home/system/terminal-migration-journal.json" ]; then
-    if ! /opt/matrix/bin/matrix-terminal-runtime --rollback; then
-      log "ERROR: terminal migration rollback failed while candidate code was available"
-      return 1
-    fi
-  fi
-  if [ "$has_app_rollback" = true ] && [ -d "$APP_DIR" ]; then
-    sudo mkdir -p "$STAGING_DIR"
-    sudo chown matrix:matrix "$STAGING_DIR"
-    sudo mv "$APP_DIR" "$STAGING_DIR/failed-$(date +%s)"
-  fi
-  if [ "$has_app_rollback" = true ]; then
-    sudo mv "$APP_DIR.rollback" "$APP_DIR"
-    sudo chown -R matrix:matrix "$APP_DIR"
-  fi
-  if [ "$restore_release_metadata" = true ] && [ "$has_app_rollback" = true ]; then
-    restore_rollback_release_metadata || {
-      log "ERROR: rollback release metadata restore failed"
-      return 1
-    }
-  fi
-  restore_update_transaction || {
-    log "ERROR: update transaction artifact restore failed"
-    return 1
-  }
-  if [ -f "$APP_DIR/$TERMINAL_RUNTIME_GENERATION_FILE" ]; then
-    activate_terminal_runtime_generation "$(cat "$APP_DIR/$TERMINAL_RUNTIME_GENERATION_FILE")"
-  fi
-  cleanup_terminal_runtime_generations || log "WARN: terminal generation cleanup remains above cap after rollback"
-  sudo systemctl start matrix-terminal-runtime || true
-  sudo systemctl start matrix-gateway matrix-shell
-  sudo systemctl start --no-block matrix-symphony || true
-  local healthy=false
-  for _ in $(seq 1 18); do
-    if curl --fail --silent --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; then
-      healthy=true; break
-    fi
-    sleep 5
-  done
-  if [ "$healthy" = true ]; then
-    cleanup_update_transaction
-    log "Rollback complete (now at $(current_version))"
-  else
-    log "ERROR: rollback health check failed — services may be down"
-    return 1
-  fi
+# ── Recovery and rollback ────────────────────────────────────────────
+# Keep recovery behavior isolated from this long-running orchestration entrypoint.
+# BEGIN update recovery library loader
+[ -f "$BIN_DIR/matrix-sync-agent-recovery" ] && [ ! -L "$BIN_DIR/matrix-sync-agent-recovery" ] || {
+  log "ERROR: update recovery library is unavailable"
+  exit 1
 }
+source "$BIN_DIR/matrix-sync-agent-recovery"
+# END update recovery library loader
 
 # ── Signal handling ──────────────────────────────────────────────────
 update_requested=false

--- a/distro/customer-vps/host-bin/matrix-sync-agent-recovery
+++ b/distro/customer-vps/host-bin/matrix-sync-agent-recovery
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+# Recovery and rollback functions for matrix-sync-agent.
+#
+# This file is sourced by the agent after its update primitives are defined. It
+# deliberately owns no process lifecycle or mutable globals of its own.
+
+release_metadata_matches_app() {
+  local app_dir="$1" release_file="$2" expected_version actual_version
+  [ -d "$app_dir" ] && [ ! -L "$app_dir" ] || return 1
+  [ -f "$app_dir/BUNDLE_VERSION" ] && [ ! -L "$app_dir/BUNDLE_VERSION" ] || return 1
+  [ -f "$release_file" ] && [ ! -L "$release_file" ] || return 1
+  IFS= read -r expected_version <"$app_dir/BUNDLE_VERSION" || return 1
+  [[ "$expected_version" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || return 1
+  actual_version="$(python3 - "$release_file" <<'PY'
+import json
+import os
+import stat
+import sys
+
+fd = os.open(sys.argv[1], os.O_RDONLY | os.O_NOFOLLOW)
+try:
+    metadata = os.fstat(fd)
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size < 2 or metadata.st_size > 65536:
+        raise ValueError("invalid rollback release metadata")
+    payload = os.read(fd, 65537)
+    if len(payload) > 65536:
+        raise ValueError("oversized rollback release metadata")
+    version = json.loads(payload).get("version")
+    if not isinstance(version, str):
+        raise ValueError("missing rollback release version")
+    print(version)
+finally:
+    os.close(fd)
+PY
+  )" || return 1
+  [ "$actual_version" = "$expected_version" ]
+}
+
+rollback_release_metadata_is_ready() {
+  release_metadata_matches_app "$1" "$RELEASE_ROLLBACK_FILE"
+}
+
+recover_interrupted_update() {
+  local phase version="" transaction_state=""
+  [ -f "$UPDATE_PHASE_MARKER" ] && [ ! -L "$UPDATE_PHASE_MARKER" ] || return 0
+  phase="$(cat "$UPDATE_PHASE_MARKER" 2>/dev/null || true)"
+  case "$phase" in
+    prepare|download|verify|extract|terminal-runtime|app-install|host-bin|health) ;;
+    *) phase=unknown ;;
+  esac
+  if [ -f "$UPDATE_TRANSACTION_STATE" ] && [ ! -L "$UPDATE_TRANSACTION_STATE" ]; then
+    transaction_state="$(cat "$UPDATE_TRANSACTION_STATE" 2>/dev/null || true)"
+    case "$transaction_state" in
+      prepared|mutating)
+        log "Recovering interrupted update transaction"
+        if [ -f "$UPDATE_TRANSACTION_DIR/candidate-version" ] && [ ! -L "$UPDATE_TRANSACTION_DIR/candidate-version" ]; then
+          IFS= read -r version <"$UPDATE_TRANSACTION_DIR/candidate-version" || version=""
+          [[ "$version" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || version=""
+        fi
+        if transaction_candidate_is_committed "$version"; then
+          log "Interrupted update had already committed; finalizing transaction"
+          clear_consumed_update_markers
+          cleanup_update_transaction
+          rm -f -- "$UPDATE_PHASE_MARKER"
+          return 0
+        fi
+        if do_rollback false; then
+          write_update_error "apply_interrupted" "The interrupted update was rolled back to the previous runtime." "$version"
+        else
+          write_update_error "post_install_rollback_failed" "The interrupted update could not be rolled back completely." "$version"
+        fi
+        return 0
+        ;;
+      *)
+        log "ERROR: update transaction state is invalid"
+        return 1
+        ;;
+    esac
+  fi
+  [ -f "$UPDATE_MARKER" ] && [ ! -L "$UPDATE_MARKER" ] || {
+    case "$phase" in
+      host-bin|health)
+        version="$(current_version)"
+        [[ "$version" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || version=""
+        if [ -d "$APP_DIR.rollback" ] && [ ! -L "$APP_DIR.rollback" ]; then
+          if release_metadata_matches_app "$APP_DIR.rollback" "$RELEASE_FILE"; then
+            log "Recovering update interrupted after a legacy updater replaced the app"
+            if do_rollback false; then
+              write_update_error "apply_interrupted" "The interrupted update was rolled back to the previous runtime." "$version"
+            else
+              write_update_error "post_install_rollback_failed" "The interrupted update could not be rolled back completely." "$version"
+            fi
+          else
+            log "ERROR: interrupted legacy update metadata does not identify the rollback app"
+            write_update_error "post_install_rollback_failed" "The interrupted update could not be rolled back completely." "$version"
+          fi
+          return 0
+        fi
+        ;;
+    esac
+    rm -f -- "$UPDATE_PHASE_MARKER"
+    return 0
+  }
+  [ ! -e "$UPDATE_ERROR_MARKER" ] && [ ! -L "$UPDATE_ERROR_MARKER" ] || return 0
+  version="$(json_field "$(cat "$UPDATE_MARKER")" version 2>/dev/null || true)"
+  log "ERROR: interrupted update recovered at bounded phase $phase"
+  write_update_error "apply_interrupted" "The update process was interrupted before completion." "$version"
+}
+
+do_rollback() {
+  local restore_release_metadata="${1:-true}" has_app_rollback=false
+  if [ -d "$APP_DIR.rollback" ] && [ ! -L "$APP_DIR.rollback" ]; then
+    has_app_rollback=true
+  elif [ ! -f "$UPDATE_TRANSACTION_STATE" ] || [ -L "$UPDATE_TRANSACTION_STATE" ]; then
+    log "ERROR: no rollback app or update transaction is available"; return 1
+  fi
+  if [ "$has_app_rollback" = true ]; then
+    if [ "$restore_release_metadata" = true ]; then
+      if rollback_release_metadata_is_ready "$APP_DIR.rollback"; then
+        :
+      elif release_metadata_matches_app "$APP_DIR.rollback" "$RELEASE_FILE"; then
+        log "Installed release metadata already identifies the rollback app"
+        restore_release_metadata=false
+      else
+        log "ERROR: rollback release metadata is unavailable or inconsistent"
+        return 1
+      fi
+    elif ! release_metadata_matches_app "$APP_DIR.rollback" "$RELEASE_FILE"; then
+      log "ERROR: installed release metadata does not identify the rollback app"
+      return 1
+    fi
+  fi
+  log "Rolling back..."
+  if ! stop_runtime_services; then
+    log "ERROR: rollback could not stop the runtime services safely"
+    return 1
+  fi
+  if [ "$has_app_rollback" = true ] \
+    && [ -f "$APP_DIR/$TERMINAL_RUNTIME_GENERATION_FILE" ] \
+    && [ ! -f "$APP_DIR.rollback/$TERMINAL_RUNTIME_GENERATION_FILE" ] \
+    && [ -f "/home/matrix/home/system/terminal-migration-journal.json" ]; then
+    if ! /opt/matrix/bin/matrix-terminal-runtime --rollback; then
+      log "ERROR: terminal migration rollback failed while candidate code was available"
+      return 1
+    fi
+  fi
+  if [ "$has_app_rollback" = true ] && [ -d "$APP_DIR" ]; then
+    sudo mkdir -p "$STAGING_DIR"
+    sudo chown matrix:matrix "$STAGING_DIR"
+    sudo mv "$APP_DIR" "$STAGING_DIR/failed-$(date +%s)"
+  fi
+  if [ "$has_app_rollback" = true ]; then
+    sudo mv "$APP_DIR.rollback" "$APP_DIR"
+    sudo chown -R matrix:matrix "$APP_DIR"
+  fi
+  if [ "$restore_release_metadata" = true ] && [ "$has_app_rollback" = true ]; then
+    restore_rollback_release_metadata || {
+      log "ERROR: rollback release metadata restore failed"
+      return 1
+    }
+  fi
+  restore_update_transaction || {
+    log "ERROR: update transaction artifact restore failed"
+    return 1
+  }
+  if [ -f "$APP_DIR/$TERMINAL_RUNTIME_GENERATION_FILE" ]; then
+    activate_terminal_runtime_generation "$(cat "$APP_DIR/$TERMINAL_RUNTIME_GENERATION_FILE")"
+  fi
+  cleanup_terminal_runtime_generations || log "WARN: terminal generation cleanup remains above cap after rollback"
+  sudo systemctl start matrix-terminal-runtime || true
+  sudo systemctl start matrix-gateway matrix-shell
+  sudo systemctl start --no-block matrix-symphony || true
+  local healthy=false
+  for _ in $(seq 1 18); do
+    if curl --fail --silent --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; then
+      healthy=true; break
+    fi
+    sleep 5
+  done
+  if [ "$healthy" = true ]; then
+    cleanup_update_transaction
+    log "Rollback complete (now at $(current_version))"
+  else
+    log "ERROR: rollback health check failed — services may be down"
+    return 1
+  fi
+}

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -125,6 +125,9 @@ chmod -R g+rwX "$STAGE_DIR/runtime/node/lib/node_modules" "$STAGE_DIR/runtime/no
 find "$STAGE_DIR/runtime/node/lib/node_modules" "$STAGE_DIR/runtime/node/bin" -type d -exec chmod g+s {} +
 
 cp -a "$ROOT_DIR/distro/customer-vps/host-bin/." "$STAGE_DIR/bin/"
+node "$ROOT_DIR/scripts/inline-sync-agent-recovery.mjs" \
+  "$STAGE_DIR/bin/matrix-sync-agent" \
+  "$STAGE_DIR/bin/matrix-sync-agent-recovery"
 cp -a "$ROOT_DIR/distro/customer-vps/systemd/." "$STAGE_DIR/systemd/"
 cp -a "$ROOT_DIR/distro/customer-vps/systemd-user/." "$STAGE_DIR/user-systemd/"
 # The bundle is usually extracted as root:root during in-place upgrades, while

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -45,6 +45,7 @@ pnpm --filter '@matrix-os/scope-runtime' build
 pnpm --filter '@matrix-os/gateway' build
 mkdir -p "$ROOT_DIR/packages/gateway/dist/app-runtime"
 cp -a "$ROOT_DIR/packages/gateway/src/app-runtime/"*.html "$ROOT_DIR/packages/gateway/dist/app-runtime/"
+node --import=tsx "$ROOT_DIR/scripts/smoke-gateway-production-loader.mjs"
 : "${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:?set NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY before building the customer host bundle}"
 # In-app auth routes; defaults keep Clerk cross-links off the hosted Account
 # Portal (accounts.matrix-os.com) on every VPS shell.

--- a/scripts/inline-sync-agent-recovery.mjs
+++ b/scripts/inline-sync-agent-recovery.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+
+const [agentPath, recoveryLibraryPath] = process.argv.slice(2);
+if (!agentPath || !recoveryLibraryPath) {
+  throw new Error("usage: inline-sync-agent-recovery.mjs <agent> <recovery-library>");
+}
+
+const loaderPattern = /# BEGIN update recovery library loader[\s\S]*?# END update recovery library loader/;
+const agent = await readFile(agentPath, "utf8");
+const recoveryLibrary = (await readFile(recoveryLibraryPath, "utf8"))
+  .replace(/^#![^\n]*\n/, "")
+  .trim();
+const matches = agent.match(new RegExp(loaderPattern.source, "g"));
+if (matches?.length !== 1 || recoveryLibrary.length === 0) {
+  throw new Error("sync-agent recovery source is invalid");
+}
+
+const expanded = agent.replace(
+  loaderPattern,
+  `# BEGIN inlined update recovery library\n${recoveryLibrary}\n# END inlined update recovery library`,
+);
+await writeFile(agentPath, expanded, "utf8");

--- a/scripts/smoke-gateway-production-loader.mjs
+++ b/scripts/smoke-gateway-production-loader.mjs
@@ -1,0 +1,5 @@
+await import("../packages/gateway/dist/server.js");
+await import("@matrix-os/terminal-runtime");
+await import("@matrix-os/terminal-runtime/user-systemd-capacity");
+
+console.log("Gateway production workspace imports resolved");

--- a/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
+++ b/tests/deploy/customer-vps/user-systemd-terminal-runtime.test.ts
@@ -153,10 +153,10 @@ describe("customer VPS user-systemd terminal runtime", () => {
   });
 
   it("updates and rolls back the current generation without stopping user terminal units", () => {
-    const updater = readFileSync(
-      join(root, "distro/customer-vps/host-bin/matrix-sync-agent"),
-      "utf8",
-    );
+    const updater = [
+      readFileSync(join(root, "distro/customer-vps/host-bin/matrix-sync-agent"), "utf8"),
+      readFileSync(join(root, "distro/customer-vps/host-bin/matrix-sync-agent-recovery"), "utf8"),
+    ].join("\n");
     const generationGc = readFileSync(
       join(root, "distro/customer-vps/host-bin/matrix-terminal-generation-gc.py"),
       "utf8",
@@ -190,10 +190,10 @@ describe("customer VPS user-systemd terminal runtime", () => {
   });
 
   it("treats host replacement and migration as one recoverable update transaction", () => {
-    const updater = readFileSync(
-      join(root, "distro/customer-vps/host-bin/matrix-sync-agent"),
-      "utf8",
-    );
+    const updater = [
+      readFileSync(join(root, "distro/customer-vps/host-bin/matrix-sync-agent"), "utf8"),
+      readFileSync(join(root, "distro/customer-vps/host-bin/matrix-sync-agent-recovery"), "utf8"),
+    ].join("\n");
     const prepare = updater.indexOf('prepare_update_transaction "$extract_dir"');
     const seal = updater.indexOf("seal_update_transaction", prepare);
     const stop = updater.indexOf("if ! stop_runtime_services; then", seal);

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -79,113 +79,6 @@ function runSyncAgentFunction(source: string, invocation: string, setup: string)
   });
 }
 
-function syncAgentHarnessSource(): string {
-  const root = process.cwd();
-  const syncAgent = readFileSync(
-    join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'),
-    'utf8',
-  );
-  return syncAgent
-    .slice(0, syncAgent.indexOf('# ── Main loop'))
-    .replace('source /opt/matrix/env/host.env', ':')
-    .replace('readonly APP_DIR="/opt/matrix/app"', 'readonly APP_DIR="$TEST_ROOT/app"')
-    .replace('readonly STAGING_DIR="/opt/matrix/staging"', 'readonly STAGING_DIR="$TEST_ROOT/staging"')
-    .replace('readonly BIN_DIR="/opt/matrix/bin"', 'readonly BIN_DIR="$TEST_ROOT/bin"')
-    .replace('readonly RELEASE_FILE="/opt/matrix/release.json"', 'readonly RELEASE_FILE="$TEST_ROOT/release.json"')
-    .replace(
-      'readonly RELEASE_ROLLBACK_FILE="/opt/matrix/release.json.rollback"',
-      'readonly RELEASE_ROLLBACK_FILE="$TEST_ROOT/release.json.rollback"',
-    )
-    .replace(
-      'readonly TERMINAL_RUNTIME_ROOT="/opt/matrix/terminal-runtime"',
-      'readonly TERMINAL_RUNTIME_ROOT="$TEST_ROOT/terminal-runtime"',
-    );
-}
-
-function runInterruptedLegacyUpdateRecovery(options: {
-  installedReleaseVersion: string;
-  rollbackAppVersion: string;
-  rollbackStatus?: number;
-}) {
-  const root = process.cwd();
-  const tempDir = mkdtempSync(join(tmpdir(), 'matrix-interrupted-update-'));
-  const appDir = join(tempDir, 'app');
-  const rollbackDir = `${appDir}.rollback`;
-  const stagingDir = join(tempDir, 'staging');
-  mkdirSync(appDir, { recursive: true });
-  mkdirSync(rollbackDir, { recursive: true });
-  mkdirSync(stagingDir, { recursive: true });
-  writeFileSync(join(appDir, 'BUNDLE_VERSION'), 'v2026.09.11-pr-test\n');
-  writeFileSync(join(rollbackDir, 'BUNDLE_VERSION'), `${options.rollbackAppVersion}\n`);
-  writeFileSync(
-    join(tempDir, 'release.json'),
-    `${JSON.stringify({ version: options.installedReleaseVersion })}\n`,
-  );
-  writeFileSync(join(stagingDir, 'update-phase'), 'health\n');
-
-  const functionDefinitions = syncAgentHarnessSource();
-  const invocation = `
-do_rollback() { printf 'rollback:%s\\n' "${'$'}{1:-true}"; return "${'$'}{ROLLBACK_STATUS:-0}"; }
-write_update_error() { printf 'error:%s:%s\\n' "${'$'}1" "${'$'}{3:-}"; }
-recover_interrupted_update
-`;
-
-  try {
-    return spawnSync('bash', ['-c', `${functionDefinitions}\n${invocation}`], {
-      cwd: root,
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        TEST_ROOT: tempDir,
-        ROLLBACK_STATUS: String(options.rollbackStatus ?? 0),
-      },
-    });
-  } finally {
-    rmSync(tempDir, { recursive: true, force: true });
-  }
-}
-
-function runLegacyManualRollback() {
-  const root = process.cwd();
-  const tempDir = mkdtempSync(join(tmpdir(), 'matrix-manual-rollback-'));
-  const appDir = join(tempDir, 'app');
-  const rollbackDir = `${appDir}.rollback`;
-  mkdirSync(appDir, { recursive: true });
-  mkdirSync(rollbackDir, { recursive: true });
-  mkdirSync(join(tempDir, 'staging'), { recursive: true });
-  writeFileSync(join(appDir, 'BUNDLE_VERSION'), 'v2026.09.11-pr-test\n');
-  writeFileSync(join(rollbackDir, 'BUNDLE_VERSION'), 'v2026.09.08-1195\n');
-  writeFileSync(
-    join(tempDir, 'release.json'),
-    `${JSON.stringify({ version: 'v2026.09.08-1195' })}\n`,
-  );
-  const invocation = `
-stop_runtime_services() { :; }
-activate_terminal_runtime_generation() { :; }
-cleanup_terminal_runtime_generations() { :; }
-sudo() {
-  case "${'$'}1" in
-    chown|systemctl) return 0 ;;
-    *) "${'$'}@" ;;
-  esac
-}
-curl() { :; }
-do_rollback true
-printf 'active-version:'
-current_version
-`;
-
-  try {
-    return spawnSync('bash', ['-c', `${syncAgentHarnessSource()}\n${invocation}`], {
-      cwd: root,
-      encoding: 'utf8',
-      env: { ...process.env, TEST_ROOT: tempDir },
-    });
-  } finally {
-    rmSync(tempDir, { recursive: true, force: true });
-  }
-}
-
 describe('customer VPS host bundle', () => {
   it('build script packages the systemd entrypoint binaries', () => {
     const root = process.cwd();
@@ -229,32 +122,6 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain('matrix-messaging-health');
     expect(script).toContain('"$STAGE_DIR/runtime/node/bin/gh"');
     expect(script).toContain('bin app runtime systemd user-systemd terminal-runtime release.json');
-  });
-
-  it('smoke-tests the production gateway loader used by the host launcher', () => {
-    const root = process.cwd();
-    const buildScript = readFileSync(join(root, 'scripts/build-host-bundle.sh'), 'utf8');
-    const launcher = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-gateway'), 'utf8');
-    const smokePath = join(root, 'scripts/smoke-gateway-production-loader.mjs');
-    const smoke = readFileSync(smokePath, 'utf8');
-
-    expect(launcher).toContain(
-      '"$NODE_BIN" --import=tsx "$APP_DIR/packages/gateway/dist/main.js" &',
-    );
-    expect(buildScript).toContain(
-      'node --import=tsx "$ROOT_DIR/scripts/smoke-gateway-production-loader.mjs"',
-    );
-    expect(smoke).toContain('await import("../packages/gateway/dist/server.js")');
-    expect(smoke).toContain('await import("@matrix-os/terminal-runtime")');
-    expect(smoke).toContain(
-      'await import("@matrix-os/terminal-runtime/user-systemd-capacity")',
-    );
-
-    const result = spawnSync('node', ['--import=tsx', smokePath], {
-      cwd: root,
-      encoding: 'utf8',
-    });
-    expect(result.status, result.stderr || result.stdout).toBe(0);
   });
 
   it('pins, verifies, smoke-tests, and packages the configured Zellij binary', () => {
@@ -1529,6 +1396,10 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
   it('sync agent persists bounded errors for destructive update phase failures', () => {
     const root = process.cwd();
     const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
+    const recoveryLibrary = readFileSync(
+      join(root, 'distro/customer-vps/host-bin/matrix-sync-agent-recovery'),
+      'utf8',
+    );
 
     expect(syncAgent).toContain('write_update_error "checksum_mismatch"');
     expect(syncAgent).toContain('write_update_error "bundle_extract_failed"');
@@ -1541,7 +1412,7 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(syncAgent).toContain('verification_error_code="post_install_runtime_version_mismatch"');
     expect(syncAgent).toContain('write_update_error "post_install_rollback_failed"');
     expect(syncAgent).toContain('write_update_error "apply_failed"');
-    expect(syncAgent).toContain('write_update_error "apply_interrupted"');
+    expect(recoveryLibrary).toContain('write_update_error "apply_interrupted"');
     expect(syncAgent).toContain('temp="$(mktemp "$APP_DIR/.update-error.json.XXXXXX")" || return 1');
     expect(syncAgent).toContain('python3 - "$temp" "$code" "$message" "$version" "$available_kb" "$required_kb"');
     expect(syncAgent).toContain('if ! mv -fT "$temp" "$UPDATE_ERROR_MARKER"; then');
@@ -1572,48 +1443,6 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(healthFailure).toBeGreaterThan(-1);
     expect(healthRollback).toBeGreaterThan(healthFailure);
     expect(durableHealthError).toBeGreaterThan(healthRollback);
-  });
-
-  it('rolls back an interrupted legacy update when installed metadata still identifies the rollback app', () => {
-    const result = runInterruptedLegacyUpdateRecovery({
-      installedReleaseVersion: 'v2026.09.08-1195',
-      rollbackAppVersion: 'v2026.09.08-1195',
-    });
-
-    expect(result.status, result.stderr || result.stdout).toBe(0);
-    expect(result.stdout).toContain('rollback:false');
-    expect(result.stdout).toContain('error:apply_interrupted:v2026.09.11-pr-test');
-  });
-
-  it('fails closed when interrupted legacy update metadata does not identify the rollback app', () => {
-    const result = runInterruptedLegacyUpdateRecovery({
-      installedReleaseVersion: 'v2026.09.07-unrelated',
-      rollbackAppVersion: 'v2026.09.08-1195',
-    });
-
-    expect(result.status, result.stderr || result.stdout).toBe(0);
-    expect(result.stdout).not.toContain('rollback:');
-    expect(result.stdout).toContain('error:post_install_rollback_failed:v2026.09.11-pr-test');
-  });
-
-  it('persists a bounded recovery error when interrupted legacy rollback fails', () => {
-    const result = runInterruptedLegacyUpdateRecovery({
-      installedReleaseVersion: 'v2026.09.08-1195',
-      rollbackAppVersion: 'v2026.09.08-1195',
-      rollbackStatus: 1,
-    });
-
-    expect(result.status, result.stderr || result.stdout).toBe(0);
-    expect(result.stdout).toContain('rollback:false');
-    expect(result.stdout).toContain('error:post_install_rollback_failed:v2026.09.11-pr-test');
-  });
-
-  it('allows manual rollback when current release metadata already identifies the rollback app', () => {
-    const result = runLegacyManualRollback();
-
-    expect(result.status, result.stderr || result.stdout).toBe(0);
-    expect(result.stdout).toContain('Installed release metadata already identifies the rollback app');
-    expect(result.stdout).toContain('active-version:v2026.09.08-1195');
   });
 
   it('sync agent refuses to replace the app until runtime services are confirmed stopped', () => {
@@ -1875,13 +1704,15 @@ json_field() { python3 -c "import json,sys; print(json.load(sys.stdin).get(sys.a
     expect(syncAgent).toContain('sudo rm -f "$ROLLBACK_TRIGGER"');
     expect(syncAgent).toContain('return 0');
     expect(syncAgent).toContain('for _ in $(seq 1 18); do');
-    expect(syncAgent).toContain('sudo mv "$APP_DIR" "$STAGING_DIR/failed-$(date +%s)"');
-    expect(syncAgent).toContain('sudo mv "$APP_DIR.rollback" "$APP_DIR"');
   });
 
   it('publishes installed release metadata only after the candidate app passes health', () => {
     const root = process.cwd();
     const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
+    const recoveryLibrary = readFileSync(
+      join(root, 'distro/customer-vps/host-bin/matrix-sync-agent-recovery'),
+      'utf8',
+    );
 
     const stageFunction = syncAgent.indexOf('stage_release_metadata()');
     const stagedInstall = syncAgent.indexOf(
@@ -1902,7 +1733,7 @@ json_field() { python3 -c "import json,sys; print(json.load(sys.stdin).get(sys.a
       'sudo install -o root -g matrix -m 0644 "$extract_dir/release.json" "$RELEASE_FILE"',
     );
     expect(syncAgent).toContain('write_update_error "post_install_release_metadata_failed"');
-    expect(syncAgent).toContain('rollback_release_metadata_is_ready "$APP_DIR.rollback"');
+    expect(recoveryLibrary).toContain('rollback_release_metadata_is_ready "$APP_DIR.rollback"');
     expect(syncAgent).toContain('restore_rollback_release_metadata');
   });
 

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -79,6 +79,113 @@ function runSyncAgentFunction(source: string, invocation: string, setup: string)
   });
 }
 
+function syncAgentHarnessSource(): string {
+  const root = process.cwd();
+  const syncAgent = readFileSync(
+    join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'),
+    'utf8',
+  );
+  return syncAgent
+    .slice(0, syncAgent.indexOf('# ── Main loop'))
+    .replace('source /opt/matrix/env/host.env', ':')
+    .replace('readonly APP_DIR="/opt/matrix/app"', 'readonly APP_DIR="$TEST_ROOT/app"')
+    .replace('readonly STAGING_DIR="/opt/matrix/staging"', 'readonly STAGING_DIR="$TEST_ROOT/staging"')
+    .replace('readonly BIN_DIR="/opt/matrix/bin"', 'readonly BIN_DIR="$TEST_ROOT/bin"')
+    .replace('readonly RELEASE_FILE="/opt/matrix/release.json"', 'readonly RELEASE_FILE="$TEST_ROOT/release.json"')
+    .replace(
+      'readonly RELEASE_ROLLBACK_FILE="/opt/matrix/release.json.rollback"',
+      'readonly RELEASE_ROLLBACK_FILE="$TEST_ROOT/release.json.rollback"',
+    )
+    .replace(
+      'readonly TERMINAL_RUNTIME_ROOT="/opt/matrix/terminal-runtime"',
+      'readonly TERMINAL_RUNTIME_ROOT="$TEST_ROOT/terminal-runtime"',
+    );
+}
+
+function runInterruptedLegacyUpdateRecovery(options: {
+  installedReleaseVersion: string;
+  rollbackAppVersion: string;
+  rollbackStatus?: number;
+}) {
+  const root = process.cwd();
+  const tempDir = mkdtempSync(join(tmpdir(), 'matrix-interrupted-update-'));
+  const appDir = join(tempDir, 'app');
+  const rollbackDir = `${appDir}.rollback`;
+  const stagingDir = join(tempDir, 'staging');
+  mkdirSync(appDir, { recursive: true });
+  mkdirSync(rollbackDir, { recursive: true });
+  mkdirSync(stagingDir, { recursive: true });
+  writeFileSync(join(appDir, 'BUNDLE_VERSION'), 'v2026.09.11-pr-test\n');
+  writeFileSync(join(rollbackDir, 'BUNDLE_VERSION'), `${options.rollbackAppVersion}\n`);
+  writeFileSync(
+    join(tempDir, 'release.json'),
+    `${JSON.stringify({ version: options.installedReleaseVersion })}\n`,
+  );
+  writeFileSync(join(stagingDir, 'update-phase'), 'health\n');
+
+  const functionDefinitions = syncAgentHarnessSource();
+  const invocation = `
+do_rollback() { printf 'rollback:%s\\n' "${'$'}{1:-true}"; return "${'$'}{ROLLBACK_STATUS:-0}"; }
+write_update_error() { printf 'error:%s:%s\\n' "${'$'}1" "${'$'}{3:-}"; }
+recover_interrupted_update
+`;
+
+  try {
+    return spawnSync('bash', ['-c', `${functionDefinitions}\n${invocation}`], {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        TEST_ROOT: tempDir,
+        ROLLBACK_STATUS: String(options.rollbackStatus ?? 0),
+      },
+    });
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function runLegacyManualRollback() {
+  const root = process.cwd();
+  const tempDir = mkdtempSync(join(tmpdir(), 'matrix-manual-rollback-'));
+  const appDir = join(tempDir, 'app');
+  const rollbackDir = `${appDir}.rollback`;
+  mkdirSync(appDir, { recursive: true });
+  mkdirSync(rollbackDir, { recursive: true });
+  mkdirSync(join(tempDir, 'staging'), { recursive: true });
+  writeFileSync(join(appDir, 'BUNDLE_VERSION'), 'v2026.09.11-pr-test\n');
+  writeFileSync(join(rollbackDir, 'BUNDLE_VERSION'), 'v2026.09.08-1195\n');
+  writeFileSync(
+    join(tempDir, 'release.json'),
+    `${JSON.stringify({ version: 'v2026.09.08-1195' })}\n`,
+  );
+  const invocation = `
+stop_runtime_services() { :; }
+activate_terminal_runtime_generation() { :; }
+cleanup_terminal_runtime_generations() { :; }
+sudo() {
+  case "${'$'}1" in
+    chown|systemctl) return 0 ;;
+    *) "${'$'}@" ;;
+  esac
+}
+curl() { :; }
+do_rollback true
+printf 'active-version:'
+current_version
+`;
+
+  try {
+    return spawnSync('bash', ['-c', `${syncAgentHarnessSource()}\n${invocation}`], {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, TEST_ROOT: tempDir },
+    });
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 describe('customer VPS host bundle', () => {
   it('build script packages the systemd entrypoint binaries', () => {
     const root = process.cwd();
@@ -122,6 +229,32 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain('matrix-messaging-health');
     expect(script).toContain('"$STAGE_DIR/runtime/node/bin/gh"');
     expect(script).toContain('bin app runtime systemd user-systemd terminal-runtime release.json');
+  });
+
+  it('smoke-tests the production gateway loader used by the host launcher', () => {
+    const root = process.cwd();
+    const buildScript = readFileSync(join(root, 'scripts/build-host-bundle.sh'), 'utf8');
+    const launcher = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-gateway'), 'utf8');
+    const smokePath = join(root, 'scripts/smoke-gateway-production-loader.mjs');
+    const smoke = readFileSync(smokePath, 'utf8');
+
+    expect(launcher).toContain(
+      '"$NODE_BIN" --import=tsx "$APP_DIR/packages/gateway/dist/main.js" &',
+    );
+    expect(buildScript).toContain(
+      'node --import=tsx "$ROOT_DIR/scripts/smoke-gateway-production-loader.mjs"',
+    );
+    expect(smoke).toContain('await import("../packages/gateway/dist/server.js")');
+    expect(smoke).toContain('await import("@matrix-os/terminal-runtime")');
+    expect(smoke).toContain(
+      'await import("@matrix-os/terminal-runtime/user-systemd-capacity")',
+    );
+
+    const result = spawnSync('node', ['--import=tsx', smokePath], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    expect(result.status, result.stderr || result.stdout).toBe(0);
   });
 
   it('pins, verifies, smoke-tests, and packages the configured Zellij binary', () => {
@@ -1439,6 +1572,48 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     expect(healthFailure).toBeGreaterThan(-1);
     expect(healthRollback).toBeGreaterThan(healthFailure);
     expect(durableHealthError).toBeGreaterThan(healthRollback);
+  });
+
+  it('rolls back an interrupted legacy update when installed metadata still identifies the rollback app', () => {
+    const result = runInterruptedLegacyUpdateRecovery({
+      installedReleaseVersion: 'v2026.09.08-1195',
+      rollbackAppVersion: 'v2026.09.08-1195',
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toContain('rollback:false');
+    expect(result.stdout).toContain('error:apply_interrupted:v2026.09.11-pr-test');
+  });
+
+  it('fails closed when interrupted legacy update metadata does not identify the rollback app', () => {
+    const result = runInterruptedLegacyUpdateRecovery({
+      installedReleaseVersion: 'v2026.09.07-unrelated',
+      rollbackAppVersion: 'v2026.09.08-1195',
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).not.toContain('rollback:');
+    expect(result.stdout).toContain('error:post_install_rollback_failed:v2026.09.11-pr-test');
+  });
+
+  it('persists a bounded recovery error when interrupted legacy rollback fails', () => {
+    const result = runInterruptedLegacyUpdateRecovery({
+      installedReleaseVersion: 'v2026.09.08-1195',
+      rollbackAppVersion: 'v2026.09.08-1195',
+      rollbackStatus: 1,
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toContain('rollback:false');
+    expect(result.stdout).toContain('error:post_install_rollback_failed:v2026.09.11-pr-test');
+  });
+
+  it('allows manual rollback when current release metadata already identifies the rollback app', () => {
+    const result = runLegacyManualRollback();
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toContain('Installed release metadata already identifies the rollback app');
+    expect(result.stdout).toContain('active-version:v2026.09.08-1195');
   });
 
   it('sync agent refuses to replace the app until runtime services are confirmed stopped', () => {

--- a/tests/platform/customer-vps-runtime-loader.test.ts
+++ b/tests/platform/customer-vps-runtime-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
@@ -33,6 +33,13 @@ describe('customer VPS production runtime loader', () => {
       },
     );
     expect(build.status, build.stderr || build.stdout).toBe(0);
+
+    const sourceAppRuntime = join(root, 'packages/gateway/src/app-runtime');
+    const builtAppRuntime = join(root, 'packages/gateway/dist/app-runtime');
+    mkdirSync(builtAppRuntime, { recursive: true });
+    for (const name of readdirSync(sourceAppRuntime).filter((entry) => entry.endsWith('.html'))) {
+      copyFileSync(join(sourceAppRuntime, name), join(builtAppRuntime, name));
+    }
 
     const result = spawnSync('node', ['--import=tsx', smokePath], {
       cwd: root,

--- a/tests/platform/customer-vps-runtime-loader.test.ts
+++ b/tests/platform/customer-vps-runtime-loader.test.ts
@@ -23,10 +23,22 @@ describe('customer VPS production runtime loader', () => {
       'await import("@matrix-os/terminal-runtime/user-systemd-capacity")',
     );
 
+    const build = spawnSync(
+      'pnpm',
+      ['--filter', '@matrix-os/gateway', 'build'],
+      {
+        cwd: root,
+        encoding: 'utf8',
+        timeout: 120_000,
+      },
+    );
+    expect(build.status, build.stderr || build.stdout).toBe(0);
+
     const result = spawnSync('node', ['--import=tsx', smokePath], {
       cwd: root,
       encoding: 'utf8',
+      timeout: 30_000,
     });
     expect(result.status, result.stderr || result.stdout).toBe(0);
-  });
+  }, 120_000);
 });

--- a/tests/platform/customer-vps-runtime-loader.test.ts
+++ b/tests/platform/customer-vps-runtime-loader.test.ts
@@ -47,5 +47,5 @@ describe('customer VPS production runtime loader', () => {
       timeout: 30_000,
     });
     expect(result.status, result.stderr || result.stdout).toBe(0);
-  }, 120_000);
+  }, 180_000);
 });

--- a/tests/platform/customer-vps-runtime-loader.test.ts
+++ b/tests/platform/customer-vps-runtime-loader.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+describe('customer VPS production runtime loader', () => {
+  it('loads the compiled gateway with the package-aware production launcher', () => {
+    const root = process.cwd();
+    const buildScript = readFileSync(join(root, 'scripts/build-host-bundle.sh'), 'utf8');
+    const launcher = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-gateway'), 'utf8');
+    const smokePath = join(root, 'scripts/smoke-gateway-production-loader.mjs');
+    const smoke = readFileSync(smokePath, 'utf8');
+
+    expect(launcher).toContain(
+      '"$NODE_BIN" --import=tsx "$APP_DIR/packages/gateway/dist/main.js" &',
+    );
+    expect(buildScript).toContain(
+      'node --import=tsx "$ROOT_DIR/scripts/smoke-gateway-production-loader.mjs"',
+    );
+    expect(smoke).toContain('await import("../packages/gateway/dist/server.js")');
+    expect(smoke).toContain('await import("@matrix-os/terminal-runtime")');
+    expect(smoke).toContain(
+      'await import("@matrix-os/terminal-runtime/user-systemd-capacity")',
+    );
+
+    const result = spawnSync('node', ['--import=tsx', smokePath], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+  });
+});

--- a/tests/platform/customer-vps-update-recovery.test.ts
+++ b/tests/platform/customer-vps-update-recovery.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const SYNC_AGENT_PATH = 'distro/customer-vps/host-bin/matrix-sync-agent';
+const RECOVERY_LIBRARY_PATH = 'distro/customer-vps/host-bin/matrix-sync-agent-recovery';
+
+function syncAgentHarnessSource(): string {
+  const root = process.cwd();
+  const syncAgent = readFileSync(join(root, SYNC_AGENT_PATH), 'utf8');
+  const recoveryLibrary = readFileSync(join(root, RECOVERY_LIBRARY_PATH), 'utf8');
+  return syncAgent
+    .slice(0, syncAgent.indexOf('# ── Main loop'))
+    .replace('source /opt/matrix/env/host.env', ':')
+    .replace(
+      /# BEGIN update recovery library loader[\s\S]*?# END update recovery library loader/,
+      recoveryLibrary,
+    )
+    .replace('readonly APP_DIR="/opt/matrix/app"', 'readonly APP_DIR="$TEST_ROOT/app"')
+    .replace('readonly STAGING_DIR="/opt/matrix/staging"', 'readonly STAGING_DIR="$TEST_ROOT/staging"')
+    .replace('readonly BIN_DIR="/opt/matrix/bin"', 'readonly BIN_DIR="$TEST_ROOT/bin"')
+    .replace('readonly RELEASE_FILE="/opt/matrix/release.json"', 'readonly RELEASE_FILE="$TEST_ROOT/release.json"')
+    .replace(
+      'readonly RELEASE_ROLLBACK_FILE="/opt/matrix/release.json.rollback"',
+      'readonly RELEASE_ROLLBACK_FILE="$TEST_ROOT/release.json.rollback"',
+    )
+    .replace(
+      'readonly TERMINAL_RUNTIME_ROOT="/opt/matrix/terminal-runtime"',
+      'readonly TERMINAL_RUNTIME_ROOT="$TEST_ROOT/terminal-runtime"',
+    );
+}
+
+function runInterruptedLegacyUpdateRecovery(options: {
+  installedReleaseVersion: string;
+  rollbackAppVersion: string;
+  rollbackStatus?: number;
+}) {
+  const root = process.cwd();
+  const tempDir = mkdtempSync(join(tmpdir(), 'matrix-interrupted-update-'));
+  const appDir = join(tempDir, 'app');
+  const rollbackDir = `${appDir}.rollback`;
+  const stagingDir = join(tempDir, 'staging');
+  mkdirSync(appDir, { recursive: true });
+  mkdirSync(rollbackDir, { recursive: true });
+  mkdirSync(stagingDir, { recursive: true });
+  writeFileSync(join(appDir, 'BUNDLE_VERSION'), 'v2026.09.11-pr-test\n');
+  writeFileSync(join(rollbackDir, 'BUNDLE_VERSION'), `${options.rollbackAppVersion}\n`);
+  writeFileSync(
+    join(tempDir, 'release.json'),
+    `${JSON.stringify({ version: options.installedReleaseVersion })}\n`,
+  );
+  writeFileSync(join(stagingDir, 'update-phase'), 'health\n');
+
+  const invocation = `
+do_rollback() { printf 'rollback:%s\\n' "${'$'}{1:-true}"; return "${'$'}{ROLLBACK_STATUS:-0}"; }
+write_update_error() { printf 'error:%s:%s\\n' "${'$'}1" "${'$'}{3:-}"; }
+recover_interrupted_update
+`;
+
+  try {
+    return spawnSync('bash', ['-c', `${syncAgentHarnessSource()}\n${invocation}`], {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        TEST_ROOT: tempDir,
+        ROLLBACK_STATUS: String(options.rollbackStatus ?? 0),
+      },
+    });
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function runLegacyManualRollback() {
+  const root = process.cwd();
+  const tempDir = mkdtempSync(join(tmpdir(), 'matrix-manual-rollback-'));
+  const appDir = join(tempDir, 'app');
+  const rollbackDir = `${appDir}.rollback`;
+  mkdirSync(appDir, { recursive: true });
+  mkdirSync(rollbackDir, { recursive: true });
+  mkdirSync(join(tempDir, 'staging'), { recursive: true });
+  writeFileSync(join(appDir, 'BUNDLE_VERSION'), 'v2026.09.11-pr-test\n');
+  writeFileSync(join(rollbackDir, 'BUNDLE_VERSION'), 'v2026.09.08-1195\n');
+  writeFileSync(
+    join(tempDir, 'release.json'),
+    `${JSON.stringify({ version: 'v2026.09.08-1195' })}\n`,
+  );
+  const invocation = `
+stop_runtime_services() { :; }
+activate_terminal_runtime_generation() { :; }
+cleanup_terminal_runtime_generations() { :; }
+sudo() {
+  case "${'$'}1" in
+    chown|systemctl) return 0 ;;
+    *) "${'$'}@" ;;
+  esac
+}
+curl() { :; }
+do_rollback true
+printf 'active-version:'
+current_version
+`;
+
+  try {
+    return spawnSync('bash', ['-c', `${syncAgentHarnessSource()}\n${invocation}`], {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, TEST_ROOT: tempDir },
+    });
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+describe('customer VPS update recovery', () => {
+  it('keeps recovery and rollback behavior in a focused sourced library', () => {
+    const root = process.cwd();
+    const syncAgent = readFileSync(join(root, SYNC_AGENT_PATH), 'utf8');
+    const recoveryLibrary = readFileSync(join(root, RECOVERY_LIBRARY_PATH), 'utf8');
+    const buildScript = readFileSync(join(root, 'scripts/build-host-bundle.sh'), 'utf8');
+
+    expect(syncAgent).toContain('source "$BIN_DIR/matrix-sync-agent-recovery"');
+    expect(syncAgent).not.toContain('recover_interrupted_update() {');
+    expect(recoveryLibrary).toContain('recover_interrupted_update() {');
+    expect(recoveryLibrary).toContain('do_rollback() {');
+    expect(recoveryLibrary).toContain('sudo mv "$APP_DIR" "$STAGING_DIR/failed-$(date +%s)"');
+    expect(recoveryLibrary).toContain('sudo mv "$APP_DIR.rollback" "$APP_DIR"');
+    expect(buildScript).toContain('scripts/inline-sync-agent-recovery.mjs"');
+  });
+
+  it('inlines recovery into the shipped agent so legacy helper installation stays self-contained', () => {
+    const root = process.cwd();
+    const syncAgent = readFileSync(join(root, SYNC_AGENT_PATH), 'utf8');
+    const recoveryLibrary = readFileSync(join(root, RECOVERY_LIBRARY_PATH), 'utf8');
+    const tempDir = mkdtempSync(join(tmpdir(), 'matrix-recovery-inline-'));
+    const stagedAgent = join(tempDir, 'matrix-sync-agent');
+    const stagedLibrary = join(tempDir, 'matrix-sync-agent-recovery');
+    writeFileSync(stagedAgent, syncAgent);
+    writeFileSync(stagedLibrary, recoveryLibrary);
+
+    try {
+      const inline = spawnSync('node', [
+        join(root, 'scripts/inline-sync-agent-recovery.mjs'),
+        stagedAgent,
+        stagedLibrary,
+      ], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+      expect(inline.status, inline.stderr || inline.stdout).toBe(0);
+      const staged = readFileSync(stagedAgent, 'utf8');
+      expect(staged).toContain('recover_interrupted_update() {');
+      expect(staged).not.toContain('source "$BIN_DIR/matrix-sync-agent-recovery"');
+      const syntax = spawnSync('bash', ['-n', stagedAgent], { encoding: 'utf8' });
+      expect(syntax.status, syntax.stderr || syntax.stdout).toBe(0);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rolls back an interrupted legacy update when installed metadata identifies the rollback app', () => {
+    const result = runInterruptedLegacyUpdateRecovery({
+      installedReleaseVersion: 'v2026.09.08-1195',
+      rollbackAppVersion: 'v2026.09.08-1195',
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toContain('rollback:false');
+    expect(result.stdout).toContain('error:apply_interrupted:v2026.09.11-pr-test');
+  });
+
+  it('fails closed when interrupted legacy update metadata does not identify the rollback app', () => {
+    const result = runInterruptedLegacyUpdateRecovery({
+      installedReleaseVersion: 'v2026.09.07-unrelated',
+      rollbackAppVersion: 'v2026.09.08-1195',
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).not.toContain('rollback:');
+    expect(result.stdout).toContain('error:post_install_rollback_failed:v2026.09.11-pr-test');
+  });
+
+  it('persists a bounded recovery error when interrupted legacy rollback fails', () => {
+    const result = runInterruptedLegacyUpdateRecovery({
+      installedReleaseVersion: 'v2026.09.08-1195',
+      rollbackAppVersion: 'v2026.09.08-1195',
+      rollbackStatus: 1,
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toContain('rollback:false');
+    expect(result.stdout).toContain('error:post_install_rollback_failed:v2026.09.11-pr-test');
+  });
+
+  it('allows manual rollback when current release metadata identifies the rollback app', () => {
+    const result = runLegacyManualRollback();
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toContain('Installed release metadata already identifies the rollback app');
+    expect(result.stdout).toContain('active-version:v2026.09.08-1195');
+  });
+});

--- a/tests/platform/preview-vps-workflow.test.ts
+++ b/tests/platform/preview-vps-workflow.test.ts
@@ -100,6 +100,23 @@ afterEach(async () => {
 });
 
 describe('Preview VPS provisioning workflow', () => {
+  it('collects bounded updater diagnostics before an install timeout', () => {
+    const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
+    const deployStep = YAML.parse(workflow).jobs.deploy.steps.find(
+      (step: { name?: string }) => step.name === 'Deploy preview bundle to preview VPS',
+    ).run as string;
+
+    expect(deployStep).toContain('collect_preview_diagnostics()');
+    expect(deployStep).toContain('"/opt/matrix/app/.update-error.json"');
+    expect(deployStep).toContain('metadata.st_size > limit');
+    expect(deployStep).toContain('state["updateError"]');
+    expect(deployStep).toContain('state["updateVersion"]');
+    expect(deployStep).not.toContain('/usr/bin/journalctl');
+    expect(deployStep).toContain('collect_preview_diagnostics || true');
+    expect(deployStep.indexOf('collect_preview_diagnostics || true'))
+      .toBeLessThan(deployStep.indexOf('Timed out waiting for ${HANDLE}'));
+  });
+
   it('budgets the job for provisioning, bounded repair, and workflow overhead', () => {
     const workflow = YAML.parse(readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8'));
     const deploy = workflow.jobs.deploy;


### PR DESCRIPTION
## Summary
- run the compiled VPS gateway with the shipped `tsx` loader so workspace TypeScript exports resolve under production Node
- make host-bundle builds import the compiled gateway server graph before packaging
- recover interrupted first-hop stable upgrades when the old updater already replaced the app but had not committed release metadata
- allow a manual rollback to use the still-canonical installed release metadata when `release.json.rollback` was never created
- fail closed without moving app trees when release metadata does not identify the rollback app
- keep recovery/rollback in a focused source module while inlining it into the shipped updater so legacy installs remain self-contained
- make the production-loader regression self-contained on clean CI runners and emit only allowlisted updater state when disposable preview installs time out

## Tests
- `pnpm install --frozen-lockfile --offline`
- full TypeScript gate via the pinned `pnpm` subcommands (pass; `bun` is unavailable in this shell)
- `pnpm run check:patterns` (0 violations)
- gateway build plus compiled production-loader smoke (pass)
- 109 focused upgrade, recovery, preview-workflow, cloud-init, and terminal-runtime checks (pass)
- focused final loader/workflow suite after review fix: 7/7 (pass)
- [exact-final-head CI](https://github.com/HamedMP/matrix-os/actions/runs/34658414120): typecheck, pattern scan, production builds, all four unit shards, and E2E (pass)
- [fresh disposable VPS validation](https://github.com/HamedMP/matrix-os/actions/runs/34656430776): provisioned on stable `v2026.09.08-1195`, upgraded directly to immutable PR-only bundle `v2026.09.11-pr1634-34656430776-1-ac30e9b` in about 100 seconds, verified active-app/platform registration agreement, and observed the gateway restart-free for 15 minutes
- final commit `1bc412dee` changes only the test timeout margin and does not alter the validated bundle bytes
- `bash -n` and `git diff --check` (pass)

## Review/Monitoring
- Review range is frozen at `43c738869..1bc412dee` and current `main` remains `43c738869`.
- Greptile reports 5/5 on final head `1bc412dee`; both findings are fixed and both threads are resolved.
- Exact-final-head CI is green and the fresh stable-to-PR upgrade proof passed.
- The non-required `claude-review` integration exits before model invocation because its credential is unavailable (31 seconds, zero usage); it does not exercise this PR's code.
- The disposable preview remains available at https://app.matrix-os.com/vm/pr-1634 and will be deleted when the PR closes or by the 72-hour reaper.
- No customer release channel was promoted during validation.

## Invariants

### Source of truth
- `/opt/matrix/release.json` remains canonical for the installed committed release.
- `/opt/matrix/app.rollback/BUNDLE_VERSION` is accepted only when it exactly matches bounded, symlink-safe release metadata.

### Lock/transaction scope
- The existing single sync-agent service remains the update serialization boundary.
- Recovery validates metadata before stopping services or moving either app tree; no network call occurs inside rollback recovery.

### Acceptable orphan states
- Matching legacy interrupted state rolls back the app and records `apply_interrupted`.
- A rollback failure records `post_install_rollback_failed`.
- Missing, malformed, symlinked, or mismatched metadata fails closed and preserves both app trees for operator recovery.

### Auth source of truth
- No network or auth boundary changes. Existing platform-signed update triggering and host systemd privilege boundaries remain authoritative.

### Deferred scope
- First-hop updates started by a pre-transaction stable updater cannot reconstruct historical host-helper backups that the old updater never recorded. Candidate host wrappers remain backward-compatible with the rollback app; all later updates use the existing complete update transaction.
- No customer release channel is promoted by this PR or its live validation.
