### PR TITLE
fix(terminal): bind attachments to requested panes

### DIFF
--- a/packages/terminal-runtime/src/zellij-adapter.ts
+++ b/packages/terminal-runtime/src/zellij-adapter.ts
@@ -22,6 +22,7 @@ const MAX_COMMAND_OUTPUT_BYTES = 5 * 1024 * 1024;
 const MAX_SUBSCRIPTION_LINE_BYTES = 1024 * 1024;
 const MAX_ATTACHMENT_HANDSHAKE_BYTES = 1024 * 1024;
 const STRUCTURED_READINESS_ATTEMPTS = 20;
+const SWITCH_SESSION_RECONNECT_SEQUENCE = "\x1b[2J";
 const SESSION_NAME = /^matrix-w-[0-9a-f]{32}$/;
 const TAB_NAME = /^matrix-tab-[0-9a-f]{32}$/;
 const PANE_ID = /^terminal_[0-9]+$/;
@@ -352,7 +353,6 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
     const { binaryPath } = target;
     const paneId = z.string().regex(PANE_ID).parse(input.paneId);
     const paneNumber = Number.parseInt(paneId.slice("terminal_".length), 10);
-    const baselineClientCount = await this.countClientsOnPane(sessionName, paneId, binaryPath);
     const bootstrapName = `matrix-attach-${randomBytes(16).toString("hex")}`;
     const routeDirectory = await mkdtemp(join(tmpdir(), "matrix-zellij-attach-"));
     const routeConfigPath = join(routeDirectory, "config.kdl");
@@ -391,8 +391,11 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
       throw error;
     }
     const bootstrapReady = Promise.withResolvers<void>();
+    const routeReady = Promise.withResolvers<void>();
     const startupFailure = Promise.withResolvers<never>();
-    let switching = false;
+    let bootstrapOutputSeen = false;
+    let routeRequested = false;
+    let reconnectSequenceSeen = false;
     let bound = false;
     let startupRejected = false;
     let handshakeOutput = "";
@@ -401,16 +404,31 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
         input.onData(new TextEncoder().encode(data));
         return;
       }
-      if (!switching) {
-        switching = true;
+      if (!bootstrapOutputSeen) {
+        bootstrapOutputSeen = true;
         bootstrapReady.resolve();
         return;
       }
+      if (!routeRequested) return;
       handshakeOutput += data;
       if (!startupRejected && Buffer.byteLength(handshakeOutput) > MAX_ATTACHMENT_HANDSHAKE_BYTES) {
         startupRejected = true;
         handshakeOutput = "";
         startupFailure.reject(new Error("Terminal attachment handshake output exceeded limit"));
+        return;
+      }
+      if (!reconnectSequenceSeen) {
+        const reconnectOffset = handshakeOutput.indexOf(SWITCH_SESSION_RECONNECT_SEQUENCE);
+        if (reconnectOffset < 0) return;
+        // Zellij writes this clear-screen sequence from the client process only
+        // after its in-band SwitchSession has disconnected from the bootstrap
+        // server. The following redraw therefore belongs to this exact PTY's
+        // target-session attachment, unlike aggregate list-clients snapshots.
+        reconnectSequenceSeen = true;
+        handshakeOutput = handshakeOutput.slice(reconnectOffset);
+      }
+      if (handshakeOutput.length > SWITCH_SESSION_RECONNECT_SEQUENCE.length) {
+        routeReady.resolve();
       }
     });
     const exitDisposable = pty.onExit((event) => {
@@ -426,12 +444,10 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
         Promise.race([this.waitForAnyClient(bootstrapName, binaryPath), startupFailure.promise]),
         "Terminal attachment bootstrap client timed out",
       );
+      routeRequested = true;
       pty.write(Buffer.from("\x1b[24;8~", "latin1"));
       await withAttachmentTimeout(
-        Promise.race([
-          this.waitForClientOnPane(sessionName, paneId, baselineClientCount, binaryPath),
-          startupFailure.promise,
-        ]),
+        Promise.race([routeReady.promise, startupFailure.promise]),
         "Terminal attachment pane binding timed out",
       );
       bound = true;
@@ -462,30 +478,6 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
         pty.kill();
       },
     };
