### PR TITLE
fix(terminal): allow attachments with legacy sessions

### DIFF
--- a/packages/gateway/src/agent-session-manager.ts
+++ b/packages/gateway/src/agent-session-manager.ts
@@ -284,11 +284,15 @@ export async function hasActiveWorkspaceSessionForTerminalRef(
 ): Promise<boolean> {
   const homePath = resolve(homePathInput);
   const ref = TerminalRefSchema.parse(refInput);
-  return (await readAllSessions(homePath)).some((session) => (
-    isActive(session)
-    && session.terminalRef.workspaceId === ref.workspaceId
-    && session.terminalRef.tabId === ref.tabId
-  ));
+  return (await readAllSessions(homePath)).some((session) => {
+    if (!isActive(session)) return false;
+    // Sessions persisted before terminal workspace references were introduced
+    // remain valid legacy records, but cannot bind a current terminal tab.
+    if (session.terminalRef === undefined) return false;
+    const sessionRef = TerminalRefSchema.parse(session.terminalRef);
+    return sessionRef.workspaceId === ref.workspaceId
+      && sessionRef.tabId === ref.tabId;
+  });
 }
 
 async function resolveWorktree(

--- a/tests/gateway/agent-session-manager.test.ts
+++ b/tests/gateway/agent-session-manager.test.ts
@@ -232,6 +232,64 @@ describe("agent-session-manager", () => {
       .resolves.toBe(false);
   });
 
+  it("ignores active legacy sessions without terminal refs during attachment authorization", async () => {
+    await atomicWriteJson(join(homePath, "system", "sessions", "sess_legacy.json"), {
+      id: "sess_legacy",
+      kind: "agent",
+      runtime: {
+        type: "zellij",
+        status: "running",
+        zellijSession: "legacy-agent-session",
+      },
+      ownerId: "user_a",
+      startedAt: "2026-04-01T00:00:00.000Z",
+      lastActivityAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    await expect(hasActiveWorkspaceSessionForTerminalRef(homePath, {
+      workspaceId: "tws_00000000000000000000000000000001",
+      tabId: "tt_00000000000000000000000000000001",
+    })).resolves.toBe(false);
+
+    const { manager } = createManager();
+    const started = await manager.startSession({
+      kind: "agent",
+      agent: "codex",
+      ownerId: "user_a",
+      projectSlug: "repo",
+      worktreeId,
+      prompt: "work",
+    });
+    if (!started.ok) throw new Error("Expected session startup");
+
+    await expect(hasActiveWorkspaceSessionForTerminalRef(homePath, started.session.terminalRef))
+      .resolves.toBe(true);
+  });
+
+  it("fails closed when an active session has a malformed terminal ref", async () => {
+    await atomicWriteJson(join(homePath, "system", "sessions", "sess_malformed.json"), {
+      id: "sess_malformed",
+      kind: "agent",
+      runtime: {
+        type: "zellij",
+        status: "running",
+      },
+      terminalRef: {
+        workspaceId: "tws_00000000000000000000000000000001",
+        tabId: "tt_00000000000000000000000000000001",
+        unexpected: "field",
+      },
+      ownerId: "user_a",
+      startedAt: "2026-04-01T00:00:00.000Z",
+      lastActivityAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    await expect(hasActiveWorkspaceSessionForTerminalRef(homePath, {
+      workspaceId: "tws_00000000000000000000000000000001",
+      tabId: "tt_00000000000000000000000000000001",
+    })).rejects.toThrow();
+  });
+
   it("includes bounded structured attachments in the agent launch prompt", async () => {
     const { manager, agentLauncher } = createManager();
 


### PR DESCRIPTION
## Summary

- prevent active agent-session records created before `terminalRef` existed from crashing terminal-tab authorization
- ignore only an absent legacy reference; present malformed references fail closed before attachment
- preserve attachment-token enforcement for valid modern agent sessions

## Root cause

Terminal attachment authorization scans active persisted agent sessions to determine whether a tab requires a one-time attachment token. Legacy active records have `runtime.zellijSession` but no `terminalRef`; the scan dereferenced `session.terminalRef.workspaceId` unconditionally. One such record caused every browser attachment attempt, including newly created tabs, to fail with `Cannot read properties of undefined (reading 'workspaceId')` and surface as `Shell attach failed`.

## Tests

- TDD regression: verified the legacy-session test failed with the production `workspaceId` exception before implementation
- TDD security regression: verified a present malformed reference initially failed open, then made it fail closed
- `pnpm exec vitest run tests/gateway/agent-session-manager.test.ts tests/gateway/session-runtime-bridge.test.ts tests/gateway/chat-terminal-gateway-wiring.test.ts tests/gateway/terminal-zellij-ws.test.ts` (99 passed)
- all constituent repo-wide TypeScript targets passed; the top-level wrapper could not start because `bun` is unavailable in this runner's PATH
- `pnpm run check:patterns` (0 violations)
- `pnpm run check:patterns:diff` (0 violations)
- `git diff --check`
- `pnpm run test` was attempted; unrelated existing platform tests prevented a clean global result: the Clerk sign-out timeout passed when rerun alone, while the host-bundle log-permission fixture remains environment-dependent and fails outside this diff

## Invariants

- **Source of truth:** persisted agent-session JSON under `$MATRIX_HOME/system/sessions` remains canonical; present `terminalRef` values must pass strict schema validation before exact workspace/tab matching.
- **Lock/transaction scope:** unchanged; this is a read-only authorization scan and introduces no writes, locks, transactions, or network calls.
- **Acceptable orphan states:** legacy active records with an absent terminal reference remain persisted and are treated as unbound; present malformed references fail closed.
- **Auth source of truth:** the authenticated request principal and exact valid modern terminal binding remain authoritative. Valid bound agent terminals still require their attachment token.
- **Deferred scope:** migrating or deleting legacy agent-session records, cleaning customer-visible terminal tabs, and the separate idle-reclamation validation warning are not part of this outage fix.

## Review / monitoring

- Backend-only change; no React audit or screenshot is required.
- Do not merge until CI passes and Greptile reports 5/5.
