### PR TITLE
fix(ci): rerun ready-for-ci checks on new commits

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -80,6 +80,10 @@ OTA payloads.
 | `release.yml` / `cli-release.yml` | Installable `@finnaai/matrix` CLI release plus standalone binaries | Manual CLI release | Required for CLI publishing |
 | `pr-title.yml` | Conventional Commit PR title policy | PR title changes | Yes |
 
+The `ready-for-ci` label is sticky: applying it starts full PR validation, and every later PR
+head reruns both core CI and Docker classification while the label remains. Reviewers must use
+the checks attached to the exact head SHA rather than an earlier green commit.
+
 ## Delivery Lane Router
 
 Use `scripts/delivery/resolve-lanes.mjs` before lane-specific build or deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main, "stack/**", "codex/**"]
-    types: [labeled, ready_for_review]
+    types: [labeled, ready_for_review, synchronize]
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name != 'ready-for-ci' && github.run_id || 'shared' }}
@@ -70,6 +70,7 @@ jobs:
         id: changed
         env:
           PR_ACTION: ${{ github.event.action || '' }}
+          PR_HAS_READY_FOR_CI: ${{ contains(github.event.pull_request.labels.*.name, 'ready-for-ci') }}
           PR_LABEL_NAME: ${{ github.event.label.name || '' }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -96,7 +97,7 @@ jobs:
           should_run_trigger=true
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             should_run_trigger=false
-            if [ "$PR_ACTION" = "ready_for_review" ] || { [ "$PR_ACTION" = "labeled" ] && [ "$PR_LABEL_NAME" = "ready-for-ci" ]; }; then
+            if [ "$PR_ACTION" = "ready_for_review" ] || { [ "$PR_ACTION" = "labeled" ] && [ "$PR_LABEL_NAME" = "ready-for-ci" ]; } || { [ "$PR_ACTION" = "synchronize" ] && [ "$PR_HAS_READY_FOR_CI" = "true" ]; }; then
               should_run_trigger=true
             fi
           fi
@@ -105,7 +106,7 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             echo "docs_contract_tests=false" >> "$GITHUB_OUTPUT"
             echo "os_view_parity_tests=false" >> "$GITHUB_OUTPUT"
-            echo "CI trigger not requested; add the ready-for-ci label, mark the PR ready for review, or run manually."
+            echo "CI trigger not requested; add the ready-for-ci label, mark the PR ready for review, or run manually. Later commits rerun automatically while ready-for-ci remains applied."
             exit 0
           fi
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -10,7 +10,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main, "stack/**"]
-    types: [labeled, ready_for_review]
+    types: [labeled, ready_for_review, synchronize]
 
 concurrency:
   group: docker-test-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name != 'ready-for-ci' && github.run_id || 'shared' }}
@@ -32,6 +32,7 @@ jobs:
         id: changed
         env:
           PR_ACTION: ${{ github.event.action || '' }}
+          PR_HAS_READY_FOR_CI: ${{ contains(github.event.pull_request.labels.*.name, 'ready-for-ci') }}
           PR_LABEL_NAME: ${{ github.event.label.name || '' }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before || '' }}
         run: |
@@ -46,14 +47,14 @@ jobs:
           should_run_trigger=true
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             should_run_trigger=false
-            if [ "$PR_ACTION" = "ready_for_review" ] || { [ "$PR_ACTION" = "labeled" ] && [ "$PR_LABEL_NAME" = "ready-for-ci" ]; }; then
+            if [ "$PR_ACTION" = "ready_for_review" ] || { [ "$PR_ACTION" = "labeled" ] && [ "$PR_LABEL_NAME" = "ready-for-ci" ]; } || { [ "$PR_ACTION" = "synchronize" ] && [ "$PR_HAS_READY_FOR_CI" = "true" ]; }; then
               should_run_trigger=true
             fi
           fi
 
           if [ "$should_run_trigger" != "true" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "Docker trigger not requested; add the ready-for-ci label, mark the PR ready for review, or run manually."
+            echo "Docker trigger not requested; add the ready-for-ci label, mark the PR ready for review, or run manually. Later commits rerun automatically while ready-for-ci remains applied."
             exit 0
           fi
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -14,9 +14,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parse } from 'yaml';
 
