### PR TITLE
fix(ci): pin available official MinIO images

### DIFF
--- a/docker-compose.dev-vps.yml
+++ b/docker-compose.dev-vps.yml
@@ -26,7 +26,7 @@ services:
       start_period: 10s
 
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     restart: unless-stopped
     volumes:
       - dev-vps-minio-data:/data
@@ -41,7 +41,7 @@ services:
       start_period: 10s
 
   minio-init:
-    image: minio/mc:latest
+    image: quay.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     depends_on:
       minio:
         condition: service_healthy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,7 +30,7 @@ services:
       start_period: 10s
 
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     restart: unless-stopped
     ports:
       - "9100:9000"
@@ -48,7 +48,7 @@ services:
       start_period: 10s
 
   minio-init:
-    image: minio/mc:latest
+    image: quay.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     depends_on:
       minio:
         condition: service_healthy

--- a/tests/scripts/local-object-store-images.test.ts
+++ b/tests/scripts/local-object-store-images.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+describe("local object store image provenance", () => {
+  it.each(["docker-compose.dev.yml", "docker-compose.dev-vps.yml"])("pins official Quay images in %s", (file) => {
+    const { services } = parse(readFileSync(resolve(file), "utf8"));
+    expect(services.minio.image).toMatch(/^quay\.io\/minio\/minio@sha256:[a-f0-9]{64}$/);
+    expect(services["minio-init"].image).toMatch(/^quay\.io\/minio\/mc@sha256:[a-f0-9]{64}$/);
+  });
+});


### PR DESCRIPTION
Docker smoke tests fail because the previous Docker Hub MinIO server and client images cannot be pulled. Both local development Compose configurations now use official Quay images pinned by verified multi-architecture digests, with a regression test covering both services and files.

Validation: Docker smoke and image build passed with these exact Compose changes in PR #1631 (run 34710311183); focused regression tests passed; official manifests include Linux amd64 and arm64. This extracts the independent CI repair from #1631 to keep that feature PR below the repository file-count limit.