### PR TITLE
fix(terminal): batch dense workspace restoration

### DIFF
--- a/packages/terminal-runtime/src/runtime.ts
+++ b/packages/terminal-runtime/src/runtime.ts
@@ -34,6 +34,10 @@ export interface ZellijRuntimeAdapter {
     onEvent: (event: ZellijObserverEvent) => void;
   }): Promise<ZellijObserver>;
   findTabByInternalName?(sessionName: string, internalName: string): Promise<{ tabId: number; paneId: string } | undefined>;
+  findTabsByInternalName?(
+    sessionName: string,
+    internalNames: string[],
+  ): Promise<Record<string, { tabId: number; paneId: string }>>;
   renameTab?(sessionName: string, tabId: number, name: string): Promise<void>;
   closeTab?(sessionName: string, tabId: number): Promise<void>;
   deleteSession?(sessionName: string): Promise<void>;
@@ -270,9 +274,19 @@ export class TerminalRuntime {
       : () => undefined;
     try {
       await this.zellij.ensureSession(workspace.zellijSessionName, workspace.canonicalSize);
-      for (const tab of Object.values(workspace.tabs).sort((left, right) => left.order - right.order)) {
-        if (tab.status === "exited" || tab.status === "failed") continue;
-        let ids = await this.zellij.findTabByInternalName?.(workspace.zellijSessionName, tab.zellijTabName);
+      const restorableTabs = Object.values(workspace.tabs)
+        .filter((tab) => tab.status !== "exited" && tab.status !== "failed")
+        .sort((left, right) => left.order - right.order);
+      const recoveredTabs = restorableTabs.length > 0 && this.zellij.findTabsByInternalName
+        ? await this.zellij.findTabsByInternalName(
+            workspace.zellijSessionName,
+            restorableTabs.map((tab) => tab.zellijTabName),
+          )
+        : undefined;
+      for (const tab of restorableTabs) {
+        let ids = recoveredTabs
+          ? recoveredTabs[tab.zellijTabName]
+          : await this.zellij.findTabByInternalName?.(workspace.zellijSessionName, tab.zellijTabName);
         if (tab.status === "starting" && tab.startupCommand === undefined) {
           // Records without startup intent predate stable client-supplied tab
           // IDs. Recover an already-created Zellij tab when possible; an

--- a/packages/terminal-runtime/src/zellij-adapter.ts
+++ b/packages/terminal-runtime/src/zellij-adapter.ts
@@ -404,32 +404,49 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
     sessionNameInput: string,
     internalNameInput: string,
   ): Promise<{ tabId: number; paneId: string } | undefined> {
-    const { sessionName, binaryPath } = await this.resolveWorkspaceTarget(sessionNameInput);
     const internalName = z.string().regex(TAB_NAME).parse(internalNameInput);
+    return (await this.findTabsByInternalName(sessionNameInput, [internalName]))[internalName];
+  }
+
+  async findTabsByInternalName(
+    sessionNameInput: string,
+    internalNamesInput: string[],
+  ): Promise<Record<string, { tabId: number; paneId: string }>> {
+    const { sessionName, binaryPath } = await this.resolveWorkspaceTarget(sessionNameInput);
+    const internalNames = z.array(z.string().regex(TAB_NAME)).max(10_000).parse(internalNamesInput);
+    if (new Set(internalNames).size !== internalNames.length) {
+      throw new Error("Terminal tab names must be unique");
+    }
+    if (internalNames.length === 0) return {};
+    const requested = new Set(internalNames);
     const tabs = await this.readStructuredJson(
       ["--session", sessionName, "action", "list-tabs", "--json"],
       z.array(TabSchema).max(10_000),
       binaryPath,
     );
-    const tab = tabs.find((candidate) => candidate.name === internalName);
-    if (!tab) return undefined;
+    const requestedTabs = tabs.filter((tab) => requested.has(tab.name));
+    if (requestedTabs.length === 0) return {};
     const panes = await this.readStructuredJson(
       ["--session", sessionName, "action", "list-panes", "--all", "--json"],
       z.array(PaneSchema).max(10_000),
       binaryPath,
     );
-    const managedPanes = panes.filter((pane) => pane.tab_id === tab.tab_id && !pane.is_plugin);
-    const primaryPane = managedPanes.find((pane) => pane.pane_title === internalName)
-      ?? managedPanes.toSorted((left, right) => left.id - right.id)[0];
-    if (!primaryPane) throw new Error("Managed terminal tab primary pane is unavailable");
-    const paneId = `terminal_${primaryPane.id}`;
-    if (primaryPane.pane_title !== internalName) {
-      await this.run(
-        ["--session", sessionName, "action", "rename-pane", "--pane-id", paneId, internalName],
-        binaryPath,
-      );
+    const found: Record<string, { tabId: number; paneId: string }> = {};
+    for (const tab of requestedTabs) {
+      const managedPanes = panes.filter((pane) => pane.tab_id === tab.tab_id && !pane.is_plugin);
+      const primaryPane = managedPanes.find((pane) => pane.pane_title === tab.name)
+        ?? managedPanes.toSorted((left, right) => left.id - right.id)[0];
+      if (!primaryPane) throw new Error("Managed terminal tab primary pane is unavailable");
+      const paneId = `terminal_${primaryPane.id}`;
+      if (primaryPane.pane_title !== tab.name) {
+        await this.run(
+          ["--session", sessionName, "action", "rename-pane", "--pane-id", paneId, tab.name],
+          binaryPath,
+        );
+      }
+      found[tab.name] = { tabId: tab.tab_id, paneId };
     }
-    return { tabId: tab.tab_id, paneId };
+    return found;
   }
 
   async subscribeWorkspace(sessionNameInput: string, input: {

--- a/tests/terminal-runtime/runtime.test.ts
+++ b/tests/terminal-runtime/runtime.test.ts
@@ -531,6 +531,52 @@ describe("project-scoped terminal runtime", () => {
     await runtime.shutdown();
   });
 
+  it("restores every tab in a dense workspace with one batch runtime lookup", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
+    homes.push(homePath);
+    const store = new TerminalWorkspaceStore({ homePath });
+    let batchLookups = 0;
+    let singleLookups = 0;
+    class BatchRestoreZellij extends FakeZellij {
+      override async findTabByInternalName(): Promise<never> {
+        singleLookups += 1;
+        throw new Error("dense restore must not inspect tabs one at a time");
+      }
+
+      async findTabsByInternalName(
+        sessionName: string,
+        internalNames: string[],
+      ): Promise<Record<string, { tabId: number; paneId: string }>> {
+        batchLookups += 1;
+        const requested = new Set(internalNames);
+        return Object.fromEntries(
+          [...(this.sessions.get(sessionName)?.entries() ?? [])]
+            .filter(([, tab]) => requested.has(tab.name))
+            .map(([tabId, tab]) => [tab.name, { tabId, paneId: tab.paneId }]),
+        );
+      }
+    }
+    const zellij = new BatchRestoreZellij();
+    const firstRuntime = new TerminalRuntime({ store, zellij });
+    const workspace = await firstRuntime.ensureWorkspace({ projectId: "matrix-os" });
+    await firstRuntime.createTab(workspace.id, { name: "one", cwd: "projects/matrix-os" });
+    await firstRuntime.createTab(workspace.id, { name: "two", cwd: "projects/matrix-os" });
+    await firstRuntime.createTab(workspace.id, { name: "three", cwd: "projects/matrix-os" });
+    await firstRuntime.shutdown();
+    batchLookups = 0;
+
+    const restartedRuntime = new TerminalRuntime({
+      store: new TerminalWorkspaceStore({ homePath }),
+      zellij,
+    });
+    await restartedRuntime.restoreAll();
+
+    expect(batchLookups).toBe(1);
+    expect(singleLookups).toBe(0);
+    expect((await restartedRuntime.listWorkspaces())[0]?.tabs).toHaveLength(3);
+    await restartedRuntime.shutdown();
+  });
+
   it("retires an unrecoverable legacy starting tab so it cannot consume capacity", async () => {
     const homePath = await mkdtemp(join(tmpdir(), "matrix-terminal-runtime-"));
     homes.push(homePath);

--- a/tests/terminal-runtime/zellij-adapter.test.ts
+++ b/tests/terminal-runtime/zellij-adapter.test.ts
@@ -160,6 +160,37 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
     )).resolves.toEqual({ tabId: 7, paneId: "terminal_12" });
   });
 
+  it("finds a dense set of tabs with one tab inventory and one pane inventory", async () => {
+    const first = "matrix-tab-0123456789abcdef0123456789abcdef";
+    const second = "matrix-tab-fedcba9876543210fedcba9876543210";
+    const run = vi.fn(async (args: string[]) => {
+      if (args.includes("list-tabs")) {
+        return JSON.stringify([
+          { tab_id: 7, name: first },
+          { tab_id: 8, name: second },
+        ]);
+      }
+      if (args.includes("list-panes")) {
+        return JSON.stringify([
+          { id: 12, is_plugin: false, tab_id: 7, pane_title: first },
+          { id: 13, is_plugin: false, tab_id: 8, pane_title: second },
+        ]);
+      }
+      return "";
+    });
+    const adapter = new ZellijCliRuntimeAdapter({ homePath: "/home/matrix", run });
+
+    await expect(adapter.findTabsByInternalName(
+      "matrix-w-0123456789abcdef0123456789abcdef",
+      [first, second],
+    )).resolves.toEqual({
+      [first]: { tabId: 7, paneId: "terminal_12" },
+      [second]: { tabId: 8, paneId: "terminal_13" },
+    });
+    expect(run.mock.calls.filter(([args]) => args.includes("list-tabs"))).toHaveLength(1);
+    expect(run.mock.calls.filter(([args]) => args.includes("list-panes"))).toHaveLength(1);
+  });
+
   it("promotes a remaining pane through the pinned generation when the primary closes", async () => {
     const logicalName = "matrix-w-0123456789abcdef0123456789abcdef";
     const ownedName = "matrix-rt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";


### PR DESCRIPTION
Hamed's 157-tab migration completed, but terminal-runtime startup then restored every tab by running a complete Zellij tab and pane inventory once per tab. The runtime could not open its socket before the updater health deadline and the deployment rolled back.

This change adds a batch lookup to the Zellij adapter and uses it during workspace restoration. A dense workspace now performs one `list-tabs` and one `list-panes` inventory for all persisted tabs, while adapters without the batch method retain the existing per-tab fallback.

Validation:
- `pnpm exec vitest run tests/terminal-runtime` (113 passed, including real Zellij integration)
- `pnpm --filter @matrix-os/terminal-runtime build`
- `git diff --check`

## Invariants

- **Source of truth:** persisted `terminal-workspaces.json` remains authoritative for managed workspace/tab identity; Zellij inventory only reconciles live runtime IDs.
- **Lock/transaction scope:** existing workspace mutation serialization still owns the full reconciliation; the batch lookup adds no separate mutation scope.
- **Acceptable orphan states:** missing persisted running tabs are marked exited; recoverable starting tabs may be recreated using their persisted startup intent.
- **Auth source of truth:** unchanged; the owner-only terminal-runtime Unix socket and gateway principal checks remain authoritative.
- **Deferred scope:** Zellij's full pane inventory remains required once per workspace because stable pane IDs are needed for attachment and observation.
