### PR TITLE
fix(platform): bootstrap previews from exact bundles

### DIFF
--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -332,8 +332,9 @@ jobs:
           provision_body="$(jq -cn \
             --arg owner "$PREVIEW_CLERK_USER_ID" \
             --arg handle "$HANDLE" \
+            --arg bundle_version "$VERSION" \
             --argjson access "$access_user_ids" \
-            '{clerkUserId: $owner, handle: $handle, runtimeSlot: $handle, accessClerkUserIds: $access}')"
+            '{clerkUserId: $owner, handle: $handle, runtimeSlot: $handle, accessClerkUserIds: $access, bundleVersion: $bundle_version}')"
           code="$(curl -sS --max-time 60 -o /tmp/provision.json -w '%{http_code}' \
             -X POST "${PLATFORM_PUBLIC_URL}/vps/preview/provision" \
             -H "authorization: Bearer ${PLATFORM_SECRET}" \

--- a/packages/platform/src/customer-vps-host-bundle.ts
+++ b/packages/platform/src/customer-vps-host-bundle.ts
@@ -1,0 +1,91 @@
+import type { PlatformDB } from './db.js';
+import {
+  getHostBundleRelease,
+  getHostBundleReleaseByChannel,
+} from './db.js';
+import type { CustomerVpsConfig } from './customer-vps-config.js';
+import { CustomerVpsError, logCustomerVpsError } from './customer-vps-errors.js';
+import { resolvePinnedPreviewTestSnapshotBundle } from './golden-snapshot-preview-test.js';
+
+const HOST_BUNDLE_CHANNELS = new Set(['stable', 'canary', 'beta', 'dev']);
+
+export interface HostBundleRef {
+  imageVersion: string;
+  hostBundleUrl: string;
+  sha256?: string | null;
+}
+
+function tryPinHostBundleUrlForImageVersion(
+  config: CustomerVpsConfig,
+  imageVersion: string,
+): string | undefined {
+  const currentSegment = `/system-bundles/${encodeURIComponent(config.imageVersion)}/`;
+  const url = new URL(config.hostBundleUrl);
+  if (!url.pathname.includes(currentSegment)) return undefined;
+  const pinnedSegment = `/system-bundles/${encodeURIComponent(imageVersion)}/`;
+  url.pathname = url.pathname.replaceAll(currentSegment, pinnedSegment);
+  return url.toString();
+}
+
+export function hostBundleUrlForImageVersion(
+  config: CustomerVpsConfig,
+  imageVersion: string,
+): string {
+  const pinnedUrl = tryPinHostBundleUrlForImageVersion(config, imageVersion);
+  if (pinnedUrl) return pinnedUrl;
+  // Defensive fallback for future URL-template changes. The current generated
+  // URL always contains the encoded image-version segment above.
+  const url = new URL(config.hostBundleUrl);
+  url.pathname = `/system-bundles/${encodeURIComponent(imageVersion)}/matrix-host-bundle.tar.gz`;
+  return url.toString();
+}
+
+export async function resolveHostBundleRef(
+  db: PlatformDB,
+  config: CustomerVpsConfig,
+  previewTestSnapshotId?: string,
+  previewBundleVersion?: string,
+): Promise<HostBundleRef> {
+  if (previewTestSnapshotId) {
+    return resolvePinnedPreviewTestSnapshotBundle({
+      db,
+      snapshotId: previewTestSnapshotId,
+      currentBundleVersion: config.imageVersion,
+      currentBundleUrl: config.hostBundleUrl,
+    });
+  }
+  if (previewBundleVersion) {
+    const release = await getHostBundleRelease(db, previewBundleVersion);
+    if (!release) {
+      throw new CustomerVpsError(409, 'invalid_state', 'Provisioning unavailable');
+    }
+    return {
+      imageVersion: release.version,
+      hostBundleUrl: hostBundleUrlForImageVersion(config, release.version),
+      sha256: release.sha256,
+    };
+  }
+  if (config.hostBundleUrlOverride || !HOST_BUNDLE_CHANNELS.has(config.imageVersion)) {
+    const release = await getHostBundleRelease(db, config.imageVersion);
+    return {
+      imageVersion: config.imageVersion,
+      hostBundleUrl: config.hostBundleUrl,
+      sha256: release?.sha256 ?? null,
+    };
+  }
+
+  const release = await getHostBundleReleaseByChannel(db, config.imageVersion);
+  if (!release) {
+    logCustomerVpsError(
+      `host bundle channel missing release channel=${config.imageVersion}`,
+      new Error('falling back to configured host bundle URL without immutable version pin'),
+    );
+    return { imageVersion: config.imageVersion, hostBundleUrl: config.hostBundleUrl, sha256: null };
+  }
+
+  return {
+    imageVersion: release.version,
+    hostBundleUrl: hostBundleUrlForImageVersion(config, release.version),
+    sha256: release.sha256,
+  };
+}

