### PR TITLE
fix(platform): recover migration deadlocks and protect preview cleanup

### DIFF
--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -322,6 +322,16 @@ jobs:
             --project "$GCP_PROJECT_ID" --region "$GCP_REGION" \
             --remove-tags "pr-${PR_NUMBER}" --quiet
           for rev in $revisions; do
+            current_service="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
+              --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --format json --quiet)"
+            if jq -e --arg revision "$rev" \
+              '.status.latestCreatedRevisionName == $revision or
+               any((.status.traffic // [])[];
+                 .revisionName == $revision and ((.percent // 0) > 0 or (.tag // "") != ""))' \
+              <<< "$current_service" >/dev/null; then
+              echo "Retaining protected or referenced revision $rev after removing the PR tag."
+              continue
+            fi
             gcloud run revisions delete "$rev" \
               --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --quiet
             echo "Deleted revision $rev"

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -11,6 +11,7 @@ import {
   type Updateable,
 } from 'kysely';
 import pg from 'pg';
+import { runPlatformMigration } from './migration-runner.js';
 import { z } from 'zod/v4';
 import type {
   BillingEntitlementSource,
@@ -1218,12 +1219,7 @@ function wrapDb(
 }
 
 async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
-  await db.transaction().execute(async (trx) => {
-    await sql`
-      SELECT pg_advisory_xact_lock(hashtext('matrix_os_platform_schema_migration'))
-    `.execute(trx);
-    await migrateSchema(trx);
-  });
+  await runPlatformMigration(db, migrateSchema);
 }
 
 async function migrateSchema(db: Executor): Promise<void> {

--- a/packages/platform/src/migration-runner.ts
+++ b/packages/platform/src/migration-runner.ts
@@ -1,0 +1,25 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { sql, type Kysely, type Transaction } from "kysely";
+
+export async function runPlatformMigration<Database>(
+  db: Kysely<Database>,
+  migrateSchema: (transaction: Transaction<Database>) => Promise<void>,
+): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await db.transaction().execute(async (transaction) => {
+        await sql`SELECT pg_advisory_xact_lock(hashtext('matrix_os_platform_schema_migration'))`.execute(transaction);
+        await migrateSchema(transaction);
+      });
+      return;
+    } catch (error) {
+      const deadlock = typeof error === "object" && error !== null &&
+        "code" in error && error.code === "40P01";
+      if (!deadlock || attempt === 2) throw error;
+      // The failed transaction has rolled back, releasing its DDL and advisory locks.
+      // Other live transactions do not participate in the migration advisory lock.
+      console.warn("[platform] Schema migration deadlocked; retrying the full transaction.");
+      await delay(250 * 2 ** attempt + Math.floor(Math.random() * 250));
+    }
+  }
+}

--- a/tests/platform/platform-db-migration-lock.test.ts
+++ b/tests/platform/platform-db-migration-lock.test.ts
@@ -10,12 +10,13 @@ describe("platform database startup migration", () => {
     expect(wrapperStart).toBeGreaterThanOrEqual(0);
     expect(schemaStart).toBeGreaterThan(wrapperStart);
 
-    const wrapper = source.slice(wrapperStart, schemaStart);
+    expect(source.slice(wrapperStart, schemaStart)).toContain('await runPlatformMigration(db, migrateSchema)');
+    const wrapper = await readFile('packages/platform/src/migration-runner.ts', 'utf8');
     const transactionStart = wrapper.indexOf("await db.transaction().execute");
     const callbackStart = wrapper.indexOf("=> {", transactionStart);
     const lockStart = wrapper.indexOf("pg_advisory_xact_lock", callbackStart);
-    const lockExecution = wrapper.indexOf(".execute(trx)", lockStart);
-    const schemaMigration = wrapper.indexOf("await migrateSchema(trx)", lockExecution);
+    const lockExecution = wrapper.indexOf(".execute(transaction)", lockStart);
+    const schemaMigration = wrapper.indexOf("await migrateSchema(transaction)", lockExecution);
     const transactionEnd = wrapper.lastIndexOf("});");
 
     expect(transactionStart).toBeGreaterThanOrEqual(0);

--- a/tests/platform/platform-migration-retry.test.ts
+++ b/tests/platform/platform-migration-retry.test.ts
@@ -1,0 +1,61 @@
+import { Kysely, DummyDriver, PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler, sql } from "kysely";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runPlatformMigration } from "../../packages/platform/src/migration-runner.js";
+
+vi.mock("node:timers/promises", () => ({ setTimeout: vi.fn().mockResolvedValue(undefined) }));
+
+function fixture() {
+  const driver = new DummyDriver();
+  const events: string[] = [];
+  vi.spyOn(driver, "beginTransaction").mockImplementation(async () => { events.push("begin"); });
+  vi.spyOn(driver, "rollbackTransaction").mockImplementation(async () => { events.push("rollback"); });
+  vi.spyOn(driver, "commitTransaction").mockImplementation(async () => { events.push("commit"); });
+  const db = new Kysely<Record<string, never>>({ dialect: {
+    createDriver: () => driver,
+    createAdapter: () => new PostgresAdapter(),
+    createIntrospector: database => new PostgresIntrospector(database),
+    createQueryCompiler: () => new PostgresQueryCompiler(),
+  }, log: event => { if (event.level === "query") events.push(event.query.sql); } });
+  return { db, events };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("platform migration retries", () => {
+  it("rolls back a deadlock and reruns the entire migration under a fresh transaction and advisory lock", async () => {
+    const { db, events } = fixture();
+    const seen = new Set();
+    const migrate = vi.fn(async trx => {
+      seen.add(trx);
+      await sql`select 1`.execute(trx);
+      if (seen.size === 1) throw Object.assign(new Error("deadlock"), { code: "40P01" });
+    });
+    try {
+      await expect(runPlatformMigration(db, migrate)).resolves.toBeUndefined();
+      expect(migrate).toHaveBeenCalledTimes(2);
+      expect(seen.size).toBe(2);
+      expect(events.filter(event => event.includes("pg_advisory_xact_lock"))).toHaveLength(2);
+      expect(events.filter(event => ["begin", "rollback", "commit"].includes(event))).toEqual(["begin", "rollback", "begin", "commit"]);
+    } finally { await db.destroy(); }
+  });
+
+  it("bounds retries to three attempts and preserves the final failure", async () => {
+    const { db } = fixture();
+    const error = Object.assign(new Error("deadlock"), { code: "40P01" });
+    const migrate = vi.fn().mockRejectedValue(error);
+    try {
+      await expect(runPlatformMigration(db, migrate)).rejects.toBe(error);
+      expect(migrate).toHaveBeenCalledTimes(3);
+    } finally { await db.destroy(); }
+  });
+
+  it("does not retry non-deadlock database errors", async () => {
+    const { db } = fixture();
+    const error = Object.assign(new Error("connection failure"), { code: "08006" });
+    const migrate = vi.fn().mockRejectedValue(error);
+    try {
+      await expect(runPlatformMigration(db, migrate)).rejects.toBe(error);
+      expect(migrate).toHaveBeenCalledTimes(1);
+    } finally { await db.destroy(); }
+  });
+});

--- a/tests/platform/preview-platform-cleanup.test.ts
+++ b/tests/platform/preview-platform-cleanup.test.ts
@@ -1,0 +1,70 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+function cleanup(latest: string, otherTraffic: unknown[] = []) {
+  const directory = mkdtempSync(join(tmpdir(), "preview-cleanup-"));
+  const stateFile = join(directory, "state.json");
+  const callsFile = join(directory, "calls.json");
+  const service = { status: { latestCreatedRevisionName: latest, traffic: [
+    { tag: "pr-1631", revisionName: "preview-target", percent: 0 }, ...otherTraffic,
+  ] } };
+  writeFileSync(stateFile, JSON.stringify(service));
+  writeFileSync(callsFile, "[]");
+  const executable = join(directory, "gcloud");
+  writeFileSync(executable, `#!${process.execPath}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const calls = JSON.parse(fs.readFileSync(process.env.CALLS_FILE, 'utf8'));
+calls.push(args); fs.writeFileSync(process.env.CALLS_FILE, JSON.stringify(calls));
+const service = JSON.parse(fs.readFileSync(process.env.STATE_FILE, 'utf8'));
+if (args.slice(0, 3).join(' ') === 'run services describe') {
+  console.log(JSON.stringify(service));
+} else if (args.slice(0, 3).join(' ') === 'run services update-traffic') {
+  service.status.traffic = service.status.traffic.filter(x => x.tag !== 'pr-1631');
+  fs.writeFileSync(process.env.STATE_FILE, JSON.stringify(service));
+} else if (args.slice(0, 3).join(' ') === 'run revisions delete') {
+  if (args[3] === service.status.latestCreatedRevisionName) {
+    console.error('FAILED_PRECONDITION: latest created revision cannot be deleted'); process.exit(1);
+  }
+  if (service.status.traffic.some(x => x.revisionName === args[3] && (x.tag || x.percent > 0))) {
+    console.error('Revision is still referenced'); process.exit(1);
+  }
+} else { console.error('Unexpected gcloud invocation'); process.exit(2); }
+`);
+  chmodSync(executable, 0o755);
+  try {
+    const workflow = parse(readFileSync(".github/workflows/preview-platform.yml", "utf8"));
+    const step = workflow.jobs["teardown"].steps.find((item: { name?: string }) => item.name === "Remove tag and delete tagged revisions");
+    const result = spawnSync("bash", ["-c", step.run], { encoding: "utf8", env: {
+      ...process.env, PATH: `${directory}:${process.env.PATH}`, STATE_FILE: stateFile, CALLS_FILE: callsFile,
+      CLOUD_RUN_PREVIEW_SERVICE: "preview-service", GCP_PROJECT_ID: "test-project", GCP_REGION: "test-region", PR_NUMBER: "1631",
+    } });
+    return { ...result, calls: JSON.parse(readFileSync(callsFile, "utf8")) as string[][] };
+  } finally { rmSync(directory, { recursive: true, force: true }); }
+}
+
+describe("Cloud Run preview cleanup", () => {
+  it("removes the PR tag while retaining the latest-created revision", () => {
+    const result = cleanup("preview-target");
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.calls.some(args => args.includes("--remove-tags"))).toBe(true);
+    expect(result.calls.some(args => args.includes("delete"))).toBe(false);
+  });
+  it("deletes an older unreferenced revision", () => {
+    const result = cleanup("newer-revision");
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.calls.some(args => args.slice(0, 4).join(" ") === "run revisions delete preview-target")).toBe(true);
+  });
+  it.each([
+    [{ revisionName: "preview-target", percent: 100 }],
+    [{ revisionName: "preview-target", tag: "another-preview", percent: 0 }],
+  ])("retains a revision still referenced after removing the PR tag", (...traffic) => {
+    const result = cleanup("newer-revision", traffic);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.calls.some(args => args.includes("delete"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Two deployment workflows failed after PR #1631 merged, while main CI passed:

- Platform Cloud Run run [34735187659](https://github.com/HamedMP/matrix-os/actions/runs/34735187659) failed to start its candidate revision because the existing startup schema migration encountered PostgreSQL deadlock `40P01`. It failed before traffic promotion. Retry the complete rolled-back migration transaction at most three times, with bounded jittered backoff and the existing advisory lock reacquired on each attempt. Other database errors still fail immediately. Schema statements are unchanged.
- Preview Platform close run [34735187584](https://github.com/HamedMP/matrix-os/actions/runs/34735187584) removed its PR tag, then attempted to delete the service's latest-created revision, which Cloud Run prohibits. Refresh service state after removing the tag and retain latest-created, traffic-bearing, or still-tagged revisions. Delete older unreferenced revisions as before.

## Tests

- Red/green regression tests reproduced the latest-created revision deletion failure and missing full-transaction deadlock retry before the fixes.
- Four focused test files: 10 tests passed, covering rollback/retry/lock reacquisition, retry exhaustion, non-deadlock errors, and Preview cleanup retention/deletion.
- `bun run typecheck`: passed.
- `bun run check:patterns`: zero violations (five existing warnings).
- `pnpm --filter @matrix-os/platform build`: passed.
- Full local `bun run test` was invoked and interrupted after establishing missing local prerequisites; it is not a completed or green validation result. Local failures include Linux VPS script tests requiring unavailable `flock`, plus other suites outside this diff that have not been classified. Main Linux CI [34735187657](https://github.com/HamedMP/matrix-os/actions/runs/34735187657) passed at the parent commit; this PR still needs its own CI.
- Production health remained OK and the preceding ready revision retained 100% traffic during diagnosis. No production redeployment was performed.

## Invariants

### Source of truth
Cloud Run service status determines revision protection and references. PostgreSQL owns schema state; the existing schema migration SQL remains unchanged.

### Lock / transaction scope
The entire schema migration and advisory lock execute in one transaction per attempt. Kysely rolls back the failed transaction before retrying. Retries are limited to PostgreSQL `40P01`, with three total attempts. No partial migration is committed.

### Acceptable orphan states
An untagged latest-created Preview revision may remain because Cloud Run prohibits its deletion. Revisions referenced by traffic or another tag remain intentionally. This does not add revision garbage collection. A concurrent reference change may still cause Cloud Run to reject deletion; API errors remain visible rather than being suppressed.

### Auth source of truth
Existing workflow workload identity, environment configuration, and database credentials are unchanged. No new endpoints or IAM privileges.

### Deferred scope
No schema redesign, traffic promotion, production rollout, general Preview revision garbage collection, or unrelated local test repairs.