-  }
-
-  private async countClientsOnPane(
-    sessionName: string,
-    paneId: string,
-    binaryPath: string,
-  ): Promise<number> {
-    const output = await this.run(["--session", sessionName, "action", "list-clients"], binaryPath);
-    return output.split("\n").filter((line) => line.trim().split(/\s+/)[1] === paneId).length;
-  }
-
-  private async waitForClientOnPane(
-    sessionName: string,
-    paneId: string,
-    baselineClientCount: number,
-    binaryPath: string,
-  ): Promise<void> {
-    for (let attempt = 0; attempt < STRUCTURED_READINESS_ATTEMPTS; attempt += 1) {
-      const output = await this.run(["--session", sessionName, "action", "list-clients"], binaryPath);
-      const count = output.split("\n").filter((line) => line.trim().split(/\s+/)[1] === paneId).length;
-      if (count > baselineClientCount) return;
-      await new Promise<void>((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
-    }
-    throw new Error("Terminal attachment client did not reach requested pane");
   }
 
   private async waitForAnyClient(sessionName: string, binaryPath: string): Promise<void> {

--- a/packages/terminal-runtime/src/zellij-adapter.ts
+++ b/packages/terminal-runtime/src/zellij-adapter.ts
@@ -1,5 +1,7 @@
 import { execFile as nodeExecFile, spawn as spawnProcess } from "node:child_process";
-import { chmod, mkdir, open, realpath as nodeRealpath, rename } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { chmod, mkdir, mkdtemp, open, realpath as nodeRealpath, rename, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, sep } from "node:path";
 import { spawn as spawnNodePty } from "node-pty";
 import { z } from "zod/v4";
@@ -18,6 +20,7 @@ import { createTerminalRuntimeEnvironment } from "./runtime-environment.js";
 
 const MAX_COMMAND_OUTPUT_BYTES = 5 * 1024 * 1024;
 const MAX_SUBSCRIPTION_LINE_BYTES = 1024 * 1024;
+const MAX_ATTACHMENT_HANDSHAKE_BYTES = 1024 * 1024;
 const STRUCTURED_READINESS_ATTEMPTS = 20;
 const SESSION_NAME = /^matrix-w-[0-9a-f]{32}$/;
 const TAB_NAME = /^matrix-tab-[0-9a-f]{32}$/;
@@ -116,6 +119,7 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
   private readonly workspaceLayoutPath: string;
   private readonly workspaceLifecycle?: WorkspaceZellijLifecycle;
   private readonly runtimeEnvironment: Record<string, string>;
+  private attachmentOpenChain = Promise.resolve();
 
   constructor(options: ZellijCliRuntimeAdapterOptions) {
     this.homePath = options.homePath;
@@ -326,18 +330,123 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
     onData: (data: Uint8Array) => void;
     onExit: (exitCode: number | null) => void;
   }): Promise<ZellijAttachment> {
-    const { sessionName, binaryPath } = await this.resolveWorkspaceTarget(sessionNameInput);
+    const previousOpen = this.attachmentOpenChain;
+    const gate = Promise.withResolvers<void>();
+    this.attachmentOpenChain = gate.promise;
+    await previousOpen;
+    try {
+      return await this.openAttachmentNow(sessionNameInput, input);
+    } finally {
+      gate.resolve();
+    }
+  }
+
+  private async openAttachmentNow(sessionNameInput: string, input: {
+    paneId: string;
+    size: { cols: number; rows: number };
+    onData: (data: Uint8Array) => void;
+    onExit: (exitCode: number | null) => void;
+  }): Promise<ZellijAttachment> {
+    const target = await this.resolveWorkspaceTarget(sessionNameInput);
+    const sessionName = z.string().regex(LEGACY_SESSION_NAME).parse(target.sessionName);
+    const { binaryPath } = target;
     const paneId = z.string().regex(PANE_ID).parse(input.paneId);
-    const pty = this.spawnPtyProcess(["attach", sessionName], {
-      cwd: this.homePath,
-      env: this.runtimeEnvironment,
-      cols: input.size.cols,
-      rows: input.size.rows,
-      binaryPath,
+    const paneNumber = Number.parseInt(paneId.slice("terminal_".length), 10);
+    const baselineClientCount = await this.countClientsOnPane(sessionName, paneId, binaryPath);
+    const bootstrapName = `matrix-attach-${randomBytes(16).toString("hex")}`;
+    const routeDirectory = await mkdtemp(join(tmpdir(), "matrix-zellij-attach-"));
+    const routeConfigPath = join(routeDirectory, "config.kdl");
+    const routeConfig = [
+      'default_mode "normal"',
+      "keybinds {",
+      "  normal {",
+      `    bind "Ctrl Alt Shift F12" { SwitchSession name="${sessionName}" pane_id=${paneNumber}; }`,
+      "  }",
+      "}",
+      "",
+    ].join("\n");
+    try {
+      const routeConfigHandle = await open(routeConfigPath, "wx", 0o600);
+      try { await routeConfigHandle.writeFile(routeConfig, "utf8"); } finally { await routeConfigHandle.close(); }
+    } catch (error) {
+      await removeAttachmentRouteDirectory(routeDirectory);
+      throw error;
+    }
+
+    let pty: RuntimePty;
+    try {
+      // Zellij 0.44.3 cannot target a pane on `attach`. A private bootstrap
+      // client performs an in-band SwitchSession instead, which is the only
+      // path that carries pane_to_focus for that exact client. No routing key
+      // is ever written into a customer pane.
+      pty = this.spawnPtyProcess(["--config", routeConfigPath, "attach", bootstrapName, "--create"], {
+        cwd: this.homePath,
+        env: this.runtimeEnvironment,
+        cols: input.size.cols,
+        rows: input.size.rows,
+        binaryPath,
+      });
+    } catch (error) {
+      await removeAttachmentRouteDirectory(routeDirectory);
+      throw error;
+    }
+    const bootstrapReady = Promise.withResolvers<void>();
+    const startupFailure = Promise.withResolvers<never>();
+    let switching = false;
+    let bound = false;
+    let startupRejected = false;
+    let handshakeOutput = "";
+    const dataDisposable = pty.onData((data) => {
+      if (bound) {
+        input.onData(new TextEncoder().encode(data));
+        return;
+      }
+      if (!switching) {
+        switching = true;
+        bootstrapReady.resolve();
+        return;
+      }
+      handshakeOutput += data;
+      if (!startupRejected && Buffer.byteLength(handshakeOutput) > MAX_ATTACHMENT_HANDSHAKE_BYTES) {
+        startupRejected = true;
+        handshakeOutput = "";
+        startupFailure.reject(new Error("Terminal attachment handshake output exceeded limit"));
+      }
     });
-    const dataDisposable = pty.onData((data) => input.onData(new TextEncoder().encode(data)));
-    const exitDisposable = pty.onExit((event) => input.onExit(event.exitCode));
-    await this.run(["--session", sessionName, "action", "focus-pane-id", paneId], binaryPath);
+    const exitDisposable = pty.onExit((event) => {
+      if (!bound) startupFailure.reject(new Error("Terminal attachment exited during startup"));
+      else input.onExit(event.exitCode);
+    });
+    try {
+      await withAttachmentTimeout(
+        Promise.race([bootstrapReady.promise, startupFailure.promise]),
+        "Terminal attachment bootstrap timed out",
+      );
+      await withAttachmentTimeout(
+        Promise.race([this.waitForAnyClient(bootstrapName, binaryPath), startupFailure.promise]),
+        "Terminal attachment bootstrap client timed out",
+      );
+      pty.write(Buffer.from("\x1b[24;8~", "latin1"));
+      await withAttachmentTimeout(
+        Promise.race([
+          this.waitForClientOnPane(sessionName, paneId, baselineClientCount, binaryPath),
+          startupFailure.promise,
+        ]),
+        "Terminal attachment pane binding timed out",
+      );
+      bound = true;
+      if (handshakeOutput) input.onData(new TextEncoder().encode(handshakeOutput));
+      handshakeOutput = "";
+      pty.resize(input.size.cols, input.size.rows);
+    } catch (error) {
+      dataDisposable.dispose();
+      exitDisposable.dispose();
+      pty.kill();
+      throw error;
+    } finally {
+      await this.deleteBootstrapSession(bootstrapName, binaryPath);
+      await removeAttachmentRouteDirectory(routeDirectory);
+    }
     let closed = false;
     return {
       write: async (data) => {
@@ -353,6 +462,51 @@ export class ZellijCliRuntimeAdapter implements ZellijRuntimeAdapter {
         pty.kill();
       },
     };
+  }
+
+  private async countClientsOnPane(
+    sessionName: string,
+    paneId: string,
+    binaryPath: string,
+  ): Promise<number> {
+    const output = await this.run(["--session", sessionName, "action", "list-clients"], binaryPath);
+    return output.split("\n").filter((line) => line.trim().split(/\s+/)[1] === paneId).length;
+  }
+
+  private async waitForClientOnPane(
+    sessionName: string,
+    paneId: string,
+    baselineClientCount: number,
+    binaryPath: string,
+  ): Promise<void> {
+    for (let attempt = 0; attempt < STRUCTURED_READINESS_ATTEMPTS; attempt += 1) {
+      const output = await this.run(["--session", sessionName, "action", "list-clients"], binaryPath);
+      const count = output.split("\n").filter((line) => line.trim().split(/\s+/)[1] === paneId).length;
+      if (count > baselineClientCount) return;
+      await new Promise<void>((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
+    }
+    throw new Error("Terminal attachment client did not reach requested pane");
+  }
+
+  private async waitForAnyClient(sessionName: string, binaryPath: string): Promise<void> {
+    for (let attempt = 0; attempt < STRUCTURED_READINESS_ATTEMPTS; attempt += 1) {
+      const output = await this.run(["--session", sessionName, "action", "list-clients"], binaryPath);
+      if (output.split("\n").some((line) => /^\s*\d+\s+\S+/.test(line))) return;
+      await new Promise<void>((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
+    }
+    throw new Error("Terminal attachment bootstrap client was unavailable");
+  }
+
+  private async deleteBootstrapSession(bootstrapName: string, binaryPath: string): Promise<void> {
+    try {
+      await this.run(["delete-session", bootstrapName, "--force"], binaryPath);
+    } catch (error) {
+      if (isMissingZellijSessionFailure(error)) return;
+      console.error(
+        "[terminal-runtime] failed to delete attachment bootstrap session",
+        error instanceof Error ? error.name : "unknown_error",
+      );
+    }
   }
 
   async writeToPane(sessionNameInput: string, paneIdInput: string, data: Uint8Array): Promise<void> {
@@ -783,6 +937,35 @@ function remainingCommandTimeout(operationDeadline?: number): number | undefined
   const remaining = operationDeadline - Date.now();
   if (remaining <= 0) throw new Error("Terminal runtime operation timed out");
   return Math.min(TERMINAL_RUNTIME_COMMAND_TIMEOUT_MS, remaining);
+}
+
+async function withAttachmentTimeout<T>(operation: Promise<T>, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(message)),
+          TERMINAL_RUNTIME_CONTROL_OPERATION_TIMEOUT_MS,
+        );
+        timer.unref();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function removeAttachmentRouteDirectory(directory: string): Promise<void> {
+  try {
+    await rm(directory, { recursive: true, force: true });
+  } catch (error) {
+    console.error(
+      "[terminal-runtime] failed to delete attachment routing files",
+      error instanceof Error ? error.name : "unknown_error",
+    );
+  }
 }
 
 function isMissingZellijSessionFailure(error: unknown): boolean {

--- a/tests/terminal-runtime/zellij-adapter.test.ts
+++ b/tests/terminal-runtime/zellij-adapter.test.ts
@@ -12,14 +12,19 @@ const lexicalRealpath = async (path: string): Promise<string> => path;
 
 function attachmentRouteHarness(paneId: string) {
   let routed = false;
+  let emitData = (_data: string) => undefined;
   const write = vi.fn((data: string | Buffer) => {
-    if (Buffer.from(data).equals(Buffer.from("\x1b[24;8~", "latin1"))) routed = true;
+    if (Buffer.from(data).equals(Buffer.from("\x1b[24;8~", "latin1"))) {
+      routed = true;
+      queueMicrotask(() => emitData("\x1b[2Jtarget-ready"));
+    }
   });
   const pty: RuntimePty = {
     write,
     resize: vi.fn(),
     kill: vi.fn(),
     onData: vi.fn((listener) => {
+      emitData = listener;
       queueMicrotask(() => listener("bootstrap-ready"));
       return { dispose: vi.fn() };
     }),
@@ -71,6 +76,28 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       "--config", "attach", "--create",
     ]), expect.objectContaining({ env: runtimeEnvironment }));
     expect(route.write).toHaveBeenCalledWith(Buffer.from("\x1b[24;8~", "latin1"));
+  });
+
+  it("ties pane-route readiness to the exact PTY reconnect output", async () => {
+    const route = attachmentRouteHarness("terminal_12");
+    const run = vi.fn(async (args: string[]) => route.clientsFor(args) ?? "");
+    const adapter = new ZellijCliRuntimeAdapter({
+      homePath: "/home/matrix/home",
+      run,
+      spawnPty: vi.fn(() => route.pty),
+    });
+
+    await adapter.openAttachment("matrix-w-0123456789abcdef0123456789abcdef", {
+      paneId: "terminal_12",
+      size: { cols: 120, rows: 36 },
+      onData: () => undefined,
+      onExit: () => undefined,
+    });
+
+    const targetClientQueries = run.mock.calls.filter(([args]) =>
+      args.includes("list-clients")
+      && args[args.indexOf("--session") + 1] === "matrix-w-0123456789abcdef0123456789abcdef");
+    expect(targetClientQueries).toHaveLength(0);
   });
 
   it("propagates non-missing legacy session deletion failures", async () => {

--- a/tests/terminal-runtime/zellij-adapter.test.ts
+++ b/tests/terminal-runtime/zellij-adapter.test.ts
@@ -10,6 +10,37 @@ import {
 
 const lexicalRealpath = async (path: string): Promise<string> => path;
 
+function attachmentRouteHarness(paneId: string) {
+  let routed = false;
+  const write = vi.fn((data: string | Buffer) => {
+    if (Buffer.from(data).equals(Buffer.from("\x1b[24;8~", "latin1"))) routed = true;
+  });
+  const pty: RuntimePty = {
+    write,
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onData: vi.fn((listener) => {
+      queueMicrotask(() => listener("bootstrap-ready"));
+      return { dispose: vi.fn() };
+    }),
+    onExit: vi.fn(() => ({ dispose: vi.fn() })),
+  };
+  return {
+    pty,
+    write,
+    clientsFor(args: string[]): string | undefined {
+      if (!args.includes("list-clients")) return undefined;
+      const sessionName = args[args.indexOf("--session") + 1] ?? "";
+      if (sessionName.startsWith("matrix-attach-")) {
+        return "CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND\n1 plugin_3 zellij:about\n";
+      }
+      return routed
+        ? `CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND\n1 ${paneId} sh\n`
+        : "CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND\n";
+    },
+  };
+}
+
 describe("Zellij 0.44.3 structured runtime adapter", () => {
   it("propagates one explicit owner runtime environment to attachments", async () => {
     const runtimeEnvironment = {
@@ -19,14 +50,9 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       XDG_RUNTIME_DIR: "/run/user/999",
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/999/bus",
     };
-    const spawnPty = vi.fn((): RuntimePty => ({
-      write: vi.fn(),
-      resize: vi.fn(),
-      kill: vi.fn(),
-      onData: vi.fn(() => ({ dispose: vi.fn() })),
-      onExit: vi.fn(() => ({ dispose: vi.fn() })),
-    }));
-    const run = vi.fn(async () => "");
+    const route = attachmentRouteHarness("terminal_12");
+    const spawnPty = vi.fn(() => route.pty);
+    const run = vi.fn(async (args: string[]) => route.clientsFor(args) ?? "");
     const adapter = new ZellijCliRuntimeAdapter({
       homePath: "/home/matrix/home",
       env: runtimeEnvironment,
@@ -41,10 +67,10 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       onExit: () => undefined,
     });
 
-    expect(spawnPty).toHaveBeenCalledWith(
-      ["attach", "matrix-w-0123456789abcdef0123456789abcdef"],
-      expect.objectContaining({ env: runtimeEnvironment }),
-    );
+    expect(spawnPty).toHaveBeenCalledWith(expect.arrayContaining([
+      "--config", "attach", "--create",
+    ]), expect.objectContaining({ env: runtimeEnvironment }));
+    expect(route.write).toHaveBeenCalledWith(Buffer.from("\x1b[24;8~", "latin1"));
   });
 
   it("propagates non-missing legacy session deletion failures", async () => {
@@ -232,20 +258,16 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       ensureWorkspaceSession: vi.fn(async () => ({ sessionName: ownedName, binaryPath })),
       deleteWorkspaceSession: vi.fn(async () => undefined),
     };
+    const route = attachmentRouteHarness("terminal_12");
     const run = vi.fn(async (args: string[], _binaryPath?: string) => {
+      const clients = route.clientsFor(args);
+      if (clients !== undefined) return clients;
       if (args.includes("new-tab")) return "7\n";
       if (args.includes("list-tabs")) return "[]";
       if (args.includes("list-panes")) return JSON.stringify([{ id: 12, is_plugin: false, tab_id: 7 }]);
       return "";
     });
-    const pty: RuntimePty = {
-      write: vi.fn(),
-      resize: vi.fn(),
-      kill: vi.fn(),
-      onData: vi.fn(() => ({ dispose: vi.fn() })),
-      onExit: vi.fn(() => ({ dispose: vi.fn() })),
-    };
-    const spawnPty = vi.fn(() => pty);
+    const spawnPty = vi.fn(() => route.pty);
     const subscription: RuntimeSubscriptionProcess = { close: vi.fn(async () => undefined) };
     const spawnSubscription = vi.fn(() => subscription);
     const adapter = new ZellijCliRuntimeAdapter({
@@ -280,10 +302,9 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
     expect(run.mock.calls.every(([args]) => !args.includes(logicalName))).toBe(true);
     expect(run.mock.calls.some(([args]) => args.includes(ownedName))).toBe(true);
     expect(run.mock.calls.every(([, selectedBinary]) => selectedBinary === binaryPath)).toBe(true);
-    expect(spawnPty).toHaveBeenCalledWith(
-      ["attach", ownedName],
-      expect.objectContaining({ binaryPath }),
-    );
+    expect(spawnPty).toHaveBeenCalledWith(expect.arrayContaining([
+      "--config", "attach", "--create",
+    ]), expect.objectContaining({ binaryPath }));
     expect(spawnSubscription).toHaveBeenCalledWith(
       expect.arrayContaining(["--session", ownedName, "subscribe"]),
       expect.any(Function),
@@ -552,8 +573,11 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
   it("uses returned tab IDs, structured pane IDs, targeted input, and subscribe output", async () => {
     const commands: string[][] = [];
     let paneReads = 0;
+    const route = attachmentRouteHarness("terminal_12");
     const run = vi.fn(async (args: string[]) => {
       commands.push(args);
+      const clients = route.clientsFor(args);
+      if (clients !== undefined) return clients;
       if (args.includes("new-tab")) return "7\n";
       if (args.includes("list-tabs")) return "[]";
       if (args.includes("list-panes")) {
@@ -565,14 +589,6 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       if (args.includes("dump-screen")) return "history\nready$ ";
       return "";
     });
-    const ptyWrite = vi.fn();
-    const pty = {
-      write: ptyWrite,
-      resize: vi.fn(),
-      kill: vi.fn(),
-      onData: vi.fn(() => ({ dispose: vi.fn() })),
-      onExit: vi.fn(() => ({ dispose: vi.fn() })),
-    } satisfies RuntimePty & { write(data: Buffer): void };
     let emitSubscription = (_line: string) => undefined;
     const subscription: RuntimeSubscriptionProcess = {
       close: vi.fn(async () => undefined),
@@ -585,7 +601,7 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       homePath: "/home/matrix",
       run,
       resolveRealpath: lexicalRealpath,
-      spawnPty: vi.fn(() => pty),
+      spawnPty: vi.fn(() => route.pty),
       spawnSubscription,
     });
 
@@ -609,8 +625,8 @@ describe("Zellij 0.44.3 structured runtime adapter", () => {
       onExit: () => undefined,
     });
     await attachment.write(new TextEncoder().encode("echo hi\r"));
-    expect(ptyWrite).toHaveBeenCalledOnce();
-    expect(Buffer.from(ptyWrite.mock.calls[0]![0] as Uint8Array)).toEqual(Buffer.from("echo hi\r"));
+    expect(route.write).toHaveBeenCalledTimes(2);
+    expect(Buffer.from(route.write.mock.calls[1]![0] as Uint8Array)).toEqual(Buffer.from("echo hi\r"));
     expect(commands.some((args) => args.includes("write-chars"))).toBe(false);
 
     const events: unknown[] = [];

--- a/tests/terminal-runtime/zellij-real.integration.test.ts
+++ b/tests/terminal-runtime/zellij-real.integration.test.ts
@@ -123,6 +123,77 @@ describe.runIf(available)("real bundled Zellij 0.44.3 integration", () => {
     expect(dump.stdout).not.toContain("rgb:1111/2222/3333");
   }, 30_000);
 
+  it("keeps simultaneous PTY attachments bound to their requested panes", async () => {
+    const firstName = `matrix-tab-${randomBytes(16).toString("hex")}`;
+    const secondName = `matrix-tab-${randomBytes(16).toString("hex")}`;
+    const first = await adapter.createTab(sessionName, { internalName: firstName, cwd: "", command: ["sh"] });
+    const second = await adapter.createTab(sessionName, { internalName: secondName, cwd: "", command: ["sh"] });
+    const firstMarker = `matrix-first-${randomBytes(8).toString("hex")}`;
+    const secondMarker = `matrix-second-${randomBytes(8).toString("hex")}`;
+    let firstOutput = "";
+    let secondOutput = "";
+    const firstReady = Promise.withResolvers<void>();
+    const secondReady = Promise.withResolvers<void>();
+    const firstAttachment = await adapter.openAttachment(sessionName, {
+      paneId: first.paneId,
+      size: { cols: 100, rows: 30 },
+      onData: (data) => {
+        firstOutput = `${firstOutput}${new TextDecoder().decode(data)}`.slice(-64 * 1024);
+        if (firstOutput.includes(firstMarker)) firstReady.resolve();
+      },
+      onExit: firstReady.reject,
+    });
+    let secondAttachment: Awaited<ReturnType<typeof adapter.openAttachment>> | undefined;
+
+    try {
+      await firstAttachment.write(new TextEncoder().encode(`printf '${firstMarker}\\n'\r`));
+      await Promise.race([
+        firstReady.promise,
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("first attachment ignored input")), 10_000)),
+      ]);
+      firstOutput = "";
+
+      secondAttachment = await adapter.openAttachment(sessionName, {
+        paneId: second.paneId,
+        size: { cols: 100, rows: 30 },
+        onData: (data) => {
+          secondOutput = `${secondOutput}${new TextDecoder().decode(data)}`.slice(-64 * 1024);
+          if (secondOutput.includes(secondMarker)) secondReady.resolve();
+        },
+        onExit: secondReady.reject,
+      });
+      await secondAttachment.write(new TextEncoder().encode(`printf '${secondMarker}\\n'\r`));
+      await Promise.race([
+        secondReady.promise,
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error(
+          `second attachment was not bound to its pane; first=${JSON.stringify(firstOutput)} second=${JSON.stringify(secondOutput)}`,
+        )), 10_000)),
+      ]);
+
+      const [firstDump, secondDump] = await Promise.all([first.paneId, second.paneId].map(async (paneId) => {
+        const result = await execFileAsync(binaryPath, [
+          "--session", sessionName, "action", "dump-screen", "--pane-id", paneId, "--full", "--ansi",
+        ], { timeout: 5_000, env: runtimeEnv });
+        return result.stdout;
+      }));
+      const liveSessions = await execFileAsync(binaryPath, ["list-sessions", "--no-formatting"], {
+        timeout: 5_000,
+        env: runtimeEnv,
+      });
+
+      expect(firstOutput).not.toContain(secondMarker);
+      expect(secondOutput).toContain(secondMarker);
+      expect(firstDump).toContain(firstMarker);
+      expect(firstDump).not.toContain(secondMarker);
+      expect(secondDump).toContain(secondMarker);
+      expect(secondDump).not.toContain(firstMarker);
+      expect(liveSessions.stdout).not.toContain("matrix-attach-");
+    } finally {
+      await secondAttachment?.close();
+      await firstAttachment.close();
+    }
+  }, 30_000);
+
   it("uses one substantially smaller Zellij server for 23 idle tabs", async () => {
     const denseSession = `matrix-w-${randomBytes(16).toString("hex")}`;
     extraSessionNames.push(denseSession);


### PR DESCRIPTION
## Summary

- bind each browser Terminal PTY to its requested Zellij pane instead of relying on a separate `focus-pane-id` command that targets Zellij's last active client
- route the exact PTY through a short-lived private bootstrap session and Zellij's in-band `SwitchSession` pane target, preserving raw keyboard and OSC protocol bytes
- verify routing from the exact PTY's Zellij reconnect/redraw instead of a shared client-count snapshot, cap buffered startup output, validate generated routing input, and remove temporary config files and bootstrap sessions on every path
- add a real two-client Zellij regression proving each command lands in the correct underlying pane and that no routing session remains

## Tests

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run tests/terminal-runtime` — 119 passed
- `pnpm exec vitest run tests/terminal-runtime/zellij-adapter.test.ts tests/terminal-runtime/zellij-real.integration.test.ts` — 30 passed, including exact-PTY route readiness, real Zellij 0.44.3, OSC round trip, two-client pane isolation, cleanup, and 23 tabs sharing one server
- typecheck command sequence from `pnpm run typecheck` with `pnpm run typecheck:build-kernel` substituted for unavailable local Bun — passed
- `pnpm run check:patterns` — 0 violations
- `git diff --check` — passed
- `pnpm run test` — attempted, then stopped after unrelated runner-wide resource pressure caused platform, shell-script, and Codex runtime workers to time out; GitHub CI shards remain the broad gate

## Review/Monitoring

- TDD: the real two-client test failed on the previous implementation because the PTYs were swapped across underlying panes, then passed after the fix
- monitor all required CI checks, unresolved review threads, Codex comments, and Greptile until the latest trusted Greptile result is 5/5

## Invariants

- **Source of truth:** persisted Matrix terminal refs and their Zellij pane IDs remain canonical; the exact PTY's in-process SwitchSession reconnect and target redraw form the attachment readiness fence, while `list-clients` is used only to establish bootstrap startup
- **Lock/transaction scope:** attachment startup is serialized within one adapter so each temporary route remains isolated; no database state or network calls are inside this critical section
- **Acceptable orphan states:** the disposable `matrix-attach-*` session and its mode-0600 temporary KDL file are removed on success and failure; cleanup errors are logged without terminating an already-routed customer attachment
- **Auth source of truth:** unchanged; the gateway/runtime authorization path still validates the terminal ref before the adapter receives the internal workspace session and pane ID
- **Deferred scope:** this PR does not recover terminal tabs lost by past migrations, rename existing customer tabs, or clean historical test-created tabs