--- a/packages/platform/src/customer-vps-schema.ts
+++ b/packages/platform/src/customer-vps-schema.ts
@@ -42,6 +42,7 @@ export const ProvisionRequestSchema = z.object({
 
 export const PREVIEW_RUNTIME_SLOT_PATTERN = /^pr-[1-9][0-9]{0,9}$/;
 export const PreviewRuntimeSlotSchema = z.string().regex(PREVIEW_RUNTIME_SLOT_PATTERN);
+export const HostBundleVersionSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9._-]+$/);
 
 export const PreviewProvisionRequestSchema = z.object({
   clerkUserId: ClerkUserIdSchema,
@@ -50,6 +51,7 @@ export const PreviewProvisionRequestSchema = z.object({
   accessClerkUserIds: z.array(ClerkUserIdSchema).max(8).default([]),
   developerTools: DeveloperToolsSchema.optional(),
   testSnapshotId: z.uuid().optional(),
+  bundleVersion: HostBundleVersionSchema.optional(),
 }).strict()
   .refine((request) => request.handle === request.runtimeSlot, {
     message: 'Preview handle and runtime slot must match',
@@ -61,6 +63,9 @@ export const PreviewProvisionRequestSchema = z.object({
     (value, index, values) => values.indexOf(value) === index,
   ), {
     message: 'Preview collaborators must be unique',
+  })
+  .refine((request) => !(request.testSnapshotId && request.bundleVersion), {
+    message: 'Specify either a test snapshot or a bundle version',
   });
 
 export const RegisterRequestSchema = z.object({

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -14,8 +14,6 @@ import {
   completeUserMachineBillingSuspend,
   completeUserMachineRegistration,
   getActiveUserMachineByClerkId,
-  getHostBundleRelease,
-  getHostBundleReleaseByChannel,
   getUserMachine,
   insertUserMachine,
   insertProviderDeletion,
@@ -71,6 +69,11 @@ import {
   type ResizeMachineRequest,
 } from './customer-vps-schema.js';
 import { assertPreviewProvisioningCapacity, isPreviewMachine } from './customer-vps-preview.js';
+import {
+  hostBundleUrlForImageVersion,
+  resolveHostBundleRef,
+  type HostBundleRef,
+} from './customer-vps-host-bundle.js';
 import { selectCustomerVpsDeployMachines } from './customer-vps-deploy-selection.js';
 import {
   getRuntimeAccessDecision,
@@ -121,7 +124,6 @@ import {
   bindTestSnapshotToPreviewProvisionInTransaction,
   createPreviewTestSnapshotCreateIntent,
   isPreviewTestSnapshotDecision,
-  resolvePinnedPreviewTestSnapshotBundle,
   resolvePersistedProvisioningImage,
 } from './golden-snapshot-preview-test.js';
 
@@ -387,87 +389,8 @@ function buildHostConfig(
   };
 }
 
-const HOST_BUNDLE_CHANNELS = new Set(['stable', 'canary', 'beta', 'dev']);
 const MAX_LOCAL_PROVISION_LOCKS = 1_024;
 const MAX_LOCAL_PROVISION_QUEUE_DEPTH = 20;
-
-interface HostBundleRef {
-  imageVersion: string;
-  hostBundleUrl: string;
-  sha256?: string | null;
-}
-
-function tryPinHostBundleUrlForImageVersion(
-  config: CustomerVpsConfig,
-  imageVersion: string,
-): string | undefined {
-  const currentSegment = `/system-bundles/${encodeURIComponent(config.imageVersion)}/`;
-  const url = new URL(config.hostBundleUrl);
-  if (!url.pathname.includes(currentSegment)) return undefined;
-  const pinnedSegment = `/system-bundles/${encodeURIComponent(imageVersion)}/`;
-  url.pathname = url.pathname.replaceAll(currentSegment, pinnedSegment);
-  return url.toString();
-}
-
-function hostBundleUrlForImageVersion(config: CustomerVpsConfig, imageVersion: string): string {
-  const pinnedUrl = tryPinHostBundleUrlForImageVersion(config, imageVersion);
-  if (pinnedUrl) return pinnedUrl;
-  // Defensive fallback for future URL-template changes. The current generated
-  // URL always contains the encoded image-version segment above.
-  const url = new URL(config.hostBundleUrl);
-  url.pathname = `/system-bundles/${encodeURIComponent(imageVersion)}/matrix-host-bundle.tar.gz`;
-  return url.toString();
-}
-
-async function resolveHostBundleRef(
-  db: PlatformDB,
-  config: CustomerVpsConfig,
-  previewTestSnapshotId?: string,
-  previewBundleVersion?: string,
-): Promise<HostBundleRef> {
-  if (previewTestSnapshotId) {
-    return resolvePinnedPreviewTestSnapshotBundle({
-      db,
-      snapshotId: previewTestSnapshotId,
-      currentBundleVersion: config.imageVersion,
-      currentBundleUrl: config.hostBundleUrl,
-    });
-  }
-  if (previewBundleVersion) {
-    const release = await getHostBundleRelease(db, previewBundleVersion);
-    if (!release) {
-      throw new CustomerVpsError(409, 'invalid_state', 'Provisioning unavailable');
-    }
-    return {
-      imageVersion: release.version,
-      hostBundleUrl: hostBundleUrlForImageVersion(config, release.version),
-      sha256: release.sha256,
-    };
-  }
-  if (config.hostBundleUrlOverride || !HOST_BUNDLE_CHANNELS.has(config.imageVersion)) {
-    const release = await getHostBundleRelease(db, config.imageVersion);
-    return {
-      imageVersion: config.imageVersion,
-      hostBundleUrl: config.hostBundleUrl,
-      sha256: release?.sha256 ?? null,
-    };
-  }
-
-  const release = await getHostBundleReleaseByChannel(db, config.imageVersion);
-  if (!release) {
-    logCustomerVpsError(
-      `host bundle channel missing release channel=${config.imageVersion}`,
-      new Error('falling back to configured host bundle URL without immutable version pin'),
-    );
-    return { imageVersion: config.imageVersion, hostBundleUrl: config.hostBundleUrl, sha256: null };
-  }
-
-  return {
-    imageVersion: release.version,
-    hostBundleUrl: hostBundleUrlForImageVersion(config, release.version),
-    sha256: release.sha256,
-  };
-}
 
 function buildServerName(handle: string): string {
   return `matrix-${handle}`;

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -1898,6 +1898,12 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       throw new CustomerVpsError(400, 'invalid_state', 'Invalid request');
     }
 
+    // Validate operator-selected preview bundles before the idempotent existing
+    // machine return so retries cannot bypass the immutable release registry.
+    const explicitPreviewBundleRef = previewBundleVersion
+      ? await resolveHostBundleRef(deps.db, deps.config, undefined, previewBundleVersion)
+      : undefined;
+
     // A non-failed active machine (provisioning/running converge; recovering
     // is rejected by activeProvisionResponse). A `failed` row is retryable, so
     // it must NOT short-circuit here — it is retired inside the transaction.
@@ -1923,12 +1929,8 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       return activeProvisionResponse(reconciled, deps.config.provisionEtaSeconds);
     }
 
-    const bundleRef = await resolveHostBundleRef(
-      deps.db,
-      deps.config,
-      testSnapshotId,
-      previewBundleVersion,
-    );
+    const bundleRef = explicitPreviewBundleRef
+      ?? await resolveHostBundleRef(deps.db, deps.config, testSnapshotId);
 
     let provisionRow: { existing: UserMachineRecord | null };
     try {

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -423,6 +423,7 @@ async function resolveHostBundleRef(
   db: PlatformDB,
   config: CustomerVpsConfig,
   previewTestSnapshotId?: string,
+  previewBundleVersion?: string,
 ): Promise<HostBundleRef> {
   if (previewTestSnapshotId) {
     return resolvePinnedPreviewTestSnapshotBundle({
@@ -431,6 +432,17 @@ async function resolveHostBundleRef(
       currentBundleVersion: config.imageVersion,
       currentBundleUrl: config.hostBundleUrl,
     });
+  }
+  if (previewBundleVersion) {
+    const release = await getHostBundleRelease(db, previewBundleVersion);
+    if (!release) {
+      throw new CustomerVpsError(409, 'invalid_state', 'Provisioning unavailable');
+    }
+    return {
+      imageVersion: release.version,
+      hostBundleUrl: hostBundleUrlForImageVersion(config, release.version),
+      sha256: release.sha256,
+    };
   }
   if (config.hostBundleUrlOverride || !HOST_BUNDLE_CHANNELS.has(config.imageVersion)) {
     const release = await getHostBundleRelease(db, config.imageVersion);
@@ -1817,6 +1829,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     const testSnapshotId = provisioningClass === 'preview' && 'testSnapshotId' in input
       ? input.testSnapshotId
       : undefined;
+    const previewBundleVersion = provisioningClass === 'preview' && 'bundleVersion' in input
+      ? input.bundleVersion
+      : undefined;
     const request = {
       ...input,
       runtimeSlot: input.runtimeSlot ?? 'primary',
@@ -1908,7 +1923,12 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       return activeProvisionResponse(reconciled, deps.config.provisionEtaSeconds);
     }
 
-    const bundleRef = await resolveHostBundleRef(deps.db, deps.config, testSnapshotId);
+    const bundleRef = await resolveHostBundleRef(
+      deps.db,
+      deps.config,
+      testSnapshotId,
+      previewBundleVersion,
+    );
 
     let provisionRow: { existing: UserMachineRecord | null };
     try {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -912,7 +912,8 @@ test "$(readlink "$MATRIX_LEGACY_HOME/.hermes")" = "$MATRIX_HOME/.hermes"
     const workflow = readFileSync(join(root, '.github/workflows/preview-vps.yml'), 'utf8');
 
     expect(workflow).toContain('-X POST "${PLATFORM_PUBLIC_URL}/vps/preview/provision"');
-    expect(workflow).toContain('{clerkUserId: $owner, handle: $handle, runtimeSlot: $handle, accessClerkUserIds: $access}');
+    expect(workflow).toContain('--arg bundle_version "$VERSION"');
+    expect(workflow).toContain('{clerkUserId: $owner, handle: $handle, runtimeSlot: $handle, accessClerkUserIds: $access, bundleVersion: $bundle_version}');
     expect(workflow).not.toContain('-X POST "${PLATFORM_PUBLIC_URL}/vps/provision"');
     expect(workflow).not.toContain('"runtimeSlot":"preview"');
     expect(workflow).toContain('PREVIEW_CLERK_ACCESS_USER_IDS');

--- a/tests/platform/customer-vps-routes.test.ts
+++ b/tests/platform/customer-vps-routes.test.ts
@@ -174,6 +174,52 @@ describe('platform/customer-vps-routes', () => {
     });
     expect(provision).not.toHaveBeenCalled();
 
+    const exactBundleAccepted = await app.request('/vps/preview/provision', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        clerkUserId: 'user_123',
+        handle: 'pr-897',
+        runtimeSlot: 'pr-897',
+        bundleVersion: 'v2026.09.11-pr897-123-1-abcdef0',
+      }),
+    });
+    expect(exactBundleAccepted.status).toBe(202);
+    expect(provisionPreview).toHaveBeenLastCalledWith({
+      clerkUserId: 'user_123',
+      handle: 'pr-897',
+      runtimeSlot: 'pr-897',
+      accessClerkUserIds: [],
+      bundleVersion: 'v2026.09.11-pr897-123-1-abcdef0',
+    });
+
+    const ambiguousBundleSource = await app.request('/vps/preview/provision', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        clerkUserId: 'user_123',
+        handle: 'pr-897',
+        runtimeSlot: 'pr-897',
+        bundleVersion: 'v2026.09.11-pr897-123-1-abcdef0',
+        testSnapshotId: 'd9428888-122b-4d59-8619-9c97c6b2289d',
+      }),
+    });
+    expect(ambiguousBundleSource.status).toBe(400);
+    expect(provisionPreview).toHaveBeenCalledTimes(2);
+
+    const invalidBundleVersion = await app.request('/vps/preview/provision', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        clerkUserId: 'user_123',
+        handle: 'pr-897',
+        runtimeSlot: 'pr-897',
+        bundleVersion: '../stable',
+      }),
+    });
+    expect(invalidBundleVersion.status).toBe(400);
+    expect(provisionPreview).toHaveBeenCalledTimes(2);
+
     provisionPreview.mockRejectedValueOnce(new Error('provider token and private path leaked'));
     const failed = await app.request('/vps/preview/provision', {
       method: 'POST',

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -1384,6 +1384,57 @@ describe('platform/customer-vps', () => {
     expect(createInput?.userData).toContain('MATRIX_UPDATE_CHANNEL=stable');
   });
 
+  it('boots operator previews from an explicitly published immutable bundle', async () => {
+    const version = 'v2026.09.11-pr1607-34614651893-1-1388d33';
+    await upsertHostBundleRelease(db, {
+      version,
+      channel: 'none',
+      gitCommit: '1388d33397ff502ff046f5d65cf3c3538b44d283',
+      gitRef: 'codex/om-214-chat-agent-ui',
+      buildTime: '2026-09-11T15:20:00.000Z',
+      bundleKey: `system-bundles/${version}/matrix-host-bundle.tar.gz`,
+      checksumKey: `system-bundles/${version}/matrix-host-bundle.tar.gz.sha256`,
+      sha256: 'b'.repeat(64),
+      size: 1_257_725_742,
+      severity: 'normal',
+      updateType: 'manual',
+      changelog: 'Preview bundle',
+      createdAt: '2026-09-11T15:22:00.000Z',
+    });
+    const { service, hetzner } = createService();
+
+    const provisioned = await service.provisionPreview({
+      clerkUserId: 'user_123',
+      handle: 'pr-1607',
+      runtimeSlot: 'pr-1607',
+      bundleVersion: version,
+    });
+
+    expect((await getUserMachine(db, provisioned.machineId))?.imageVersion).toBe(version);
+    const createInput = vi.mocked(hetzner.createServer).mock.calls[0]?.[0];
+    expect(createInput?.userData).toContain(
+      `MATRIX_HOST_BUNDLE_URL=http://localhost:9000/system-bundles/${version}/matrix-host-bundle.tar.gz`,
+    );
+    expect(createInput?.userData).toContain(`MATRIX_IMAGE_VERSION=${version}`);
+    expect(createInput?.userData).toContain('MATRIX_UPDATE_CHANNEL=stable');
+  });
+
+  it('rejects an unpublished explicit preview bundle before creating a server', async () => {
+    const { service, hetzner } = createService();
+
+    await expect(service.provisionPreview({
+      clerkUserId: 'user_123',
+      handle: 'pr-1607',
+      runtimeSlot: 'pr-1607',
+      bundleVersion: 'v2026.09.11-pr1607-1-1-abcdef0',
+    })).rejects.toMatchObject({
+      status: 409,
+      code: 'invalid_state',
+      publicMessage: 'Provisioning unavailable',
+    });
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+  });
+
   it('can provision an isolated staging runtime for the same Clerk user', async () => {
     let nextId = 0;
     const ids = [

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -1435,6 +1435,28 @@ describe('platform/customer-vps', () => {
     expect(hetzner.createServer).not.toHaveBeenCalled();
   });
 
+  it('rejects an unpublished explicit bundle before resuming an existing preview', async () => {
+    const { service, hetzner } = createService();
+    await service.provisionPreview({
+      clerkUserId: 'user_123',
+      handle: 'pr-1607',
+      runtimeSlot: 'pr-1607',
+    });
+    vi.mocked(hetzner.createServer).mockClear();
+
+    await expect(service.provisionPreview({
+      clerkUserId: 'user_123',
+      handle: 'pr-1607',
+      runtimeSlot: 'pr-1607',
+      bundleVersion: 'v2026.09.11-pr1607-unknown',
+    })).rejects.toMatchObject({
+      status: 409,
+      code: 'invalid_state',
+      publicMessage: 'Provisioning unavailable',
+    });
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+  });
+
   it('can provision an isolated staging runtime for the same Clerk user', async () => {
     let nextId = 0;
     const ids = [


### PR DESCRIPTION
## Summary
- allow the trusted preview provision route to select an already-published immutable host bundle
- boot fresh preview VPSes from the exact PR bundle instead of the frozen stable bundle
- reject unpublished versions and ambiguous snapshot plus bundle requests before provider mutation

## Tests
- platform TypeScript type-check
- exact published and unpublished preview bundle service tests
- preview provision route auth and validation contract
- preview workflow provision payload contract

## Invariants
- **Source of truth:** platform host bundle release metadata is authoritative; the workflow supplies the immutable version it just published or explicitly validated.
- **Lock/transaction scope:** existing owner-scoped provisioning locks and the machine-claim transaction remain unchanged; release resolution happens before provider creation.
- **Acceptable orphan states:** no new orphan state is introduced; an unknown release fails before Hetzner mutation, while existing cleanup/reconciliation continues to own provider cleanup.
- **Auth source of truth:** only the platform bearer-authenticated preview route may request an exact bundle; snapshot selection remains restricted to the distinct snapshot-operator credential.
- **Deferred scope:** existing previews already stuck on an older bootstrap bundle still require teardown and reprovisioning. Customer provisioning and stable-channel selection are unchanged. No public product documentation changes are needed for this internal preview deployment repair.