### PR TITLE
fix(terminal): batch dense workspace reconciliation

### DIFF
--- a/packages/terminal-runtime/src/limits.ts
+++ b/packages/terminal-runtime/src/limits.ts
@@ -13,3 +13,11 @@ export const MAX_TERMINAL_SNAPSHOT_BYTES =
 export const MAX_TERMINAL_RUNTIME_REQUEST_FRAME_BYTES = 8 * 1024 * 1024;
 export const MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES =
   MAX_TERMINAL_SNAPSHOT_BYTES + (1024 * 1024);
+
+// Dense tab creation has one aggregate operation deadline. Each child command
+// receives only the remaining time, so work cannot continue after the caller's
+// request has failed. The socket layers retain explicit response margin.
+export const TERMINAL_RUNTIME_COMMAND_TIMEOUT_MS = 30_000;
+export const TERMINAL_RUNTIME_CONTROL_OPERATION_TIMEOUT_MS = 150_000;
+export const TERMINAL_RUNTIME_SERVER_IDLE_TIMEOUT_MS = 180_000;
+export const TERMINAL_RUNTIME_CLIENT_REQUEST_TIMEOUT_MS = 210_000;

--- a/packages/terminal-runtime/src/migration.ts
+++ b/packages/terminal-runtime/src/migration.ts
@@ -84,6 +84,11 @@ type Journal = z.infer<typeof JournalSchema>;
 export interface LegacyZellijCutover {
   stopLegacySessions(names: string[]): Promise<void>;
   ensureWorkspace(sessionName: string, size: { cols: number; rows: number }): Promise<void>;
+  prepareShellTabs?(sessionName: string, inputs: Array<{
+    internalName: string;
+    cwd: string;
+    command?: never;
+  }>): Promise<Record<string, { tabId: number; paneId: string }>>;
   createShellTab(sessionName: string, input: {
     internalName: string;
     cwd: string;
@@ -266,7 +271,20 @@ async function prepareReplacementWorkspaces(
     const internal = await stagedStore.getRuntimeWorkspace(workspace.id);
     if (!internal) throw new Error("staged_workspace_missing");
     await cutover.ensureWorkspace(internal.zellijSessionName, internal.canonicalSize);
-    for (const tab of Object.values(internal.tabs).sort((left, right) => left.order - right.order)) {
+    const tabs = Object.values(internal.tabs).sort((left, right) => left.order - right.order);
+    if (cutover.prepareShellTabs) {
+      const prepared = await cutover.prepareShellTabs(
+        internal.zellijSessionName,
+        tabs.map((tab) => ({ internalName: tab.zellijTabName, cwd: tab.cwd })),
+      );
+      for (const tab of tabs) {
+        const ids = prepared[tab.zellijTabName];
+        if (!ids) throw new Error("prepared_terminal_tab_missing");
+        await stagedStore.activateTab({ workspaceId: internal.id, tabId: tab.id }, ids);
+      }
+      continue;
+    }
+    for (const tab of tabs) {
       const ref = { workspaceId: internal.id, tabId: tab.id };
       let ids = await cutover.findTabByInternalName?.(internal.zellijSessionName, tab.zellijTabName);
       ids ??= tab.zellijTabId !== null && tab.zellijPaneId !== null

--- a/packages/terminal-runtime/src/socket-client.ts
+++ b/packages/terminal-runtime/src/socket-client.ts
@@ -12,7 +12,10 @@ import {
 import { z } from "zod/v4";
 import { terminalRuntimeErrorFromDetails } from "./errors.js";
 import { encodeSocketFrame, SocketFrameDecoder } from "./socket-framing.js";
-import { MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES } from "./limits.js";
+import {
+  MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES,
+  TERMINAL_RUNTIME_CLIENT_REQUEST_TIMEOUT_MS,
+} from "./limits.js";
 import {
   TerminalRuntimeResponseSchema,
   type TerminalRuntimeRequest,
@@ -34,7 +37,7 @@ export class TerminalRuntimeSocketClient {
 
   constructor(options: TerminalRuntimeSocketClientOptions) {
     this.socketPath = options.socketPath;
-    this.timeoutMs = options.timeoutMs ?? 10_000;
+    this.timeoutMs = options.timeoutMs ?? TERMINAL_RUNTIME_CLIENT_REQUEST_TIMEOUT_MS;
   }
 
   async listWorkspaces(): Promise<TerminalWorkspace[]> {

--- a/packages/terminal-runtime/src/socket-server.ts
+++ b/packages/terminal-runtime/src/socket-server.ts
@@ -13,7 +13,10 @@ import type { z } from "zod/v4";
 import { terminalRuntimeErrorDetails } from "./errors.js";
 import type { TerminalSnapshot } from "./workspace-store.js";
 import { encodeSocketFrame, SocketFrameDecoder } from "./socket-framing.js";
-import { MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES } from "./limits.js";
+import {
+  MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES,
+  TERMINAL_RUNTIME_SERVER_IDLE_TIMEOUT_MS,
+} from "./limits.js";
 import {
   TerminalRuntimeRequestSchema,
   type TerminalRuntimeRequest,
@@ -132,7 +135,10 @@ export class TerminalRuntimeSocketServer {
       return;
     }
     this.connections.add(socket);
-    socket.setTimeout(this.options.idleTimeoutMs ?? 30_000, () => socket.destroy());
+    socket.setTimeout(
+      this.options.idleTimeoutMs ?? TERMINAL_RUNTIME_SERVER_IDLE_TIMEOUT_MS,
+      () => socket.destroy(),
+    );
     const decoder = new SocketFrameDecoder();
     let handled = false;
     let streamMessage: ((raw: unknown) => Promise<void>) | null = null;

--- a/packages/terminal-runtime/src/zellij-adapter.ts
+++ b/packages/terminal-runtime/src/zellij-adapter.ts
@@ -10,6 +10,10 @@ import type {
   ZellijObserverEvent,
   ZellijRuntimeAdapter,
 } from "./runtime.js";
+import {
+  TERMINAL_RUNTIME_COMMAND_TIMEOUT_MS,
+  TERMINAL_RUNTIME_CONTROL_OPERATION_TIMEOUT_MS,
+} from "./limits.js";
 import { createTerminalRuntimeEnvironment } from "./runtime-environment.js";
 
 const MAX_COMMAND_OUTPUT_BYTES = 5 * 1024 * 1024;
@@ -101,7 +105,11 @@ export interface ZellijCliRuntimeAdapterOptions {
 export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
   private readonly homePath: string;
   private readonly binaryPath: string;
-  private readonly runCommand: NonNullable<ZellijCliRuntimeAdapterOptions["run"]>;
+  private readonly runCommand: (
+    args: string[],
+    binaryPath?: string,
+    timeoutMs?: number,
+  ) => Promise<string>;
   private readonly resolveRealpath: (path: string) => Promise<string>;
   private readonly spawnPtyProcess: NonNullable<ZellijCliRuntimeAdapterOptions["spawnPty"]>;
   private readonly spawnSubscriptionProcess: NonNullable<ZellijCliRuntimeAdapterOptions["spawnSubscription"]>;
@@ -122,17 +130,21 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
       binaryPath: this.binaryPath,
       cwd: this.homePath,
       env: this.runtimeEnvironment,
-      timeoutMs: options.timeoutMs ?? 10_000,
+      timeoutMs: options.timeoutMs ?? TERMINAL_RUNTIME_COMMAND_TIMEOUT_MS,
     });
-    this.runCommand = options.run ?? ((args, binaryPath) => {
-      if (!binaryPath || binaryPath === this.binaryPath) return currentGenerationRunner(args);
-      return createCommandRunner({
-        binaryPath,
-        cwd: this.homePath,
-        env: this.runtimeEnvironment,
-        timeoutMs: options.timeoutMs ?? 10_000,
-      })(args);
-    });
+    this.runCommand = options.run
+      ? ((args, binaryPath) => binaryPath === undefined
+          ? options.run!(args)
+          : options.run!(args, binaryPath))
+      : ((args, binaryPath, timeoutMs) => {
+        if (!binaryPath || binaryPath === this.binaryPath) return currentGenerationRunner(args, timeoutMs);
+        return createCommandRunner({
+          binaryPath,
+          cwd: this.homePath,
+          env: this.runtimeEnvironment,
+          timeoutMs: options.timeoutMs ?? TERMINAL_RUNTIME_COMMAND_TIMEOUT_MS,
+        })(args, timeoutMs);
+      });
     this.resolveRealpath = options.resolveRealpath ?? nodeRealpath;
     this.spawnPtyProcess = options.spawnPty ?? ((args, spawnOptions) => {
       return spawnNodePty(spawnOptions.binaryPath ?? this.binaryPath, args, {
@@ -177,6 +189,94 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
     return this.createTab(sessionName, input);
   }
 
+  async prepareShellTabs(sessionNameInput: string, inputs: Array<{
+    internalName: string;
+    cwd: string;
+    command?: string[];
+  }>, operationDeadline?: number): Promise<Record<string, { tabId: number; paneId: string }>> {
+    const { sessionName, binaryPath } = await this.resolveWorkspaceTarget(sessionNameInput);
+    const requested = z.array(z.object({
+      internalName: z.string().regex(TAB_NAME),
+      cwd: z.string(),
+      command: z.array(z.string()).max(1_000).optional(),
+    }).strict()).max(10_000).parse(inputs);
+    if (new Set(requested.map((input) => input.internalName)).size !== requested.length) {
+      throw new Error("Terminal tab names must be unique");
+    }
+    if (requested.length === 0) return {};
+
+    const tabs = await this.readStructuredJson(
+      ["--session", sessionName, "action", "list-tabs", "--json"],
+      z.array(TabSchema).max(10_000),
+      binaryPath,
+      operationDeadline,
+    );
+    const bootstrap = tabs.find((tab) => tab.name === "matrix-bootstrap");
+    const tabsByName = new Map(tabs.map((tab) => [tab.name, tab]));
+    const tabIds = new Map(
+      requested.flatMap((input) => {
+        const tab = tabsByName.get(input.internalName);
+        return tab ? [[input.internalName, tab.tab_id] as const] : [];
+      }),
+    );
+    const missing = requested.filter((input) => !tabIds.has(input.internalName));
+    const resolvedCwds = new Map(await Promise.all(missing.map(async (input) => [
+      input.internalName,
+      await this.resolveCwd(input.cwd),
+    ] as const)));
+
+    for (const input of missing) {
+      const cwd = resolvedCwds.get(input.internalName)!;
+      const output = await this.run([
+        "--session", sessionName, "action", "new-tab",
+        "--name", input.internalName,
+        "--cwd", cwd,
+        ...(input.command ? ["--", ...input.command] : []),
+      ], binaryPath, remainingCommandTimeout(operationDeadline));
+      const outputTabId = output.trim();
+      const tabId = /^\d+$/.test(outputTabId)
+        ? z.coerce.number().int().min(0).parse(outputTabId)
+        : await this.waitForTabId(sessionName, input.internalName, binaryPath, operationDeadline);
+      tabIds.set(input.internalName, tabId);
+    }
+    if (bootstrap) {
+      await this.run([
+        "--session", sessionName, "action", "close-tab", "--tab-id", String(bootstrap.tab_id),
+      ], binaryPath, remainingCommandTimeout(operationDeadline));
+    }
+
+    const panes = await this.waitForManagedPanes(
+      sessionName,
+      [...tabIds.values()],
+      binaryPath,
+      operationDeadline,
+    );
+    const panesByTab = new Map<number, Array<z.infer<typeof PaneSchema>>>();
+    for (const pane of panes) {
+      if (pane.is_plugin) continue;
+      const tabPanes = panesByTab.get(pane.tab_id) ?? [];
+      tabPanes.push(pane);
+      panesByTab.set(pane.tab_id, tabPanes);
+    }
+    const prepared: Record<string, { tabId: number; paneId: string }> = {};
+    for (const input of requested) {
+      const tabId = tabIds.get(input.internalName);
+      if (tabId === undefined) throw new Error("Managed terminal tab failed to report its identifier");
+      const managedPanes = panesByTab.get(tabId) ?? [];
+      const primaryPane = managedPanes.find((pane) => pane.pane_title === input.internalName)
+        ?? managedPanes.toSorted((left, right) => left.id - right.id)[0];
+      if (!primaryPane) throw new Error("Managed terminal tab primary pane is unavailable");
+      const paneId = `terminal_${primaryPane.id}`;
+      if (primaryPane.pane_title !== input.internalName) {
+        await this.run([
+          "--session", sessionName, "action", "rename-pane", "--pane-id", paneId, input.internalName,
+        ], binaryPath, remainingCommandTimeout(operationDeadline));
+      }
+      prepared[input.internalName] = { tabId, paneId };
+    }
+    return prepared;
+  }
+
   async stopLegacySessions(namesInput: string[]): Promise<void> {
     const names = z.array(z.string().regex(LEGACY_SESSION_NAME)).max(10_000).parse(namesInput);
     for (const name of names) {
@@ -210,31 +310,14 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
     cwd: string;
     command?: string[];
   }): Promise<{ tabId: number; paneId: string }> {
-    const { sessionName, binaryPath } = await this.resolveWorkspaceTarget(sessionNameInput);
     const internalName = z.string().regex(TAB_NAME).parse(input.internalName);
-    const cwd = await this.resolveCwd(input.cwd);
-    const tabs = await this.readStructuredJson(
-      ["--session", sessionName, "action", "list-tabs", "--json"],
-      z.array(TabSchema).max(10_000),
-      binaryPath,
+    await this.resolveCwd(input.cwd);
+    const prepared = await this.prepareShellTabs(
+      sessionNameInput,
+      [{ ...input, internalName }],
+      Date.now() + TERMINAL_RUNTIME_CONTROL_OPERATION_TIMEOUT_MS,
     );
-    const bootstrap = tabs.find((tab) => tab.name === "matrix-bootstrap");
-    const output = await this.run([
-      "--session", sessionName, "action", "new-tab",
-      "--name", internalName,
-      "--cwd", cwd,
-      ...(input.command ? ["--", ...input.command] : []),
-    ], binaryPath);
-    const outputTabId = output.trim();
-    const tabId = /^\d+$/.test(outputTabId)
-      ? z.coerce.number().int().min(0).parse(outputTabId)
-      : await this.waitForTabId(sessionName, internalName, binaryPath);
-    if (bootstrap) {
-      await this.run(["--session", sessionName, "action", "close-tab", "--tab-id", String(bootstrap.tab_id)], binaryPath);
-    }
-    const paneId = await this.waitForManagedPane(sessionName, tabId, binaryPath);
-    await this.run(["--session", sessionName, "action", "rename-pane", "--pane-id", paneId, internalName], binaryPath);
-    return { tabId, paneId };
+    return prepared[internalName]!;
   }
 
   async openAttachment(sessionNameInput: string, input: {
@@ -504,21 +587,26 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
     return canonicalCwd;
   }
 
-  private run(args: string[], binaryPath = this.binaryPath): Promise<string> {
+  private run(args: string[], binaryPath = this.binaryPath, timeoutMs?: number): Promise<string> {
     return binaryPath === this.binaryPath
-      ? this.runCommand(args)
-      : this.runCommand(args, binaryPath);
+      ? this.runCommand(args, undefined, timeoutMs)
+      : this.runCommand(args, binaryPath, timeoutMs);
   }
 
   private async readStructuredJson<T>(
     args: string[],
     schema: z.ZodType<T>,
     binaryPath = this.binaryPath,
+    operationDeadline?: number,
   ): Promise<T> {
     let lastError: unknown;
     for (let attempt = 0; attempt < 10; attempt += 1) {
       try {
-        const output = (await this.run(args, binaryPath)).trim();
+        const output = (await this.run(
+          args,
+          binaryPath,
+          remainingCommandTimeout(operationDeadline),
+        )).trim();
         const arrayStart = output.indexOf("[");
         const objectStart = output.indexOf("{");
         const start = arrayStart < 0
@@ -539,34 +627,39 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
     throw lastError instanceof Error ? lastError : new Error("Zellij structured command failed");
   }
 
-  private async waitForManagedPane(
+  private async waitForManagedPanes(
     sessionName: string,
-    tabId: number,
+    tabIds: number[],
     binaryPath = this.binaryPath,
-  ): Promise<string> {
+    operationDeadline?: number,
+  ): Promise<Array<z.infer<typeof PaneSchema>>> {
+    const requested = new Set(tabIds);
     for (let attempt = 0; attempt < STRUCTURED_READINESS_ATTEMPTS; attempt += 1) {
       const panes = await this.readStructuredJson(
         ["--session", sessionName, "action", "list-panes", "--all", "--json"],
         z.array(PaneSchema).max(10_000),
         binaryPath,
+        operationDeadline,
       );
-      const tabPanes = panes.filter((pane) => pane.tab_id === tabId && !pane.is_plugin);
-      if (tabPanes.length === 1) return `terminal_${tabPanes[0]!.id}`;
+      const ready = new Set(panes.filter((pane) => !pane.is_plugin).map((pane) => pane.tab_id));
+      if ([...requested].every((tabId) => ready.has(tabId))) return panes;
       await new Promise<void>((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
     }
-    throw new Error("Managed terminal tab must contain exactly one pane");
+    throw new Error("Managed terminal tabs must each contain a pane");
   }
 
   private async waitForTabId(
     sessionName: string,
     internalName: string,
     binaryPath = this.binaryPath,
+    operationDeadline?: number,
   ): Promise<number> {
     for (let attempt = 0; attempt < STRUCTURED_READINESS_ATTEMPTS; attempt += 1) {
       const tabs = await this.readStructuredJson(
         ["--session", sessionName, "action", "list-tabs", "--json"],
         z.array(TabSchema).max(10_000),
         binaryPath,
+        operationDeadline,
       );
       const tab = tabs.find((candidate) => candidate.name === internalName);
       if (tab) return tab.tab_id;
@@ -650,12 +743,12 @@ function createCommandRunner(options: {
   cwd: string;
   env: Record<string, string>;
   timeoutMs: number;
-}): (args: string[]) => Promise<string> {
-  return (args) => new Promise((resolve, reject) => {
+}): (args: string[], timeoutMs?: number) => Promise<string> {
+  return (args, timeoutMs) => new Promise((resolve, reject) => {
     nodeExecFile(options.binaryPath, args, {
       cwd: options.cwd,
       env: options.env,
-      timeout: options.timeoutMs,
+      timeout: timeoutMs ?? options.timeoutMs,
       maxBuffer: MAX_COMMAND_OUTPUT_BYTES,
     }, (error, stdout, stderr) => {
       if (error) {
@@ -666,6 +759,13 @@ function createCommandRunner(options: {
       } else resolve(String(stdout));
     });
   });
+}
+
+function remainingCommandTimeout(operationDeadline?: number): number | undefined {
+  if (operationDeadline === undefined) return undefined;
+  const remaining = operationDeadline - Date.now();
+  if (remaining <= 0) throw new Error("Terminal runtime operation timed out");
+  return Math.min(TERMINAL_RUNTIME_COMMAND_TIMEOUT_MS, remaining);
 }
 
 function isMissingZellijSessionFailure(error: unknown): boolean {

--- a/tests/terminal-runtime/migration.test.ts
+++ b/tests/terminal-runtime/migration.test.ts
@@ -44,6 +44,48 @@ describe("terminal workspace cutover", () => {
     expect(events.slice(0, stopIndex).filter((event) => event.startsWith("tab:"))).toHaveLength(2);
   });
 
+  it("batch-reconciles all replacement tabs in a workspace", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-batch-"));
+    homes.push(homePath);
+    await mkdir(join(homePath, "system"), { recursive: true });
+    await writeFile(join(homePath, "system", "shell-sessions.json"), JSON.stringify({
+      sessions: {
+        first: { name: "first", status: "active", cwd: "" },
+        second: { name: "second", status: "active", cwd: "" },
+      },
+    }));
+    const batches: string[][] = [];
+    const cutover: LegacyZellijCutover = {
+      ensureWorkspace: async () => undefined,
+      prepareShellTabs: async (_sessionName, inputs) => {
+        batches.push(inputs.map((input) => input.internalName));
+        return Object.fromEntries(inputs.map((input, index) => [
+          input.internalName,
+          { tabId: index + 7, paneId: `terminal_${index + 12}` },
+        ]));
+      },
+      findTabByInternalName: async () => { throw new Error("per-tab lookup must not run"); },
+      createShellTab: async () => { throw new Error("per-tab creation must not run"); },
+      stopLegacySessions: async () => undefined,
+    };
+
+    await expect(migrateTerminalWorkspaces({ homePath, projects: [], cutover }))
+      .resolves.toMatchObject({ status: "committed", migratedTabs: 2 });
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(2);
+    const state = JSON.parse(await readFile(join(homePath, "system", "terminal-workspaces.json"), "utf8"));
+    const workspace = Object.values(state.workspaces)[0] as { tabs: Record<string, {
+      status: string;
+      zellijTabId: number;
+      zellijPaneId: string;
+    }> };
+    expect(Object.values(workspace.tabs)).toEqual([
+      expect.objectContaining({ status: "running", zellijTabId: 7, zellijPaneId: "terminal_12" }),
+      expect.objectContaining({ status: "running", zellijTabId: 8, zellijPaneId: "terminal_13" }),
+    ]);
+  });
+
   it("leaves legacy sessions running when replacement preparation fails", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-migration-prepare-failure-"));
     homes.push(homePath);

--- a/tests/terminal-runtime/socket-api.test.ts
+++ b/tests/terminal-runtime/socket-api.test.ts
@@ -10,6 +10,10 @@ import {
   MAX_TERMINAL_RUNTIME_REQUEST_FRAME_BYTES,
   MAX_TERMINAL_RUNTIME_RESPONSE_FRAME_BYTES,
   MAX_TERMINAL_SNAPSHOT_BYTES,
+  TERMINAL_RUNTIME_COMMAND_TIMEOUT_MS,
+  TERMINAL_RUNTIME_CONTROL_OPERATION_TIMEOUT_MS,
+  TERMINAL_RUNTIME_SERVER_IDLE_TIMEOUT_MS,
+  TERMINAL_RUNTIME_CLIENT_REQUEST_TIMEOUT_MS,
 } from "../../packages/terminal-runtime/src/limits.js";
 
 const directories: string[] = [];
@@ -19,6 +23,15 @@ afterEach(async () => {
 });
 
 describe("terminal runtime Unix socket API", () => {
+  it("keeps the end-to-end request deadline above the dense multi-command budget", () => {
+    expect(TERMINAL_RUNTIME_CONTROL_OPERATION_TIMEOUT_MS)
+      .toBeGreaterThan(TERMINAL_RUNTIME_COMMAND_TIMEOUT_MS);
+    expect(TERMINAL_RUNTIME_SERVER_IDLE_TIMEOUT_MS)
+      .toBeGreaterThan(TERMINAL_RUNTIME_CONTROL_OPERATION_TIMEOUT_MS);
+    expect(TERMINAL_RUNTIME_CLIENT_REQUEST_TIMEOUT_MS)
+      .toBeGreaterThan(TERMINAL_RUNTIME_SERVER_IDLE_TIMEOUT_MS);
+  });
+
   it("keeps legacy five MiB snapshots within a finite socket-frame bound", () => {
     const value = { type: "snapshot", ansi: "x".repeat(5 * 1024 * 1024) };
     const frame = encodeSocketFrame(value);

--- a/tests/terminal-runtime/zellij-adapter.test.ts
+++ b/tests/terminal-runtime/zellij-adapter.test.ts
@@ -387,6 +387,57 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
     expect(tabReads).toBe(2);
   });
 
+  it("reconciles a dense workspace with one pane inventory", async () => {
+    const logicalName = "matrix-w-0123456789abcdef0123456789abcdef";
+    const ownedName = "matrix-rt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const binaryPath = `/opt/matrix/terminal-runtime/generations/gen_${"b".repeat(64)}/zellij`;
+    const existingName = "matrix-tab-0123456789abcdef0123456789abcdef";
+    const missingName = "matrix-tab-fedcba9876543210fedcba9876543210";
+    const run = vi.fn(async (args: string[]) => {
+      if (args.includes("list-tabs")) {
+        return JSON.stringify([
+          { tab_id: 0, name: "matrix-bootstrap" },
+          { tab_id: 7, name: existingName },
+        ]);
+      }
+      if (args.includes("new-tab")) return "8\n";
+      if (args.includes("list-panes")) {
+        return JSON.stringify([
+          { id: 12, is_plugin: false, tab_id: 7, pane_title: existingName },
+          { id: 13, is_plugin: false, tab_id: 8, pane_title: "shell" },
+        ]);
+      }
+      return "";
+    });
+    const adapter = new ZellijCliRuntimeAdapter({
+      homePath: "/home/matrix",
+      run,
+      resolveRealpath: lexicalRealpath,
+      workspaceLifecycle: {
+        resolveWorkspaceTarget: vi.fn(async () => ({ sessionName: ownedName, binaryPath })),
+        ensureWorkspaceSession: vi.fn(),
+        deleteWorkspaceSession: vi.fn(),
+      },
+    });
+
+    await expect(adapter.prepareShellTabs(logicalName, [
+      { internalName: existingName, cwd: "" },
+      { internalName: missingName, cwd: "projects/matrix-os" },
+    ])).resolves.toEqual({
+      [existingName]: { tabId: 7, paneId: "terminal_12" },
+      [missingName]: { tabId: 8, paneId: "terminal_13" },
+    });
+
+    expect(run.mock.calls.filter(([args]) => args.includes("list-tabs"))).toHaveLength(1);
+    expect(run.mock.calls.filter(([args]) => args.includes("list-panes"))).toHaveLength(1);
+    expect(run).toHaveBeenCalledWith([
+      "--session", ownedName, "action", "close-tab", "--tab-id", "0",
+    ], binaryPath);
+    expect(run).toHaveBeenCalledWith([
+      "--session", ownedName, "action", "rename-pane", "--pane-id", "terminal_13", missingName,
+    ], binaryPath);
+  });
+
   it("resolves tab cwd inside Matrix home and rejects missing or symlink-escaped paths", async () => {
     const root = await mkdtemp(join(tmpdir(), "matrix-runtime-tab-cwd-"));
     const homePath = join(root, "home");


### PR DESCRIPTION
Dense migrated Zellij workspaces timed out while Terminal created or recovered a tab because each tab triggered a full pane inventory. A workspace with 157 tabs could therefore fail migration after minutes, and a single **New** action returned `runtime_unavailable` at the 10-second boundary.

This change reconciles all requested tabs from one tab inventory and one bounded pane inventory, reuses that batch path for individual tab creation, and raises the command/socket bounds to 30 seconds for the measured dense-workspace scan. Existing primary-pane recovery and generation pinning remain intact.

## Validation

- TDD red: batch migration called the per-tab lookup and the adapter had no batch API
- `pnpm exec vitest run tests/terminal-runtime` — 110 passed
- `pnpm --filter @matrix-os/terminal-runtime build`
- `git diff --check`

## Invariants

- **Source of truth:** `TerminalWorkspaceStore` remains canonical; Zellij tab/pane IDs are reconciled into staged state before commit.
- **Lock/transaction scope:** existing workspace mutation and atomic migration-journal boundaries are unchanged; batching only replaces repeated read/reconcile calls during the same preparation phase.
- **Acceptable orphan states:** replacement Zellij workspaces may remain staged before migration commit and are handled by the existing rollback journal and workspace cleanup path.
- **Auth source of truth:** unchanged; the owner-only Unix socket and gateway authentication remain authoritative.
- **Deferred scope:** optimizing ordinary pane-geometry actions and changing the 10,000-tab capacity are outside this incident fix.
