### PR TITLE
fix(terminal): route emulator replies through zellij attachment

### DIFF
--- a/apps/mobile/__tests__/live-terminal-session.test.tsx
+++ b/apps/mobile/__tests__/live-terminal-session.test.tsx
@@ -1,6 +1,7 @@
 const mockConnect = jest.fn();
 const mockDetach = jest.fn();
 const mockSendInput = jest.fn(() => true);
+const mockSendBinary = jest.fn(() => true);
 const mockResize = jest.fn(() => true);
 const mockGatewayClient = {};
 const mockSurfaceWrite = jest.fn();
@@ -31,7 +32,10 @@ jest.mock("@/components/TerminalSurface", () => {
   const React = require("react");
   const { Pressable, Text, View } = require("react-native");
   return {
-    TerminalSurface: React.forwardRef((props: { onInput: (data: string) => void }, ref: React.Ref<unknown>) => {
+    TerminalSurface: React.forwardRef((props: {
+      onInput: (data: string) => void;
+      onBinary: (data: string) => void;
+    }, ref: React.Ref<unknown>) => {
       React.useImperativeHandle(ref, () => ({
         write: mockSurfaceWrite,
         clear: mockSurfaceClear,
@@ -48,6 +52,10 @@ jest.mock("@/components/TerminalSurface", () => {
           accessibilityLabel: "Type terminal input",
           onPress: () => props.onInput("a"),
         }, React.createElement(Text, null, "terminal")),
+        React.createElement(Pressable, {
+          accessibilityLabel: "Send terminal protocol reply",
+          onPress: () => props.onBinary("\x1b]10;?\x07"),
+        }, React.createElement(Text, null, "protocol")),
       );
     }),
   };
@@ -68,6 +76,7 @@ describe("live terminal session modal", () => {
     mockConnect.mockResolvedValue({
       detach: mockDetach,
       sendInput: mockSendInput,
+      sendBinary: mockSendBinary,
       resize: mockResize,
       close: jest.fn(),
     });
@@ -85,9 +94,11 @@ describe("live terminal session modal", () => {
     const options = mockConnect.mock.calls[0]?.[0] as {
       onMessage: (frame: { type: string; data?: string; ansi?: string; canonicalSize?: { cols: number; rows: number } }) => void;
     };
-    options.onMessage({ type: "attached", canonicalSize: { cols: 100, rows: 30 } });
-    options.onMessage({ type: "snapshot", ansi: "ready" });
-    options.onMessage({ type: "output", data: "\nhello" });
+    act(() => {
+      options.onMessage({ type: "attached", canonicalSize: { cols: 100, rows: 30 } });
+      options.onMessage({ type: "snapshot", ansi: "ready" });
+      options.onMessage({ type: "output", data: "\nhello" });
+    });
     expect(mockSurfaceClear).toHaveBeenCalled();
     expect(mockSurfaceResize).toHaveBeenCalledWith(100, 30);
     expect(mockSurfaceWrite).toHaveBeenCalledWith("ready");
@@ -95,6 +106,8 @@ describe("live terminal session modal", () => {
 
     fireEvent.press(screen.getByLabelText("Type terminal input"));
     expect(mockSendInput).toHaveBeenCalledWith("a");
+    fireEvent.press(screen.getByLabelText("Send terminal protocol reply"));
+    expect(mockSendBinary).toHaveBeenCalledWith("\x1b]10;?\x07");
 
     rendered.unmount();
     expect(mockDetach).toHaveBeenCalled();
@@ -102,6 +115,16 @@ describe("live terminal session modal", () => {
 
   it("stops showing an indefinite loader when the socket handshake never opens", async () => {
     jest.useFakeTimers();
+    mockConnect.mockImplementationOnce(async (options: { onStatus: (status: "open") => void }) => {
+      options.onStatus("open");
+      return {
+        detach: mockDetach,
+        sendInput: mockSendInput,
+        sendBinary: mockSendBinary,
+        resize: mockResize,
+        close: jest.fn(),
+      };
+    });
     render(<TerminalSessionScreen />);
 
     await waitFor(() => expect(mockConnect).toHaveBeenCalled());

--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -8,6 +8,12 @@ import {
 } from "../lib/terminal-client";
 import { jsonResponse } from "./mobile-shell-test-utils";
 
+// The terminal client does not exercise Markdown rendering. Keep this focused
+// React Native Jest suite from loading the ESM-only micromark implementation
+// re-exported by the shared contracts package.
+jest.mock("micromark", () => ({ micromark: jest.fn() }));
+jest.mock("micromark-extension-gfm", () => ({ gfm: jest.fn(), gfmHtml: jest.fn() }));
+
 const WORKSPACE_ID = "tws_00000000000000000000000000000001";
 const TAB_ID = "tt_00000000000000000000000000000001";
 const SESSION_ID = `${WORKSPACE_ID}:${TAB_ID}`;
@@ -98,7 +104,7 @@ describe("mobile terminal client", () => {
 
   it("builds token-authenticated terminal websocket URLs", () => {
     expect(buildTerminalWebSocketUrl("https://app.matrix-os.test/", SESSION_ID, "ws token")).toBe(
-      `wss://app.matrix-os.test/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=mobile&token=ws+token`,
+      `wss://app.matrix-os.test/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=mobile&inputCapability=binary-input-v1&token=ws+token`,
     );
     expect(isSafeSessionId(SESSION_ID)).toBe(true);
     expect(isSafeSessionId("../bad")).toBe(false);
@@ -134,6 +140,94 @@ describe("mobile terminal client", () => {
     expect((ws as unknown as MockWebSocket).closed).toBe(true);
   });
 
+  it("preserves binary emulator replies when the runtime advertises byte input", () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const connection = new MobileTerminalConnection(ws, {
+      sessionId: SESSION_ID,
+      onMessage: jest.fn(),
+    });
+
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({
+        type: "attached",
+        terminalRef: TERMINAL_REF,
+        canonicalSize: { cols: 80, rows: 24 },
+        revision: 1,
+        nextSeq: 0,
+        capabilities: ["binary-input-v1"],
+      }),
+    });
+
+    expect(connection.sendBinary("\x1b]10;?\x07\x80\xff")).toBe(true);
+    expect(JSON.parse((ws as unknown as MockWebSocket).sent.at(-1)!)).toEqual({
+      type: "binary",
+      terminalRef: TERMINAL_REF,
+      dataBase64: "G10xMDs/B4D/",
+    });
+    connection.close();
+  });
+
+  it("uses text input for emulator replies when connected to an older runtime", () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const connection = new MobileTerminalConnection(ws, {
+      sessionId: SESSION_ID,
+      onMessage: jest.fn(),
+    });
+
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({
+        type: "attached",
+        terminalRef: TERMINAL_REF,
+        canonicalSize: { cols: 80, rows: 24 },
+        revision: 1,
+        nextSeq: 0,
+      }),
+    });
+
+    expect(connection.sendBinary("\x1b]10;rgb:1111/2222/3333\x07")).toBe(true);
+    expect(JSON.parse((ws as unknown as MockWebSocket).sent.at(-1)!)).toEqual({
+      type: "input",
+      terminalRef: TERMINAL_REF,
+      data: "\x1b]10;rgb:1111/2222/3333\x07",
+    });
+    connection.close();
+  });
+
+  it("validates a complete binary reply before sending bounded chunks", () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const connection = new MobileTerminalConnection(ws, {
+      sessionId: SESSION_ID,
+      onMessage: jest.fn(),
+    });
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+    (ws as unknown as MockWebSocket).onmessage?.({
+      data: JSON.stringify({
+        type: "attached",
+        terminalRef: TERMINAL_REF,
+        canonicalSize: { cols: 80, rows: 24 },
+        revision: 1,
+        nextSeq: 0,
+        capabilities: ["binary-input-v1"],
+      }),
+    });
+    const before = (ws as unknown as MockWebSocket).sent.length;
+
+    expect(connection.sendBinary(`${"x".repeat(32_768)}\u{100}`)).toBe(false);
+    expect((ws as unknown as MockWebSocket).sent).toHaveLength(before);
+
+    expect(connection.sendBinary("x".repeat(70_000))).toBe(true);
+    const chunks = (ws as unknown as MockWebSocket).sent
+      .slice(before)
+      .map((value) => JSON.parse(value) as { type: string; dataBase64: string });
+    expect(chunks.map((frame) => atob(frame.dataBase64).length)).toEqual([32_768, 32_768, 4_464]);
+    connection.close();
+  });
+
   it("opens terminal sockets with browser-compatible query auth and native bearer headers", async () => {
     const webSocketMock = jest.fn().mockImplementation(() => new MockWebSocket());
     global.WebSocket = webSocketMock as unknown as typeof WebSocket;
@@ -148,7 +242,7 @@ describe("mobile terminal client", () => {
 
     expect(connection).toBeTruthy();
     expect(webSocketMock).toHaveBeenCalledWith(
-      `wss://app.matrix-os.test/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=mobile&token=ws-token`,
+      `wss://app.matrix-os.test/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=mobile&inputCapability=binary-input-v1&token=ws-token`,
       [],
       { headers: { Authorization: "Bearer clerk-token" } },
     );
@@ -168,7 +262,7 @@ describe("mobile terminal client", () => {
 
     expect(connection).toBeTruthy();
     expect(webSocketMock).toHaveBeenCalledWith(
-      `wss://app.matrix-os.test/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=mobile`,
+      `wss://app.matrix-os.test/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=mobile&inputCapability=binary-input-v1`,
       [],
       { headers: { Authorization: "Bearer clerk-token" } },
     );

--- a/apps/mobile/__tests__/terminal-surface.test.tsx
+++ b/apps/mobile/__tests__/terminal-surface.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react-native";
+
+const mockInjectJavaScript = jest.fn();
+
+jest.mock("react-native-webview", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    WebView: React.forwardRef((props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+      React.useImperativeHandle(ref, () => ({ injectJavaScript: mockInjectJavaScript }));
+      return React.createElement(View, { ...props, testID: "terminal-webview" });
+    }),
+  };
+});
+
+import { TerminalSurface } from "../components/TerminalSurface";
+
+describe("native mobile terminal surface", () => {
+  it("forwards xterm onBinary protocol bytes through the React Native bridge", () => {
+    const onBinary = jest.fn();
+    render(
+      <TerminalSurface
+        fontScale={1}
+        onInput={jest.fn()}
+        onBinary={onBinary}
+        onResize={jest.fn()}
+      />,
+    );
+
+    const webView = screen.getByTestId("terminal-webview");
+    expect(webView.props.source.html).toContain("term.onBinary(function (data)");
+
+    act(() => webView.props.onMessage({
+      nativeEvent: { data: JSON.stringify({ type: "binary", data: "\x1b]10;?\x07\x80\xff" }) },
+    }));
+
+    expect(onBinary).toHaveBeenCalledWith("\x1b]10;?\x07\x80\xff");
+  });
+});

--- a/apps/mobile/app/terminal-session/[session].tsx
+++ b/apps/mobile/app/terminal-session/[session].tsx
@@ -112,10 +112,6 @@ export default function TerminalSessionScreen() {
         },
         onStatus: (nextStatus) => {
           if (connectionAttemptRef.current !== attempt) return;
-          if (nextStatus === "open") {
-            clearHandshakeTimeout();
-            setStatus("attached");
-          }
           if (nextStatus === "closed") {
             clearHandshakeTimeout();
             setStatus((current) => current === "ended" || current === "error" ? current : "detached");
@@ -175,6 +171,14 @@ export default function TerminalSessionScreen() {
     }
   }, []);
 
+  const sendBinary = useCallback((data: string) => {
+    if (!data) return;
+    if (!connectionRef.current?.sendBinary(data)) {
+      setStatus("error");
+      setError("Terminal unavailable. Try again.");
+    }
+  }, []);
+
   const handleResize = useCallback((cols: number, rows: number) => {
     gridRef.current = { cols, rows };
     connectionRef.current?.resize(cols, rows);
@@ -196,6 +200,7 @@ export default function TerminalSessionScreen() {
           ref={surfaceRef}
           fontScale={fontScale}
           onInput={sendData}
+          onBinary={sendBinary}
           onResize={handleResize}
         />
 

--- a/apps/mobile/components/TerminalSurface.tsx
+++ b/apps/mobile/components/TerminalSurface.tsx
@@ -32,6 +32,8 @@ interface TerminalSurfaceProps {
   fontScale: number;
   /** Raw keystrokes typed directly into the emulator (hardware keyboard / tap). */
   onInput: (data: string) => void;
+  /** Byte-valued xterm protocol replies such as OSC and binary mouse reports. */
+  onBinary: (data: string) => void;
   /** Reports the fitted grid size whenever the surface lays out or resizes. */
   onResize: (cols: number, rows: number) => void;
   /** Cursor bottom edge in surface-local pixels; throttled by the emulator. */
@@ -159,6 +161,7 @@ function buildHtml(fontScale: number): string {
       doFit();
       window.addEventListener("resize", doFit);
       term.onData(function (data) { post({ type: "input", data: data }); });
+      term.onBinary(function (data) { post({ type: "binary", data: data }); });
 
       // Cursor bottom edge in page pixels so the RN side can lift the view
       // only as much as needed to keep typing visible above the keyboard.
@@ -213,7 +216,7 @@ function buildHtml(fontScale: number): string {
 }
 
 export const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurfaceProps>(
-  function TerminalSurface({ fontScale, onInput, onResize, onCursor }, ref) {
+  function TerminalSurface({ fontScale, onInput, onBinary, onResize, onCursor }, ref) {
     const webRef = useRef<WebView | null>(null);
     const readyRef = useRef(false);
     const pendingRef = useRef<string[]>([]);
@@ -286,6 +289,10 @@ export const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurface
           onInput(msg.data);
           return;
         }
+        if (msg.type === "binary" && typeof msg.data === "string") {
+          onBinary(msg.data);
+          return;
+        }
         if (msg.type === "resize" && typeof msg.cols === "number" && typeof msg.rows === "number") {
           onResize(msg.cols, msg.rows);
           return;
@@ -294,7 +301,7 @@ export const TerminalSurface = forwardRef<TerminalSurfaceHandle, TerminalSurface
           onCursor?.(msg.bottom);
         }
       },
-      [flush, onInput, onResize, onCursor],
+      [flush, onInput, onBinary, onResize, onCursor],
     );
 
     return (

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -645,6 +645,7 @@ export class GatewayClient {
     if (workspaceId) params.set("workspaceId", workspaceId);
     if (tabId) params.set("tabId", tabId);
     params.set("client", "mobile");
+    params.set("inputCapability", "binary-input-v1");
     if (typeof fromSeq === "number" && Number.isFinite(fromSeq)) params.set("fromSeq", String(fromSeq));
     if (token) params.set("token", token);
     const query = params.toString();

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -4,9 +4,11 @@ export { isSafeSessionId, parseTerminalSessions } from "@/lib/terminal-state";
 
 const WS_CONNECTING = 0;
 const WS_OPEN = 1;
+const TERMINAL_INPUT_CHUNK_CHARS = 32_768;
 
 export type TerminalClientFrame =
   | { type: "input"; terminalRef: TerminalRef; data: string }
+  | { type: "binary"; terminalRef: TerminalRef; dataBase64: string }
   | { type: "resize"; terminalRef: TerminalRef; mode: "soft"; size: { cols: number; rows: number } }
   | { type: "detach"; terminalRef: TerminalRef }
   | { type: "ping"; terminalRef: TerminalRef };
@@ -14,7 +16,7 @@ export type TerminalClientFrame =
 type TerminalRef = { workspaceId: string; tabId: string };
 
 export type TerminalServerFrame =
-  | { type: "attached"; terminalRef: TerminalRef; canonicalSize: { cols: number; rows: number }; revision: number; nextSeq: number }
+  | { type: "attached"; terminalRef: TerminalRef; canonicalSize: { cols: number; rows: number }; revision: number; nextSeq: number; capabilities?: string[] }
   | { type: "snapshot"; terminalRef: TerminalRef; ansi: string; seq: number; revision: number }
   | { type: "output"; terminalRef: TerminalRef; data: string; seq: number; revision: number }
   | { type: "replay-start"; fromSeq?: number; toSeq?: number }
@@ -72,6 +74,7 @@ export class MobileTerminalConnection {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
   private lastSeq: number;
+  private binaryInputSupported = false;
 
   constructor(
     private ws: WebSocket,
@@ -92,6 +95,7 @@ export class MobileTerminalConnection {
   }
 
   private bindSocket(ws: WebSocket): void {
+    this.binaryInputSupported = false;
     // The TerminalRef is supplied in the WS query; announce the viewport once open.
     ws.onopen = () => {
       if (this.ws !== ws || this.disposed) return;
@@ -108,6 +112,9 @@ export class MobileTerminalConnection {
       if (this.ws !== ws || this.disposed) return;
       const frame = parseTerminalServerFrame(event.data);
       if (frame) {
+        if (frame.type === "attached") {
+          this.binaryInputSupported = frame.capabilities?.includes("binary-input-v1") ?? false;
+        }
         if ((frame.type === "snapshot" || frame.type === "output") && typeof frame.seq === "number") {
           this.lastSeq = Math.max(this.lastSeq, frame.seq);
         }
@@ -131,6 +138,25 @@ export class MobileTerminalConnection {
 
   sendInput(data: string): boolean {
     return this.sendFrame({ type: "input", terminalRef: this.terminalRef, data });
+  }
+
+  sendBinary(data: string): boolean {
+    if (data.length === 0) return false;
+    for (const value of data) {
+      if (value.charCodeAt(0) > 0xff) return false;
+    }
+    let sent = true;
+    for (let offset = 0; offset < data.length; offset += TERMINAL_INPUT_CHUNK_CHARS) {
+      const chunk = data.slice(offset, offset + TERMINAL_INPUT_CHUNK_CHARS);
+      sent = (this.binaryInputSupported
+        ? this.sendFrame({
+            type: "binary",
+            terminalRef: this.terminalRef,
+            dataBase64: binaryStringToBase64(chunk),
+          })
+        : this.sendInput(chunk)) && sent;
+    }
+    return sent;
   }
 
   resize(cols: number, rows: number): boolean {
@@ -218,12 +244,32 @@ export class MobileTerminalConnection {
   }
 }
 
+function binaryStringToBase64(value: string): string {
+  if (typeof btoa === "function") return btoa(value);
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let output = "";
+  for (let index = 0; index < value.length; index += 3) {
+    const a = value.charCodeAt(index);
+    const hasB = index + 1 < value.length;
+    const hasC = index + 2 < value.length;
+    const b = hasB ? value.charCodeAt(index + 1) : 0;
+    const c = hasC ? value.charCodeAt(index + 2) : 0;
+    const triple = (a << 16) | (b << 8) | c;
+    output += alphabet[(triple >> 18) & 63];
+    output += alphabet[(triple >> 12) & 63];
+    output += hasB ? alphabet[(triple >> 6) & 63] : "=";
+    output += hasC ? alphabet[triple & 63] : "=";
+  }
+  return output;
+}
+
 export function buildTerminalWebSocketUrl(baseUrl: string, refKey: string, token?: string | null): string {
   const [workspaceId, tabId] = refKey.split(":");
   const url = new URL(`${baseUrl.replace(/\/+$/, "").replace(/^http/, "ws")}/ws/terminal/tab`);
   url.searchParams.set("workspaceId", workspaceId ?? "");
   url.searchParams.set("tabId", tabId ?? "");
   url.searchParams.set("client", "mobile");
+  url.searchParams.set("inputCapability", "binary-input-v1");
   if (token) url.searchParams.set("token", token);
   return url.toString();
 }
@@ -233,7 +279,13 @@ function parseTerminalServerFrame(data: unknown): TerminalServerFrame | null {
   try {
     const frame = JSON.parse(data) as TerminalServerFrame;
     if (!frame || typeof frame !== "object" || typeof frame.type !== "string") return null;
-    if (frame.type === "attached" && frame.terminalRef && typeof frame.nextSeq === "number") return frame;
+    if (frame.type === "attached" && frame.terminalRef && typeof frame.nextSeq === "number") {
+      const capabilities = Array.isArray(frame.capabilities)
+        ? frame.capabilities.slice(0, 8)
+          .filter((value): value is string => value === "binary-input-v1")
+        : undefined;
+      return { ...frame, ...(capabilities ? { capabilities } : {}) };
+    }
     if (frame.type === "snapshot" && typeof frame.ansi === "string") return frame;
     if (frame.type === "output" && typeof frame.data === "string") return frame;
     if (frame.type === "replay-start" || frame.type === "replay-end" || frame.type === "exit") return frame;

--- a/desktop/src/renderer/src/features/terminal/TerminalView.tsx
+++ b/desktop/src/renderer/src/features/terminal/TerminalView.tsx
@@ -531,7 +531,7 @@ export default function TerminalView({
       attachment.write(data);
     });
     const binaryDisposable = terminal.onBinary((data) => {
-      attachment.write(data);
+      attachment.writeBinary(data);
     });
     const proposed = proposedTerminalDimensions(fit, terminal);
     attachment.resize(proposed.cols, proposed.rows);

--- a/desktop/src/renderer/src/features/terminal/attach-manager.ts
+++ b/desktop/src/renderer/src/features/terminal/attach-manager.ts
@@ -10,6 +10,7 @@ const DEFAULT_BUFFER_CACHE_CAP = 8;
 export interface SocketControl {
   connect(): void;
   sendInput(data: string): void;
+  sendBinary(data: string): void;
   resize(cols: number, rows: number): void;
   detach(): void;
   dispose(): void;
@@ -28,6 +29,7 @@ export interface AttachManagerOptions {
 export interface ActiveAttachment {
   sessionName: string;
   write(data: string): void;
+  writeBinary(data: string): void;
   resize(cols: number, rows: number): void;
 }
 
@@ -95,6 +97,9 @@ export class AttachManager {
       sessionName,
       write: (data: string) => {
         if (this.isLive(generation)) socket.sendInput(data);
+      },
+      writeBinary: (data: string) => {
+        if (this.isLive(generation)) socket.sendBinary(data);
       },
       resize: (cols: number, rows: number) => {
         if (this.isLive(generation)) socket.resize(cols, rows);

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -124,8 +124,9 @@ export class ShellSocket {
   private failedAttempts = 0;
   private pendingInput: Array<
     | { type: "input"; data: string }
-    | { type: "binary"; dataBase64: string }
+    | { type: "binary"; data: string }
   > = [];
+  private binaryInputSupported = false;
   private lastKnownDims: Dims | null = null;
   private lastSentDims: Dims | null = null;
   private resizeSentSinceAttach = false;
@@ -191,11 +192,10 @@ export class ShellSocket {
     }
     for (let offset = 0; offset < data.length; offset += INPUT_CHUNK_CHARS) {
       const chunk = data.slice(offset, offset + INPUT_CHUNK_CHARS);
-      const frame = { type: "binary" as const, dataBase64: btoa(chunk) };
       if (this.currentState === "attached" && this.socket !== null) {
-        this.sendFrame({ ...frame, terminalRef: this.terminalRef });
+        this.sendBinaryChunk(chunk);
       } else {
-        this.pendingInput.push(frame);
+        this.pendingInput.push({ type: "binary", data: chunk });
         if (this.pendingInput.length > PENDING_INPUT_MAX_CHUNKS) this.pendingInput.shift();
       }
     }
@@ -245,6 +245,7 @@ export class ShellSocket {
 
   private openSocket(isReconnect: boolean): void {
     if (this.disposed) return;
+    this.binaryInputSupported = false;
     // Per-connection resize bookkeeping: a fresh attach starts a new startup
     // window and may need the last known dims resent.
     this.lastSentDims = null;
@@ -310,7 +311,7 @@ export class ShellSocket {
       : LIVE_TAIL_FROM_SEQ;
     const size = this.lastKnownDims;
     const sizingSuffix = size ? `&cols=${size.cols}&rows=${size.rows}` : "";
-    return `${base}/ws/terminal/tab?workspaceId=${encodeURIComponent(this.terminalRef.workspaceId)}&tabId=${encodeURIComponent(this.terminalRef.tabId)}&client=electron&fromSeq=${fromSeq}${chatSuffix}${runtimeSuffix}${sizingSuffix}`;
+    return `${base}/ws/terminal/tab?workspaceId=${encodeURIComponent(this.terminalRef.workspaceId)}&tabId=${encodeURIComponent(this.terminalRef.tabId)}&client=electron&fromSeq=${fromSeq}${chatSuffix}${runtimeSuffix}${sizingSuffix}&inputCapability=binary-input-v1`;
   }
 
   private scheduleReconnect(): void {
@@ -439,6 +440,8 @@ export class ShellSocket {
       return;
     }
     this.failedAttempts = 0;
+    this.binaryInputSupported = Array.isArray(frame.capabilities)
+      && frame.capabilities.includes("binary-input-v1");
     this.handleCanonicalSize(frame.canonicalSize && typeof frame.canonicalSize === "object"
       ? frame.canonicalSize as Record<string, unknown>
       : {});
@@ -558,8 +561,21 @@ export class ShellSocket {
     const chunks = this.pendingInput;
     this.pendingInput = [];
     for (const chunk of chunks) {
-      this.sendFrame({ ...chunk, terminalRef: this.terminalRef });
+      if (chunk.type === "binary") this.sendBinaryChunk(chunk.data);
+      else this.sendFrame({ ...chunk, terminalRef: this.terminalRef });
     }
+  }
+
+  private sendBinaryChunk(data: string): void {
+    if (this.binaryInputSupported) {
+      this.sendFrame({
+        type: "binary",
+        terminalRef: this.terminalRef,
+        dataBase64: btoa(data),
+      });
+      return;
+    }
+    this.sendFrame({ type: "input", terminalRef: this.terminalRef, data });
   }
 
   private scheduleHeartbeat(): void {

--- a/desktop/src/renderer/src/lib/shell-socket.ts
+++ b/desktop/src/renderer/src/lib/shell-socket.ts
@@ -122,7 +122,10 @@ export class ShellSocket {
   private readonly terminalRef: TerminalRef;
   private detachPending = false;
   private failedAttempts = 0;
-  private pendingInput: string[] = [];
+  private pendingInput: Array<
+    | { type: "input"; data: string }
+    | { type: "binary"; dataBase64: string }
+  > = [];
   private lastKnownDims: Dims | null = null;
   private lastSentDims: Dims | null = null;
   private resizeSentSinceAttach = false;
@@ -171,10 +174,29 @@ export class ShellSocket {
       if (this.currentState === "attached" && this.socket !== null) {
         this.sendFrame({ type: "input", terminalRef: this.terminalRef, data: chunk });
       } else {
-        this.pendingInput.push(chunk);
+        this.pendingInput.push({ type: "input", data: chunk });
         if (this.pendingInput.length > PENDING_INPUT_MAX_CHUNKS) {
           this.pendingInput.shift();
         }
+      }
+    }
+  }
+
+  sendBinary(data: string): void {
+    if (this.disposed || this.currentState === "ended" || this.currentState === "fatal") return;
+    if (data.length === 0) return;
+    if ([...data].some((value) => value.charCodeAt(0) > 0xff)) {
+      console.warn("[shell-socket] ignoring invalid binary terminal input");
+      return;
+    }
+    for (let offset = 0; offset < data.length; offset += INPUT_CHUNK_CHARS) {
+      const chunk = data.slice(offset, offset + INPUT_CHUNK_CHARS);
+      const frame = { type: "binary" as const, dataBase64: btoa(chunk) };
+      if (this.currentState === "attached" && this.socket !== null) {
+        this.sendFrame({ ...frame, terminalRef: this.terminalRef });
+      } else {
+        this.pendingInput.push(frame);
+        if (this.pendingInput.length > PENDING_INPUT_MAX_CHUNKS) this.pendingInput.shift();
       }
     }
   }
@@ -536,7 +558,7 @@ export class ShellSocket {
     const chunks = this.pendingInput;
     this.pendingInput = [];
     for (const chunk of chunks) {
-      this.sendFrame({ type: "input", terminalRef: this.terminalRef, data: chunk });
+      this.sendFrame({ ...chunk, terminalRef: this.terminalRef });
     }
   }
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -714,11 +714,15 @@ const TerminalServerEventBaseSchema = z.object({
   revision: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
 });
 
+export const TerminalInputCapabilitySchema = z.enum(["binary-input-v1"]);
+export type TerminalInputCapability = z.infer<typeof TerminalInputCapabilitySchema>;
+
 export const TerminalTabServerFrameSchema = z.discriminatedUnion("type", [
   TerminalServerEventBaseSchema.extend({
     type: z.literal("attached"),
     canonicalSize: TerminalGridSizeSchema,
     nextSeq: z.number().int().min(0),
+    capabilities: z.array(TerminalInputCapabilitySchema).max(8).optional(),
   }).strict(),
   TerminalServerEventBaseSchema.extend({
     type: z.literal("snapshot"),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -673,11 +673,25 @@ export const TerminalServerFrameSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("safe-error"), error: SafeClientErrorSchema }).strict(),
 ]);
 
+const TerminalBinaryInputSchema = z.string()
+  .min(4)
+  .max(Math.ceil((64 * 1024) / 3) * 4)
+  .regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/)
+  .refine((value) => {
+    const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+    return (value.length / 4) * 3 - padding <= 64 * 1024;
+  });
+
 export const TerminalTabClientFrameSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("input"),
     terminalRef: TerminalRefSchema,
     data: z.string().min(1).max(64 * 1024),
+  }).strict(),
+  z.object({
+    type: z.literal("binary"),
+    terminalRef: TerminalRefSchema,
+    dataBase64: TerminalBinaryInputSchema,
   }).strict(),
   z.object({
     type: z.literal("resize"),

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -76,6 +76,10 @@ import {
   resolveTerminalAttachmentMode,
   terminalAttachmentAllowsFrame,
 } from "./session-runtime-bridge.js";
+import {
+  parseTerminalInputCapabilityRequest,
+  terminalFrameForInputCapabilities,
+} from "./terminal-input-capabilities.js";
 import { createWorkspaceStartupRecovery } from "./workspace-startup-recovery.js";
 import { createChannelManager, type ChannelManager } from "./channels/manager.js";
 import { createOutboundQueue } from "./security/outbound-queue.js";
@@ -2641,6 +2645,7 @@ export async function createGateway(config: GatewayConfig) {
       const fromSeq = /^\d+$/.test(fromSeqRaw) ? Number(fromSeqRaw) : Number.NaN;
       const cols = /^\d+$/.test(colsRaw) ? Number(colsRaw) : Number.NaN;
       const rows = /^\d+$/.test(rowsRaw) ? Number(rowsRaw) : Number.NaN;
+      const binaryInputRequested = parseTerminalInputCapabilityRequest(c.req.query("inputCapability"));
       const validNumbers = Number.isSafeInteger(fromSeq) && fromSeq >= 0
         && Number.isSafeInteger(cols) && cols >= 20 && cols <= 500
         && Number.isSafeInteger(rows) && rows >= 5 && rows <= 200;
@@ -2706,7 +2711,9 @@ export async function createGateway(config: GatewayConfig) {
               size: { cols, rows },
               onFrame: (frame) => {
                 if (closed) return;
-                try { ws.send(JSON.stringify(frame)); }
+                try {
+                  ws.send(JSON.stringify(terminalFrameForInputCapabilities(frame, binaryInputRequested)));
+                }
                 catch (error) { logUnexpectedWsSendFailure("Terminal tab WebSocket send failed", error); }
               },
               onClose: () => { if (!closed) ws.close(); },

--- a/packages/gateway/src/session-runtime-bridge.ts
+++ b/packages/gateway/src/session-runtime-bridge.ts
@@ -158,7 +158,9 @@ export function terminalAttachmentAllowsFrame(
   frame: z.input<typeof TerminalTabClientFrameSchema>,
 ): boolean {
   if (mode === "owner") return true;
-  return frame.type !== "input" && !(frame.type === "resize" && frame.mode === "hard");
+  return frame.type !== "input"
+    && frame.type !== "binary"
+    && !(frame.type === "resize" && frame.mode === "hard");
 }
 
 export async function resolveTerminalAttachmentMode(

--- a/packages/gateway/src/terminal-input-capabilities.ts
+++ b/packages/gateway/src/terminal-input-capabilities.ts
@@ -1,0 +1,15 @@
+type TerminalServerFrame = { type: string; capabilities?: unknown } & Record<string, unknown>;
+
+export function parseTerminalInputCapabilityRequest(value: string | undefined): boolean {
+  return value === "binary-input-v1";
+}
+
+export function terminalFrameForInputCapabilities<T extends TerminalServerFrame>(
+  frame: T,
+  binaryInputRequested: boolean,
+): T | Omit<T, "capabilities"> {
+  if (frame.type !== "attached" || binaryInputRequested || !("capabilities" in frame)) return frame;
+  const { capabilities, ...compatibleFrame } = frame;
+  void capabilities;
+  return compatibleFrame;
+}

--- a/packages/terminal-runtime/src/runtime.ts
+++ b/packages/terminal-runtime/src/runtime.ts
@@ -72,7 +72,7 @@ export interface TerminalRuntimeOptions {
   observerCloseTimeoutMs?: number;
 }
 export interface TerminalViewer {
-  write(data: string): Promise<void>;
+  write(data: string | Uint8Array): Promise<void>;
   touch(): void;
   detach(): Promise<void>;
 }
@@ -781,14 +781,19 @@ export class TerminalRuntime {
 
   private async enqueueWrite(
     ref: TerminalRef,
-    dataInput: string,
+    dataInput: string | Uint8Array,
     writer: (data: Uint8Array) => Promise<void>,
   ): Promise<void> {
     if (this.shuttingDown) throw new TerminalRuntimeError("unavailable");
     if (this.deletingWorkspaceId === ref.workspaceId) {
       throw new TerminalRuntimeError("conflict", "Terminal workspace deletion in progress");
     }
-    const data = new TextEncoder().encode(z.string().min(1).max(64 * 1024).parse(dataInput));
+    const data = typeof dataInput === "string"
+      ? new TextEncoder().encode(z.string().min(1).max(64 * 1024).parse(dataInput))
+      : Uint8Array.from(dataInput);
+    if (data.byteLength < 1 || data.byteLength > 64 * 1024) {
+      throw new TerminalRuntimeError("invalid_request");
+    }
     const key = refKey(ref);
     this.assertTabAcceptsInput(key);
     let queue = this.inputQueues.get(key);

--- a/packages/terminal-runtime/src/socket-server.ts
+++ b/packages/terminal-runtime/src/socket-server.ts
@@ -251,6 +251,7 @@ export class TerminalRuntimeSocketServer {
       canonicalSize: resized.canonicalSize,
       revision,
       nextSeq,
+      capabilities: ["binary-input-v1"],
     });
     if (snapshot) {
       send({ type: "replay-start", terminalRef: ref, revision, fromSeq: effectiveFromSeq });

--- a/packages/terminal-runtime/src/socket-server.ts
+++ b/packages/terminal-runtime/src/socket-server.ts
@@ -50,7 +50,7 @@ export interface TerminalRuntimeControlApi {
     viewerId: string;
     send(data: Uint8Array): void | Promise<void>;
     onExit(exitCode: number | null): void | Promise<void>;
-  }): Promise<{ write(data: string): Promise<void>; touch(): void; detach(): Promise<void> }>;
+  }): Promise<{ write(data: string | Uint8Array): Promise<void>; touch(): void; detach(): Promise<void> }>;
 }
 
 type TerminalServerFrame = z.infer<typeof TerminalTabServerFrameSchema>;
@@ -296,6 +296,7 @@ export class TerminalRuntimeSocketServer {
         throw new Error("Terminal reference mismatch");
       }
       if (frame.type === "input") await viewer.write(frame.data);
+      if (frame.type === "binary") await viewer.write(Buffer.from(frame.dataBase64, "base64"));
       if (frame.type === "resize") {
         const workspace = await this.options.runtime.resize(ref, frame);
         revision = workspace.revision;

--- a/packages/terminal-runtime/src/zellij-adapter.ts
+++ b/packages/terminal-runtime/src/zellij-adapter.ts
@@ -50,6 +50,7 @@ const SubscribeEventSchema = z.discriminatedUnion("event", [
 ]);
 
 export interface RuntimePty {
+  write(data: string | Buffer): void;
   resize(cols: number, rows: number): void;
   kill(): void;
   onData(listener: (data: string) => void): { dispose(): void };
@@ -255,10 +256,7 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
     return {
       write: async (data) => {
         if (closed) throw new Error("Terminal attachment closed");
-        await this.run([
-          "--session", sessionName, "action", "write-chars", "--pane-id", paneId, "--",
-          new TextDecoder().decode(data),
-        ], binaryPath);
+        pty.write(Buffer.from(data));
       },
       resize: async (cols, rows) => { if (!closed) pty.resize(cols, rows); },
       close: async () => {

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -111,10 +111,22 @@ const TERMINAL_OVERLAY_BASE_STYLE: CSSProperties = {
   fontSize: 13,
   boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
 };
+const TERMINAL_INPUT_CHUNK_CHARS = 32_768;
+
 function sendTerminalInputFrame(ws: WebSocket, terminalKey: string | null, data: string): boolean {
   const terminalRef = parseTerminalRefKey(terminalKey);
   if (!terminalRef || ws.readyState !== WebSocket.OPEN) return false;
   ws.send(JSON.stringify({ type: "input", terminalRef, data }));
+  return true;
+}
+
+function sendTerminalBinaryFrame(ws: WebSocket, terminalKey: string | null, data: string): boolean {
+  const terminalRef = parseTerminalRefKey(terminalKey);
+  if (!terminalRef || ws.readyState !== WebSocket.OPEN || data.length === 0) return false;
+  for (const value of data) {
+    if (value.charCodeAt(0) > 0xff) return false;
+  }
+  ws.send(JSON.stringify({ type: "binary", terminalRef, dataBase64: btoa(data) }));
   return true;
 }
 
@@ -196,6 +208,7 @@ export function TerminalPane({
   const webglContextLossDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const webglRecreateAttemptedRef = useRef(false);
   const onDataDisposableRef = useRef<{ dispose: () => void } | null>(null);
+  const onBinaryDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const onResizeDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const initialStartupCommandRef = useRef(startupCommand);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -1627,6 +1640,26 @@ export function TerminalPane({
         }
       });
 
+      onBinaryDisposableRef.current?.dispose();
+      onBinaryDisposableRef.current = term.onBinary((data: string) => {
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) return;
+        if ([...data].some((value) => value.charCodeAt(0) > 0xff)) {
+          console.warn("[terminal] Rejected invalid binary terminal input");
+          return;
+        }
+        for (let offset = 0; offset < data.length; offset += TERMINAL_INPUT_CHUNK_CHARS) {
+          if (!sendTerminalBinaryFrame(
+            ws,
+            sessionIdRef.current,
+            data.slice(offset, offset + TERMINAL_INPUT_CHUNK_CHARS),
+          )) {
+            console.warn("[terminal] Rejected invalid binary terminal input");
+            return;
+          }
+        }
+      });
+
       onResizeDisposableRef.current?.dispose();
       onResizeDisposableRef.current = term.onResize(({ cols, rows }: { cols: number; rows: number }) => {
         if (usesCanonicalGrid()) {
@@ -1702,6 +1735,8 @@ export function TerminalPane({
         teardownWebglSubscription();
         onDataDisposableRef.current?.dispose();
         onDataDisposableRef.current = null;
+        onBinaryDisposableRef.current?.dispose();
+        onBinaryDisposableRef.current = null;
         onResizeDisposableRef.current?.dispose();
         onResizeDisposableRef.current = null;
         const shouldCache = !isClosingRef.current && (shouldCacheOnUnmountRef.current?.(paneId) ?? true);

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -209,6 +209,7 @@ export function TerminalPane({
   const webglRecreateAttemptedRef = useRef(false);
   const onDataDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const onBinaryDisposableRef = useRef<{ dispose: () => void } | null>(null);
+  const binaryInputSupportedRef = useRef(false);
   const onResizeDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const initialStartupCommandRef = useRef(startupCommand);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -1304,6 +1305,7 @@ export function TerminalPane({
 
           switch (msg.type) {
             case "attached":
+              binaryInputSupportedRef.current = msg.capabilities.includes("binary-input-v1");
               log("attached", {
                 attachedSessionId: msg.sessionId,
                 state: msg.state,
@@ -1494,6 +1496,7 @@ export function TerminalPane({
           tabId: terminalRef.tabId,
           fromSeq: String(replayRequest?.requestedSeq ?? 0),
           client: suppressNativeKeyboard ? "mobile" : "browser",
+          inputCapability: "binary-input-v1",
           ...(declaredSize ? { cols: String(declaredSize.cols), rows: String(declaredSize.rows) } : {}),
         };
         log("connect-ws", {
@@ -1649,11 +1652,11 @@ export function TerminalPane({
           return;
         }
         for (let offset = 0; offset < data.length; offset += TERMINAL_INPUT_CHUNK_CHARS) {
-          if (!sendTerminalBinaryFrame(
-            ws,
-            sessionIdRef.current,
-            data.slice(offset, offset + TERMINAL_INPUT_CHUNK_CHARS),
-          )) {
+          const chunk = data.slice(offset, offset + TERMINAL_INPUT_CHUNK_CHARS);
+          const sent = binaryInputSupportedRef.current
+            ? sendTerminalBinaryFrame(ws, sessionIdRef.current, chunk)
+            : sendTerminalInputFrame(ws, sessionIdRef.current, chunk);
+          if (!sent) {
             console.warn("[terminal] Rejected invalid binary terminal input");
             return;
           }
@@ -1737,6 +1740,7 @@ export function TerminalPane({
         onDataDisposableRef.current = null;
         onBinaryDisposableRef.current?.dispose();
         onBinaryDisposableRef.current = null;
+        binaryInputSupportedRef.current = false;
         onResizeDisposableRef.current?.dispose();
         onResizeDisposableRef.current = null;
         const shouldCache = !isClosingRef.current && (shouldCacheOnUnmountRef.current?.(paneId) ?? true);

--- a/shell/src/components/terminal/terminal-server-message.ts
+++ b/shell/src/components/terminal/terminal-server-message.ts
@@ -13,6 +13,7 @@ export type TerminalServerMessage =
       exitCode: null;
       fromSeq: number;
       canonicalSize: TerminalCanonicalSize;
+      capabilities: string[];
     })
   | (TerminalMessageIdentity & { type: "canonical-size"; cols: number; rows: number })
   | (TerminalMessageIdentity & { type: "output"; data: string; seq: number })
@@ -71,6 +72,7 @@ export function parseTerminalServerMessage(raw: string): TerminalServerMessage |
         exitCode: null,
         fromSeq: msg.nextSeq,
         canonicalSize: msg.canonicalSize,
+        capabilities: msg.capabilities ?? [],
       };
     case "canonical-size":
       return { ...identity, type: "canonical-size", ...msg.canonicalSize };

--- a/tests/contracts/terminal-workspaces.test.ts
+++ b/tests/contracts/terminal-workspaces.test.ts
@@ -89,6 +89,21 @@ describe("project-scoped terminal workspace contracts", () => {
       terminalRef,
       data: "ls\r",
     }).terminalRef).toEqual(terminalRef);
+    expect(TerminalTabClientFrameSchema.parse({
+      type: "binary",
+      terminalRef,
+      dataBase64: "G1s8NjQ7MTU7NU0=",
+    })).toMatchObject({ type: "binary", dataBase64: "G1s8NjQ7MTU7NU0=" });
+    expect(() => TerminalTabClientFrameSchema.parse({
+      type: "binary",
+      terminalRef,
+      dataBase64: "not base64",
+    })).toThrow();
+    expect(() => TerminalTabClientFrameSchema.parse({
+      type: "binary",
+      terminalRef,
+      dataBase64: Buffer.alloc((64 * 1024) + 1).toString("base64"),
+    })).toThrow();
     const snapshotFrame = TerminalTabServerFrameSchema.parse({
       type: "snapshot",
       terminalRef,

--- a/tests/contracts/terminal-workspaces.test.ts
+++ b/tests/contracts/terminal-workspaces.test.ts
@@ -104,6 +104,14 @@ describe("project-scoped terminal workspace contracts", () => {
       terminalRef,
       dataBase64: Buffer.alloc((64 * 1024) + 1).toString("base64"),
     })).toThrow();
+    expect(TerminalTabServerFrameSchema.parse({
+      type: "attached",
+      terminalRef,
+      canonicalSize: { cols: 120, rows: 36 },
+      revision: 4,
+      nextSeq: 12,
+      capabilities: ["binary-input-v1"],
+    })).toMatchObject({ capabilities: ["binary-input-v1"] });
     const snapshotFrame = TerminalTabServerFrameSchema.parse({
       type: "snapshot",
       terminalRef,

--- a/tests/desktop/attach-manager.test.ts
+++ b/tests/desktop/attach-manager.test.ts
@@ -13,6 +13,7 @@ class FakeSocketControl implements SocketControl {
   detached = 0;
   disposedCount = 0;
   readonly inputs: string[] = [];
+  readonly binaryInputs: string[] = [];
   readonly resizes: Array<{ cols: number; rows: number }> = [];
 
   constructor(
@@ -27,6 +28,10 @@ class FakeSocketControl implements SocketControl {
 
   sendInput(data: string): void {
     this.inputs.push(data);
+  }
+
+  sendBinary(data: string): void {
+    this.binaryInputs.push(data);
   }
 
   resize(cols: number, rows: number): void {
@@ -164,18 +169,24 @@ describe("AttachManager generation guard", () => {
     const { manager, created } = createManager();
     const a = manager.attach("alpha", recordingEvents().events);
     a.write("first");
+    a.writeBinary("\x1b]10;?\x07");
     a.resize(80, 24);
     expect(created[0]?.inputs).toEqual(["first"]);
+    expect(created[0]?.binaryInputs).toEqual(["\x1b]10;?\x07"]);
     expect(created[0]?.resizes).toEqual([{ cols: 80, rows: 24 }]);
 
     const b = manager.attach("beta", recordingEvents().events);
     a.write("stale");
+    a.writeBinary("stale-binary");
     a.resize(100, 30);
     expect(created[0]?.inputs).toEqual(["first"]);
+    expect(created[0]?.binaryInputs).toEqual(["\x1b]10;?\x07"]);
     expect(created[0]?.resizes).toEqual([{ cols: 80, rows: 24 }]);
 
     b.write("live");
+    b.writeBinary("live-binary");
     expect(created[1]?.inputs).toEqual(["live"]);
+    expect(created[1]?.binaryInputs).toEqual(["live-binary"]);
     expect(b.sessionName).toBe("beta");
   });
 });

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -25,6 +25,7 @@ function currentServerFrame(value: unknown): unknown {
       canonicalSize: frame.canonicalSize ?? { cols: 120, rows: 40 },
       revision: frame.revision ?? 1,
       nextSeq: frame.nextSeq ?? frame.fromSeq ?? 0,
+      ...(frame.capabilities === undefined ? {} : { capabilities: frame.capabilities }),
     };
   }
   if (frame.type === "exit") return {
@@ -201,7 +202,7 @@ function createHarness(overrides: Partial<ShellSocketOptions> = {}): Harness {
 function connectAndAttach(h: Harness): void {
   h.socket.connect();
   h.latest().open();
-  h.latest().frame({ type: "attached", nextSeq: 0 });
+  h.latest().frame({ type: "attached", nextSeq: 0, capabilities: ["binary-input-v1"] });
 }
 
 let warnSpy: ReturnType<typeof vi.spyOn>;
@@ -219,7 +220,7 @@ describe("ShellSocket URL building", () => {
     const h = createHarness();
     h.socket.connect();
     expect(h.latest().url).toBe(
-      `wss://app.matrix-os.com/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=${LIVE_TAIL_FROM_SEQ}`,
+      `wss://app.matrix-os.com/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=${LIVE_TAIL_FROM_SEQ}&inputCapability=binary-input-v1`,
     );
     expect(LIVE_TAIL_FROM_SEQ).toBe(9_007_199_254_740_991);
   });
@@ -243,7 +244,7 @@ describe("ShellSocket URL building", () => {
     const h = createHarness();
     h.socket.connect();
     expect(h.latest().url).toBe(
-      `wss://app.matrix-os.com/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=${LIVE_TAIL_FROM_SEQ}`,
+      `wss://app.matrix-os.com/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=${LIVE_TAIL_FROM_SEQ}&inputCapability=binary-input-v1`,
     );
     expect(h.latest().url).not.toContain("chat=");
   });
@@ -314,7 +315,7 @@ describe("ShellSocket URL building", () => {
     const h = createHarness({ baseUrl: "http://localhost:3001/" });
     h.socket.connect();
     expect(h.latest().url).toBe(
-      `ws://localhost:3001/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=${LIVE_TAIL_FROM_SEQ}`,
+      `ws://localhost:3001/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=${LIVE_TAIL_FROM_SEQ}&inputCapability=binary-input-v1`,
     );
   });
 
@@ -358,7 +359,7 @@ describe("ShellSocket URL building", () => {
     h.timers.advance(500);
     expect(h.sockets).toHaveLength(2);
     expect(h.latest().url).toBe(
-      `wss://app.matrix-os.com/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=42`,
+      `wss://app.matrix-os.com/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=42&inputCapability=binary-input-v1`,
     );
   });
 
@@ -369,7 +370,7 @@ describe("ShellSocket URL building", () => {
     h.timers.advance(500);
     expect(h.sockets).toHaveLength(2);
     expect(h.latest().url).toBe(
-      `wss://app.matrix-os.com/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=${LIVE_TAIL_FROM_SEQ}`,
+      `wss://app.matrix-os.com/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=${LIVE_TAIL_FROM_SEQ}&inputCapability=binary-input-v1`,
     );
   });
 
@@ -707,7 +708,7 @@ describe("ShellSocket server frames", () => {
     h.timers.advance(500);
     expect(h.sockets).toHaveLength(2);
     expect(h.latest().url).toBe(
-      `wss://app.matrix-os.com/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=${LIVE_TAIL_FROM_SEQ}`,
+      `wss://app.matrix-os.com/ws/terminal/tab?workspaceId=${WORKSPACE_ID}&tabId=${TAB_ID}&client=electron&fromSeq=${LIVE_TAIL_FROM_SEQ}&inputCapability=binary-input-v1`,
     );
   });
 
@@ -867,7 +868,13 @@ describe("ShellSocket reconnect", () => {
     h.timers.advance(2000);
 
     h.latest().open();
-    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    h.latest().frame({
+      type: "attached",
+      session: "main",
+      state: "running",
+      fromSeq: 0,
+      capabilities: ["binary-input-v1"],
+    });
     expect(h.socket.state).toBe("attached");
 
     h.latest().serverClose();
@@ -1005,6 +1012,21 @@ describe("ShellSocket resize coalescing", () => {
 });
 
 describe("ShellSocket input", () => {
+  it("falls back to a compatible text frame when an older runtime does not advertise binary input", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.latest().open();
+    h.latest().frame({ type: "attached", nextSeq: 0 });
+
+    h.socket.sendBinary("\x1b]10;rgb:1111/2222/3333\x07");
+
+    expect(h.latest().sentFrames()).toContainEqual({
+      type: "input",
+      terminalRef: TERMINAL_REF,
+      data: "\x1b]10;rgb:1111/2222/3333\x07",
+    });
+  });
+
   it("preserves xterm binary reports in a dedicated base64 frame", () => {
     const h = createHarness();
     connectAndAttach(h);
@@ -1043,7 +1065,13 @@ describe("ShellSocket input", () => {
     h.socket.sendInput("lo");
     expect(h.latest().sent).toHaveLength(0);
     h.latest().open();
-    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    h.latest().frame({
+      type: "attached",
+      session: "main",
+      state: "running",
+      fromSeq: 0,
+      capabilities: ["binary-input-v1"],
+    });
     expect(h.latest().inputFrames()).toEqual(["hel", "lo"]);
   });
 
@@ -1055,7 +1083,13 @@ describe("ShellSocket input", () => {
     h.socket.sendInput("b");
 
     h.latest().open();
-    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+    h.latest().frame({
+      type: "attached",
+      session: "main",
+      state: "running",
+      fromSeq: 0,
+      capabilities: ["binary-input-v1"],
+    });
 
     expect(h.latest().sentFrames().slice(0, 3)).toEqual([
       { type: "input", terminalRef: TERMINAL_REF, data: "a" },

--- a/tests/desktop/shell-socket.test.ts
+++ b/tests/desktop/shell-socket.test.ts
@@ -1005,6 +1005,28 @@ describe("ShellSocket resize coalescing", () => {
 });
 
 describe("ShellSocket input", () => {
+  it("preserves xterm binary reports in a dedicated base64 frame", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    h.socket.sendBinary("\x1b]10;?\x07\x1b\\\x1b[<64;15;5M\x80\xff");
+
+    expect(h.latest().sentFrames()).toContainEqual({
+      type: "binary",
+      terminalRef: TERMINAL_REF,
+      dataBase64: "G10xMDs/BxtcG1s8NjQ7MTU7NU2A/w==",
+    });
+  });
+
+  it("rejects an invalid binary report before sending any partial chunks", () => {
+    const h = createHarness();
+    connectAndAttach(h);
+    const before = h.latest().sent.length;
+
+    h.socket.sendBinary(`${"x".repeat(32_768)}\u{100}`);
+
+    expect(h.latest().sent).toHaveLength(before);
+  });
+
   it("chunks large input into <=32768-char pieces", () => {
     const h = createHarness();
     connectAndAttach(h);
@@ -1023,6 +1045,27 @@ describe("ShellSocket input", () => {
     h.latest().open();
     h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
     expect(h.latest().inputFrames()).toEqual(["hel", "lo"]);
+  });
+
+  it("keeps text and terminal protocol replies ordered while an attachment connects", () => {
+    const h = createHarness();
+    h.socket.connect();
+    h.socket.sendInput("a");
+    h.socket.sendBinary("\x1b]10;rgb:1111/2222/3333\x07");
+    h.socket.sendInput("b");
+
+    h.latest().open();
+    h.latest().frame({ type: "attached", session: "main", state: "running", fromSeq: 0 });
+
+    expect(h.latest().sentFrames().slice(0, 3)).toEqual([
+      { type: "input", terminalRef: TERMINAL_REF, data: "a" },
+      {
+        type: "binary",
+        terminalRef: TERMINAL_REF,
+        dataBase64: "G10xMDtyZ2I6MTExMS8yMjIyLzMzMzMH",
+      },
+      { type: "input", terminalRef: TERMINAL_REF, data: "b" },
+    ]);
   });
 
   it("flushes pending input before the attached state callback runs", () => {

--- a/tests/desktop/terminal-view.test.tsx
+++ b/tests/desktop/terminal-view.test.tsx
@@ -18,6 +18,7 @@ const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(navigator, "p
 const TERMINAL_REF_KEY = `tws_${"a".repeat(32)}:tt_${"b".repeat(32)}`;
 const attachMock = vi.fn();
 const attachmentWrite = vi.fn();
+const attachmentWriteBinary = vi.fn();
 const attachmentResize = vi.fn();
 
 function deferred<T>() {
@@ -202,9 +203,11 @@ describe("TerminalView session switching", () => {
     attachMock.mockImplementation((_sessionName: string, _events: ShellSocketEvents) => ({
       resize: attachmentResize,
       write: attachmentWrite,
+      writeBinary: attachmentWriteBinary,
     }));
     attachmentResize.mockReset();
     attachmentWrite.mockReset();
+    attachmentWriteBinary.mockReset();
     useAppearance.setState({ mode: "light", themeId: "operator", hydrated: true });
     useTerminalAppearance.setState({
       ...useTerminalAppearance.getInitialState(),
@@ -347,7 +350,8 @@ describe("TerminalView session switching", () => {
 
     act(() => terminal.binaryCallback?.(mouseReport));
 
-    expect(attachmentWrite).toHaveBeenCalledWith(mouseReport);
+    expect(attachmentWriteBinary).toHaveBeenCalledWith(mouseReport);
+    expect(attachmentWrite).not.toHaveBeenCalled();
   });
 
   it("copies a valid OSC 52 payload without reading clipboard contents", async () => {

--- a/tests/gateway/session-runtime-bridge.test.ts
+++ b/tests/gateway/session-runtime-bridge.test.ts
@@ -113,6 +113,11 @@ describe("session runtime bridge", () => {
       data: "rm -rf project",
     })).toBe(false);
     expect(terminalAttachmentAllowsFrame("observe", {
+      type: "binary",
+      terminalRef: TERMINAL_REF,
+      dataBase64: "Gw==",
+    })).toBe(false);
+    expect(terminalAttachmentAllowsFrame("observe", {
       type: "resize",
       terminalRef: TERMINAL_REF,
       mode: "hard",

--- a/tests/gateway/terminal-input-capabilities.test.ts
+++ b/tests/gateway/terminal-input-capabilities.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseTerminalInputCapabilityRequest,
+  terminalFrameForInputCapabilities,
+} from "../../packages/gateway/src/terminal-input-capabilities.js";
+
+const ATTACHED_FRAME = {
+  type: "attached" as const,
+  terminalRef: {
+    workspaceId: "tws_00000000000000000000000000000001",
+    tabId: "tt_00000000000000000000000000000001",
+  },
+  revision: 1,
+  canonicalSize: { cols: 80, rows: 24 },
+  nextSeq: 0,
+  capabilities: ["binary-input-v1" as const],
+};
+
+describe("terminal input capability negotiation", () => {
+  it("accepts only the exact bounded binary-input capability request", () => {
+    expect(parseTerminalInputCapabilityRequest("binary-input-v1")).toBe(true);
+    expect(parseTerminalInputCapabilityRequest(undefined)).toBe(false);
+    expect(parseTerminalInputCapabilityRequest("binary-input-v2")).toBe(false);
+    expect(parseTerminalInputCapabilityRequest("binary-input-v1,other")).toBe(false);
+  });
+
+  it("does not send new attached fields to older clients that did not opt in", () => {
+    expect(terminalFrameForInputCapabilities(ATTACHED_FRAME, false)).toEqual({
+      type: "attached",
+      terminalRef: ATTACHED_FRAME.terminalRef,
+      revision: 1,
+      canonicalSize: { cols: 80, rows: 24 },
+      nextSeq: 0,
+    });
+  });
+
+  it("advertises binary input only to clients that explicitly opted in", () => {
+    expect(terminalFrameForInputCapabilities(ATTACHED_FRAME, true)).toEqual(ATTACHED_FRAME);
+    const output = {
+      type: "output" as const,
+      terminalRef: ATTACHED_FRAME.terminalRef,
+      revision: 1,
+      seq: 0,
+      data: "ready",
+    };
+    expect(terminalFrameForInputCapabilities(output, false)).toBe(output);
+  });
+});

--- a/tests/shell/terminal-pane-privacy.test.tsx
+++ b/tests/shell/terminal-pane-privacy.test.tsx
@@ -21,6 +21,7 @@ const stubTerminal = vi.hoisted(() => ({
   rows: 24,
   options: {} as Record<string, unknown>,
   onData: vi.fn(() => ({ dispose: vi.fn() })),
+  onBinary: vi.fn(() => ({ dispose: vi.fn() })),
   onResize: vi.fn(() => ({ dispose: vi.fn() })),
   attachCustomKeyEventHandler: vi.fn(),
   customKeyEventHandler: null as ((event: KeyboardEvent) => boolean) | null,

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -19,8 +19,20 @@ const TAB_ID = `tt_${"b".repeat(32)}`;
 const TERMINAL_REF_KEY = `${WORKSPACE_ID}:${TAB_ID}`;
 const TERMINAL_REF = { workspaceId: WORKSPACE_ID, tabId: TAB_ID };
 
-function attachedFrame(nextSeq: number, canonicalSize = { cols: 120, rows: 42 }, revision = 1) {
-  return { type: "attached", terminalRef: TERMINAL_REF, canonicalSize, revision, nextSeq };
+function attachedFrame(
+  nextSeq: number,
+  canonicalSize = { cols: 120, rows: 42 },
+  revision = 1,
+  capabilities: string[] | null = ["binary-input-v1"],
+) {
+  return {
+    type: "attached",
+    terminalRef: TERMINAL_REF,
+    canonicalSize,
+    revision,
+    nextSeq,
+    ...(capabilities === null ? {} : { capabilities }),
+  };
 }
 
 function outputFrame(seq: number, data: string, revision = 1) {
@@ -906,6 +918,17 @@ describe("TerminalPane scrolling", () => {
       terminalRef: TERMINAL_REF,
       dataBase64: "G10xMDs/BxtcG1s8NjQ7MTU7NU2A/w==",
     }));
+    await act(async () => {
+      socket.onmessage?.({
+        data: JSON.stringify(attachedFrame(0, { cols: 140, rows: 40 }, 2, null)),
+      });
+    });
+    terminal.emitBinary("\x1b]10;rgb:1111/2222/3333\x07");
+    expect(stubWs.send).toHaveBeenCalledWith(JSON.stringify({
+      type: "input",
+      terminalRef: TERMINAL_REF,
+      data: "\x1b]10;rgb:1111/2222/3333\x07",
+    }));
     const sentBeforeInvalidBinary = stubWs.send.mock.calls.length;
     terminal.emitBinary(`${"x".repeat(32_768)}\u{100}`);
     expect(stubWs.send).toHaveBeenCalledTimes(sentBeforeInvalidBinary);
@@ -1370,6 +1393,7 @@ describe("TerminalPane scrolling", () => {
     expect(url.searchParams.get("workspaceId")).toBe(WORKSPACE_ID);
     expect(url.searchParams.get("tabId")).toBe(TAB_ID);
     expect(url.searchParams.get("fromSeq")).toBe("0");
+    expect(url.searchParams.get("inputCapability")).toBe("binary-input-v1");
     expect(url.searchParams.get("fromSeq")).not.toBe(String(Number.MAX_SAFE_INTEGER));
   });
 

--- a/tests/shell/terminal-pane-scrolling.test.tsx
+++ b/tests/shell/terminal-pane-scrolling.test.tsx
@@ -45,6 +45,7 @@ const createdTerminals = vi.hoisted(() => [] as Array<{
   focus: ReturnType<typeof vi.fn>;
   flushWrites: () => void;
   emitData: (data: string) => void;
+  emitBinary: (data: string) => void;
   resize: ReturnType<typeof vi.fn>;
   write: ReturnType<typeof vi.fn>;
   reset: ReturnType<typeof vi.fn>;
@@ -102,6 +103,7 @@ const restorePlan = vi.hoisted(() => ({
         write: ReturnType<typeof vi.fn>;
         dispose: ReturnType<typeof vi.fn>;
         onData: ReturnType<typeof vi.fn>;
+        onBinary: ReturnType<typeof vi.fn>;
         onResize: ReturnType<typeof vi.fn>;
         attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
         clearSelection: ReturnType<typeof vi.fn>;
@@ -216,6 +218,12 @@ vi.mock("@xterm/xterm", () => ({
       return { dispose: vi.fn(() => { this.dataListener = null; }) };
     });
     emitData = (data: string) => this.dataListener?.(data);
+    private binaryListener: ((data: string) => void) | null = null;
+    onBinary = vi.fn((listener: (data: string) => void) => {
+      this.binaryListener = listener;
+      return { dispose: vi.fn(() => { this.binaryListener = null; }) };
+    });
+    emitBinary = (data: string) => this.binaryListener?.(data);
     onResize = vi.fn(() => ({ dispose: vi.fn() }));
     attachCustomKeyEventHandler = vi.fn((handler: (event: KeyboardEvent) => boolean) => {
       this.customKeyEventHandler = handler;
@@ -451,6 +459,7 @@ function createCachedTerminal() {
       resize: vi.fn(),
       dispose: vi.fn(),
       onData: vi.fn(() => ({ dispose: vi.fn() })),
+      onBinary: vi.fn(() => ({ dispose: vi.fn() })),
       onResize: vi.fn(() => ({ dispose: vi.fn() })),
       attachCustomKeyEventHandler: vi.fn(),
       clearSelection: vi.fn(),
@@ -891,6 +900,15 @@ describe("TerminalPane scrolling", () => {
 
     terminal.emitData("x");
     expect(stubWs.send).toHaveBeenCalledWith(JSON.stringify({ type: "input", terminalRef: TERMINAL_REF, data: "x" }));
+    terminal.emitBinary("\x1b]10;?\x07\x1b\\\x1b[<64;15;5M\x80\xff");
+    expect(stubWs.send).toHaveBeenCalledWith(JSON.stringify({
+      type: "binary",
+      terminalRef: TERMINAL_REF,
+      dataBase64: "G10xMDs/BxtcG1s8NjQ7MTU7NU2A/w==",
+    }));
+    const sentBeforeInvalidBinary = stubWs.send.mock.calls.length;
+    terminal.emitBinary(`${"x".repeat(32_768)}\u{100}`);
+    expect(stubWs.send).toHaveBeenCalledTimes(sentBeforeInvalidBinary);
 
     Object.defineProperty(pane, "clientWidth", { configurable: true, value: 1_600 });
     Object.defineProperty(pane, "clientHeight", { configurable: true, value: 900 });
@@ -1840,7 +1858,14 @@ describe("TerminalPane scrolling", () => {
 
     expect(createdTerminals).toHaveLength(1);
     expect(terminal.write.mock.calls.filter(([data]) => data === "cached-output\r\n")).toHaveLength(1);
-    expect(new URL(WebSocketMock.instances[1]!.url).searchParams.get("fromSeq")).toBe("8");
+    const restoredSocket = WebSocketMock.instances[1]!;
+    expect(new URL(restoredSocket.url).searchParams.get("fromSeq")).toBe("8");
+    await act(async () => {
+      restoredSocket.onmessage?.({ data: JSON.stringify(attachedFrame(8)) });
+    });
+    stubWs.send.mockClear();
+    terminal.emitBinary("\x1b]10;rgb:1111/2222/3333\x07");
+    expect(stubWs.send).toHaveBeenCalledOnce();
   });
 
   it("detaches and restores a suspended canonical pane with replay and current dimensions", async () => {

--- a/tests/shell/terminal-soft-grid.test.ts
+++ b/tests/shell/terminal-soft-grid.test.ts
@@ -97,6 +97,7 @@ describe("terminal soft-client canonical grid", () => {
       exitCode: null,
       fromSeq: 0,
       canonicalSize: { cols: 140, rows: 40 },
+      capabilities: [],
     });
     expect(parseTerminalServerMessage(JSON.stringify({
       type: "canonical-size",

--- a/tests/terminal-runtime/socket-api.test.ts
+++ b/tests/terminal-runtime/socket-api.test.ts
@@ -248,7 +248,10 @@ describe("terminal runtime Unix socket API", () => {
     await emitOutput?.(new TextEncoder().encode("second"));
     await outputsReady.promise;
 
-    expect(frames.find((frame) => frame.type === "attached")?.nextSeq).toBe(42);
+    expect(frames.find((frame) => frame.type === "attached")).toMatchObject({
+      nextSeq: 42,
+      capabilities: ["binary-input-v1"],
+    });
     expect(frames.filter((frame) => frame.type === "output").map((frame) => frame.seq))
       .toEqual([42, 43]);
     stream.close();

--- a/tests/terminal-runtime/socket-api.test.ts
+++ b/tests/terminal-runtime/socket-api.test.ts
@@ -255,6 +255,80 @@ describe("terminal runtime Unix socket API", () => {
     await server.close();
   });
 
+  it("preserves binary terminal input bytes across the gateway-runtime socket", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "matrix-terminal-socket-binary-"));
+    directories.push(directory);
+    const socketPath = join(directory, "terminal-runtime.sock");
+    const terminalRef = {
+      workspaceId: "tws_0123456789abcdef0123456789abcdef",
+      tabId: "tt_0123456789abcdef0123456789abcdef",
+    };
+    const tab = {
+      id: terminalRef.tabId,
+      workspaceId: terminalRef.workspaceId,
+      name: "main",
+      cwd: "",
+      status: "running" as const,
+      revision: 1,
+      order: 0,
+      createdAt: "2026-08-11T12:00:00.000Z",
+      updatedAt: "2026-08-11T12:00:00.000Z",
+    };
+    const workspace = {
+      id: terminalRef.workspaceId,
+      scope: "main" as const,
+      canonicalSize: { cols: 120, rows: 36 },
+      status: "running" as const,
+      revision: 1,
+      createdAt: tab.createdAt,
+      updatedAt: tab.updatedAt,
+      tabs: [tab],
+    };
+    const received = Promise.withResolvers<Uint8Array>();
+    const server = new TerminalRuntimeSocketServer({
+      socketPath,
+      runtime: {
+        listWorkspaces: async () => [workspace],
+        ensureWorkspace: async () => workspace,
+        createTab: async () => tab,
+        getSnapshot: async () => undefined,
+        resize: async () => workspace,
+        attach: async () => ({
+          write: async (data) => { received.resolve(Uint8Array.from(data as Uint8Array)); },
+          touch: () => undefined,
+          detach: async () => undefined,
+        }),
+        updateTabUiState: async () => tab,
+      },
+    });
+    await server.start();
+    const client = new TerminalRuntimeSocketClient({ socketPath });
+    const stream = client.attach({
+      ref: terminalRef,
+      viewerId: "desktop-binary-test",
+      fromSeq: Number.MAX_SAFE_INTEGER,
+      mode: "soft",
+      size: { cols: 120, rows: 36 },
+      onFrame: (frame) => {
+        if (frame.type === "attached") {
+          stream.send({ type: "binary", terminalRef, dataBase64: "G10xMDs/BxtcG1s8NjQ7MTU7NU2A/w==" });
+        }
+      },
+      onClose: () => undefined,
+      onError: received.reject,
+    });
+
+    await expect(received.promise).resolves.toEqual(
+      Uint8Array.from([
+        0x1b, 0x5d, 0x31, 0x30, 0x3b, 0x3f, 0x07, 0x1b, 0x5c,
+        0x1b, 0x5b, 0x3c, 0x36, 0x34, 0x3b, 0x31, 0x35, 0x3b, 0x35, 0x4d,
+        0x80, 0xff,
+      ]),
+    );
+    stream.close();
+    await server.close();
+  });
+
   it("preserves typed domain failures across the socket boundary", async () => {
     const directory = await mkdtemp(join(tmpdir(), "matrix-terminal-socket-errors-"));
     directories.push(directory);

--- a/tests/terminal-runtime/zellij-adapter.test.ts
+++ b/tests/terminal-runtime/zellij-adapter.test.ts
@@ -20,6 +20,7 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/999/bus",
     };
     const spawnPty = vi.fn((): RuntimePty => ({
+      write: vi.fn(),
       resize: vi.fn(),
       kill: vi.fn(),
       onData: vi.fn(() => ({ dispose: vi.fn() })),
@@ -207,6 +208,7 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       return "";
     });
     const pty: RuntimePty = {
+      write: vi.fn(),
       resize: vi.fn(),
       kill: vi.fn(),
       onData: vi.fn(() => ({ dispose: vi.fn() })),
@@ -458,12 +460,14 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       if (args.includes("dump-screen")) return "history\nready$ ";
       return "";
     });
-    const pty: RuntimePty = {
+    const ptyWrite = vi.fn();
+    const pty = {
+      write: ptyWrite,
       resize: vi.fn(),
       kill: vi.fn(),
       onData: vi.fn(() => ({ dispose: vi.fn() })),
       onExit: vi.fn(() => ({ dispose: vi.fn() })),
-    };
+    } satisfies RuntimePty & { write(data: Buffer): void };
     let emitSubscription = (_line: string) => undefined;
     const subscription: RuntimeSubscriptionProcess = {
       close: vi.fn(async () => undefined),
@@ -500,10 +504,9 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       onExit: () => undefined,
     });
     await attachment.write(new TextEncoder().encode("echo hi\r"));
-    expect(commands).toContainEqual([
-      "--session", "matrix-w-0123456789abcdef0123456789abcdef",
-      "action", "write-chars", "--pane-id", "terminal_12", "--", "echo hi\r",
-    ]);
+    expect(ptyWrite).toHaveBeenCalledOnce();
+    expect(Buffer.from(ptyWrite.mock.calls[0]![0] as Uint8Array)).toEqual(Buffer.from("echo hi\r"));
+    expect(commands.some((args) => args.includes("write-chars"))).toBe(false);
 
     const events: unknown[] = [];
     await adapter.subscribeWorkspace("matrix-w-0123456789abcdef0123456789abcdef", {

--- a/tests/terminal-runtime/zellij-real.integration.test.ts
+++ b/tests/terminal-runtime/zellij-real.integration.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { ZellijCliRuntimeAdapter } from "../../packages/terminal-runtime/src/zellij-adapter.js";
+import { createTerminalRuntimeEnvironment } from "../../packages/terminal-runtime/src/runtime-environment.js";
 
 const execFileAsync = promisify(execFile);
 const binaryPath = process.env.MATRIX_TEST_ZELLIJ_BIN ?? "/usr/local/bin/zellij";
@@ -16,6 +17,7 @@ describe.runIf(available)("real bundled Zellij 0.44.3 integration", () => {
   let homePath = "";
   let sessionName = "";
   let adapter: ZellijCliRuntimeAdapter;
+  let runtimeEnv: Record<string, string>;
   const extraSessionNames: string[] = [];
 
   beforeAll(async () => {
@@ -23,7 +25,8 @@ describe.runIf(available)("real bundled Zellij 0.44.3 integration", () => {
     expect(version.stdout.trim()).toBe("zellij 0.44.3");
     homePath = await mkdtemp(join(tmpdir(), "matrix-zellij-real-"));
     sessionName = `matrix-w-${randomBytes(16).toString("hex")}`;
-    adapter = new ZellijCliRuntimeAdapter({ homePath, binaryPath });
+    runtimeEnv = createTerminalRuntimeEnvironment({ homePath, uid: process.getuid?.() ?? 0 });
+    adapter = new ZellijCliRuntimeAdapter({ homePath, binaryPath, env: runtimeEnv });
     await adapter.ensureSession(sessionName, { cols: 100, rows: 30 });
   }, 20_000);
 
@@ -63,7 +66,7 @@ describe.runIf(available)("real bundled Zellij 0.44.3 integration", () => {
     await Promise.race([observed, new Promise<never>((_, reject) => setTimeout(async () => {
       const dump = await execFileAsync(binaryPath, ["--session", sessionName, "action", "dump-screen", "--pane-id", first.paneId, "--full", "--ansi"], {
         timeout: 5_000,
-        env: { ...process.env, HOME: homePath, MATRIX_HOME: homePath, ZELLIJ_CONFIG_DIR: join(homePath, "system", "zellij") },
+        env: runtimeEnv,
       }).catch(() => ({ stdout: "<dump failed>" }));
       reject(new Error(`observer did not receive targeted output; dump=${dump.stdout}; updates=${JSON.stringify(paneUpdates)}`));
     }, 15_000))]);
@@ -73,6 +76,51 @@ describe.runIf(available)("real bundled Zellij 0.44.3 integration", () => {
     await adapter.renameTab(sessionName, second.tabId, "renamed");
     await adapter.closeTab(sessionName, second.tabId);
     expect(await adapter.findTabByInternalName(sessionName, secondName)).toBeUndefined();
+  }, 30_000);
+
+  it("routes keyboard and terminal-emulator replies through the attached PTY", async () => {
+    const internalName = `matrix-tab-${randomBytes(16).toString("hex")}`;
+    const tab = await adapter.createTab(sessionName, { internalName, cwd: "", command: ["sh"] });
+    let output = "";
+    let attachmentExitCode: number | null | undefined;
+    const commandObserved = Promise.withResolvers<void>();
+    const paletteQueryObserved = Promise.withResolvers<void>();
+    const attachment = await adapter.openAttachment(sessionName, {
+      paneId: tab.paneId,
+      size: { cols: 100, rows: 30 },
+      onData: (data) => {
+        output = `${output}${new TextDecoder().decode(data)}`.slice(-64 * 1024);
+        if (output.split("matrix-pty-round-trip").length >= 3) commandObserved.resolve();
+        if (output.includes("\x1b]10;?")) paletteQueryObserved.resolve();
+      },
+      onExit: (exitCode) => { attachmentExitCode = exitCode; },
+    });
+
+    await attachment.write(new TextEncoder().encode("printf 'matrix-pty-round-trip\\n'\r"));
+    await Promise.race([
+      commandObserved.promise,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("attached PTY ignored keyboard input")), 10_000)),
+    ]);
+    await Promise.race([
+      paletteQueryObserved.promise,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`Zellij emitted no OSC 10 query: ${JSON.stringify(output.slice(0, 4096))}`)), 2_000)),
+    ]);
+    expect(await adapter.findTabByInternalName(sessionName, internalName)).toEqual(tab);
+    expect(attachmentExitCode).toBeUndefined();
+    const oscReply = Buffer.from("\x1b]10;rgb:1111/2222/3333\x07", "latin1");
+    await attachment.write(oscReply);
+    await new Promise<void>((resolve) => setTimeout(resolve, 250));
+    expect(await adapter.findTabByInternalName(sessionName, internalName)).toEqual(tab);
+    expect(attachmentExitCode).toBeUndefined();
+    const dump = await execFileAsync(binaryPath, [
+      "--session", sessionName, "action", "dump-screen", "--pane-id", tab.paneId, "--full", "--ansi",
+    ], {
+      timeout: 5_000,
+      env: runtimeEnv,
+    });
+    await attachment.close();
+
+    expect(dump.stdout).not.toContain("rgb:1111/2222/3333");
   }, 30_000);
 
   it("uses one substantially smaller Zellij server for 23 idle tabs", async () => {


### PR DESCRIPTION
## Summary

- route keyboard input and terminal-emulator replies through the same Zellij attach PTY that produces terminal output, instead of injecting them into the inner shell with a separate `write-chars` command
- add a bounded base64 binary-input frame so xterm binary reports survive renderer -> gateway -> terminal-runtime transport byte-for-byte
- negotiate `binary-input-v1` explicitly: new clients safely fall back against old runtimes, while new runtimes omit the extended handshake for older strict clients
- wire xterm `onBinary` in Web Canvas, Web Desktop, Web Mobile, Electron Desktop, and Native Mobile, including reconnect ordering, stale-attachment guards, and listener cleanup
- keep Native Mobile in `connecting` until the runtime's protocol-level `attached` frame arrives, rather than treating a transport-only WebSocket open as usable
- add a real Zellij regression that executes a command through the attachment, answers a real OSC color query, and proves the reply is not rendered inside the shell

## Tests

- TDD red: adapter regression initially showed zero PTY writes because input used Zellij `write-chars`
- TDD red: compatibility tests showed unconditional binary frames disconnect from old runtimes and unconditional handshake fields break old strict clients
- TDD red: Native Mobile dropped xterm binary replies and treated transport-open as attached
- 330 affected contracts, gateway, Web terminal, Electron terminal, runtime, migration, and adapter tests passed
- 15 Native Mobile terminal client/surface/session tests passed
- 6 terminal-runtime Unix socket tests passed, including exact ESC, BEL, ST, mouse-report, and non-UTF-8 byte preservation
- real Zellij 0.44.3 keyboard/OSC round-trip and 23-tab shared-server resource cases passed
- package typechecks passed for contracts, terminal-runtime, gateway, shell, and Electron Desktop
- Native Mobile's repository-wide TypeScript command remains blocked by pre-existing React Native dependency declaration conflicts outside this diff; the changed Mobile code is compiled by its passing Jest suites and audited by React Doctor
- pattern scanner: 0 violations
- React Doctor changed-file audits: no findings for shell, Electron Desktop, or Native Mobile
- `git diff --check` passed

## Review / Monitoring

- CI and Greptile are monitored on this PR; no merge until the latest trusted Greptile review is 5/5
- broad root typecheck/test commands require Bun, which is not installed in this runner; equivalent affected-package typechecks and focused suites were run locally, with full gates delegated to CI
- no screenshot is included because this repairs terminal transport behavior without changing visible layout, styling, or copy; live runtime verification is still required before rollout

## Invariants

- **Source of truth:** TerminalRef and terminal-runtime workspace state remain canonical; Zellij IDs stay private runtime identities. The live Zellij attach PTY is the single bidirectional terminal transport for an attached renderer.
- **Lock / transaction scope:** terminal input remains serialized by the existing per-tab input queue. Frame validation and base64 decoding happen before enqueueing; no network call is held inside a new lock.
- **Acceptable orphan states:** disconnects may leave the Zellij process running, as designed, but cannot leave an unbounded input buffer. Pending input stays capped and stale attachment generations cannot write.
- **Auth source of truth:** the gateway request principal and one-time attachment capability remain authoritative. Observe-only attachments are denied both text and binary input and hard resize.
- **Deferred scope:** this PR does not attempt recovery of terminal processes already lost during migration and does not delete existing customer tabs. Customer cleanup will be performed only after matching durable migration/test provenance to exact TerminalRefs; names alone are not sufficient.