-function readChangeDetectionCheckoutRun(root: string): string | undefined {
+function readWorkflowStepRun(
+  root: string,
+  workflowPath: string,
+  stepName: string,
+): string | undefined {
   const workflow = parse(
-    readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8'),
+    readFileSync(join(root, workflowPath), 'utf8'),
   ) as {
     jobs?: {
       changes?: {
@@ -29,8 +33,16 @@ function readChangeDetectionCheckoutRun(root: string): string | undefined {
   };
 
   return workflow.jobs?.changes?.steps?.find(
-    (step) => step.name === 'Checkout with bounded retry',
+    (step) => step.name === stepName,
   )?.run;
+}
+
+function readChangeDetectionCheckoutRun(root: string): string | undefined {
+  return readWorkflowStepRun(
+    root,
+    '.github/workflows/ci.yml',
+    'Checkout with bounded retry',
+  );
 }
 
 function runChangeDetectionCheckout(
@@ -111,6 +123,81 @@ fi
   }
 }
 
+function runPullRequestChangeDetection(
+  root: string,
+  workflowPath: string,
+  hasReadyForCi: boolean,
+): {
+  output: string;
+  status: number | null;
+  stderr: string;
+} {
+  const changeDetectionRun = readWorkflowStepRun(
+    root,
+    workflowPath,
+    workflowPath.endsWith('docker-test.yml')
+      ? 'Classify Docker/local-runtime changes'
+      : 'Detect source changes',
+  );
+  if (!changeDetectionRun) {
+    throw new Error(`Missing change-detection step in ${workflowPath}`);
+  }
+
+  const tempDir = mkdtempSync(join(tmpdir(), 'matrix-ci-pr-trigger-'));
+  const fakeBin = join(tempDir, 'bin');
+  const githubOutput = join(tempDir, 'github-output');
+  mkdirSync(fakeBin);
+  writeFileSync(
+    join(fakeBin, 'git'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "fetch" ]; then
+  exit 0
+fi
+if [ "\${1:-}" = "diff" ]; then
+  if [[ " $* " == *" -z "* ]]; then
+    printf '.github/workflows/docker-test.yml\\0'
+  else
+    printf '.github/workflows/docker-test.yml\\n'
+  fi
+  exit 0
+fi
+echo "unexpected git command: $*" >&2
+exit 64
+`,
+  );
+  chmodSync(join(fakeBin, 'git'), 0o755);
+
+  try {
+    const result = spawnSync('bash', ['-c', changeDetectionRun], {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        GITHUB_BASE_REF: 'main',
+        GITHUB_EVENT_BEFORE: '',
+        GITHUB_EVENT_NAME: 'pull_request',
+        GITHUB_OUTPUT: githubOutput,
+        GITHUB_REF: 'refs/pull/1/merge',
+        GITHUB_SHA: '0123456789012345678901234567890123456789',
+        GITHUB_TOKEN: 'test-token',
+        PR_ACTION: 'synchronize',
+        PR_HAS_READY_FOR_CI: String(hasReadyForCi),
+        PR_LABEL_NAME: '',
+      },
+    });
+
+    return {
+      output: existsSync(githubOutput) ? readFileSync(githubOutput, 'utf8') : '',
+      status: result.status,
+      stderr: result.stderr,
+    };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 describe('CI workflows', () => {
   const stripePriceSecrets = [
     [
@@ -147,6 +234,14 @@ describe('CI workflows', () => {
     expect(workflow).toContain(
       '[ "$PR_ACTION" = "synchronize" ] && [ "$PR_HAS_READY_FOR_CI" = "true" ]',
     );
+
+    const unlabeled = runPullRequestChangeDetection(process.cwd(), path, false);
+    expect(unlabeled.status, unlabeled.stderr).toBe(0);
+    expect(unlabeled.output).toContain('should_run=false');
+
+    const labeled = runPullRequestChangeDetection(process.cwd(), path, true);
+    expect(labeled.status, labeled.stderr).toBe(0);
+    expect(labeled.output).toContain('should_run=true');
   });
 
   it('queues main CI runs and delegates only full-plan supersession to a narrow workflow', () => {

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -134,6 +134,21 @@ describe('CI workflows', () => {
     ['STRIPE_LEGACY_PRICE_CATALOG_JSON', 'stripe-legacy-price-catalog-json', 'latest'],
   ] as const;
 
+  it.each([
+    ['core CI', '.github/workflows/ci.yml'],
+    ['Docker CI', '.github/workflows/docker-test.yml'],
+  ])('reruns %s for each new head while ready-for-ci remains applied', (_name, path) => {
+    const workflow = readFileSync(join(process.cwd(), path), 'utf8');
+
+    expect(workflow).toMatch(/types:\s*\[[^\]]*synchronize[^\]]*\]/);
+    expect(workflow).toContain(
+      "PR_HAS_READY_FOR_CI: ${{ contains(github.event.pull_request.labels.*.name, 'ready-for-ci') }}",
+    );
+    expect(workflow).toContain(
+      '[ "$PR_ACTION" = "synchronize" ] && [ "$PR_HAS_READY_FOR_CI" = "true" ]',
+    );
+  });
+
   it('queues main CI runs and delegates only full-plan supersession to a narrow workflow', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');


### PR DESCRIPTION
## Summary

- rerun core CI and Docker classification on every new PR head while ready-for-ci remains applied
- keep synchronize events gated so unlabeled work does not start the expensive validation lanes
- document the exact-head review requirement and add workflow regression coverage

## Tests

- pnpm exec vitest run tests/platform/ci-workflows.test.ts --reporter=dot (45 passed)
- pnpm run check:patterns (0 violations)
- package TypeScript checks via pnpm equivalents (all passed; Bun is unavailable locally)
- git diff --check
- full pnpm test exposed an unrelated current-main failure in customer-vps-host-bundle.test.ts: bundled home sync treats log write failures as best effort; the focused test reproduces unchanged on the base

## Invariants

- Source of truth: the current pull-request event payload supplies both the head SHA and the retained ready-for-ci label.
- Lock/concurrency scope: core CI keeps queued branch runs; Docker CI cancels superseded runs in the same branch group so only the latest head remains authoritative.
- Acceptable orphan states: superseded Docker runs may be cancelled, but the latest labeled head must receive a fresh run; no product or customer state is mutated.
- Auth source of truth: GitHub event metadata under existing read-only workflow permissions.
- Deferred scope: repository branch-protection settings and unrelated baseline test failures are unchanged.

## Review monitoring

This PR will not merge until the exact head has fresh ready-for-ci validation and Greptile reports 5/5. Claude Code review is informational for this PR.