### PR TITLE
fix(terminal): trust supervised workspace readiness

### DIFF
--- a/packages/terminal-runtime/src/zellij-adapter.ts
+++ b/packages/terminal-runtime/src/zellij-adapter.ts
@@ -150,8 +150,11 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
   async ensureSession(sessionNameInput: string, size = { cols: 120, rows: 36 }): Promise<void> {
     const logicalSessionName = z.string().regex(SESSION_NAME).parse(sessionNameInput);
     if (this.workspaceLifecycle) {
-      const target = await this.workspaceLifecycle.ensureWorkspaceSession(logicalSessionName, size);
-      await this.waitForSession(target.sessionName, target.binaryPath);
+      // The systemd lifecycle does its own invocation-fenced readiness check
+      // before returning. Re-probing with `list-panes` scales with every pane
+      // in a migrated workspace and can exceed this adapter's fixed timeout
+      // even though the owned runtime is already ready.
+      await this.workspaceLifecycle.ensureWorkspaceSession(logicalSessionName, size);
       return;
     }
     const sessionName = logicalSessionName;

--- a/tests/terminal-runtime/zellij-adapter.test.ts
+++ b/tests/terminal-runtime/zellij-adapter.test.ts
@@ -260,6 +260,29 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
     expect(lifecycle.deleteWorkspaceSession).toHaveBeenCalledWith(logicalName);
   });
 
+  it("trusts the systemd lifecycle readiness fence when ensuring a workspace", async () => {
+    const logicalName = "matrix-w-0123456789abcdef0123456789abcdef";
+    const ownedName = "matrix-rt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const binaryPath = `/opt/matrix/terminal-runtime/generations/gen_${"b".repeat(64)}/zellij`;
+    const run = vi.fn(async () => "[]");
+    const ensureWorkspaceSession = vi.fn(async () => ({ sessionName: ownedName, binaryPath }));
+    const adapter = new ZellijCliRuntimeAdapter({
+      homePath: "/home/matrix",
+      run,
+      workspaceLifecycle: {
+        resolveWorkspaceTarget: vi.fn(),
+        ensureWorkspaceSession,
+        deleteWorkspaceSession: vi.fn(),
+      },
+    });
+
+    await expect(adapter.ensureSession(logicalName, { cols: 120, rows: 36 }))
+      .resolves.toBeUndefined();
+
+    expect(ensureWorkspaceSession).toHaveBeenCalledWith(logicalName, { cols: 120, rows: 36 });
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it("skips rollback cleanup for workspace sessions that were never created", async () => {
     const existingSession = "matrix-w-0123456789abcdef0123456789abcdef";
     const missingSession = "matrix-w-fedcba9876543210fedcba9876543210";


### PR DESCRIPTION
## Summary

Terminal workspace migration can fail on an already-ready supervised Zellij workspace because `ensureSession()` performs a second `list-panes` readiness probe after the systemd lifecycle has already passed its invocation-fenced readiness check. Dense migrated workspaces make that probe exceed the fixed 10-second adapter timeout, aborting the Terminal control plane and causing **New** to return `503 runtime_unavailable`.

Trust the systemd lifecycle result and skip the redundant pane enumeration. Legacy non-systemd sessions keep their existing readiness probe.

## Tests

- `pnpm exec vitest run tests/terminal-runtime/zellij-adapter.test.ts tests/terminal-runtime/migration.test.ts tests/terminal-runtime/user-systemd-workspace.test.ts` (41 passed)
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing scanner warnings only)

## Review/Monitoring

- Reproduced on a live dense migration: the supervised workspace was active, while `list-panes --json` returned 110 panes and took about 11.5 seconds against a 10-second readiness deadline.
- Awaiting Greptile review and label-gated CI.

## Invariants

- Source of truth: the systemd runtime controller's invocation-fenced readiness signal remains authoritative for supervised workspaces.
- Lock/transaction scope: unchanged; no database or filesystem transaction boundaries change.
- Acceptable orphan states: unchanged; the lifecycle still must create or start the owned unit successfully before the adapter returns.
- Auth source of truth: unchanged.
- Deferred scope: legacy non-systemd Zellij readiness behavior remains unchanged.
